### PR TITLE
Fix axis2Server.bat file does not start issue

### DIFF
--- a/samples/product/src/main/java/samples/util/SampleAxis2Server.java
+++ b/samples/product/src/main/java/samples/util/SampleAxis2Server.java
@@ -65,11 +65,11 @@ public class SampleAxis2Server {
         Runtime.getRuntime().addShutdownHook(shutdownHook);
     }
 
-    private static void startServer(String[] args) throws Exception {
+    public static void startServer(String[] args) throws Exception {
         SampleAxis2ServerManager.getInstance().start(args);
     }
 
-    private static void stopServer() throws Exception {
+    public static void stopServer() throws Exception {
         SampleAxis2ServerManager.getInstance().stop();
     }
 


### PR DESCRIPTION
This is to reverting the fix in PR #147. Set startServer, stopServer methods as public