### PR TITLE
Disable bind address feature test

### DIFF
--- a/integration/mediation-tests/tests-patches/src/test/resources/testng.xml
+++ b/integration/mediation-tests/tests-patches/src/test/resources/testng.xml
@@ -298,11 +298,6 @@
             <class name="org.wso2.carbon.esb.passthru.transport.test.ESBJAVA3770DropLargePayloadsPreventESBFromOOMTestCase"/>
         </classes>
     </test>
-    <test name="ESBJAVA4973BindAddressFeatureTestCase" preserve-order="true" verbose="2">
-        <classes>
-            <class name="org.wso2.carbon.esb.passthru.transport.test.ESBJAVA4973BindAddressFeatureTestCase"/>
-        </classes>
-    </test>
     <test name="Datamapper-mediator-tests" preserve-order="true" verbose="2">
         <classes>
             <class name="org.wso2.carbon.esb.datamapper.ESBJAVA5021MultiplePrefixesAndDashSupport"/>


### PR DESCRIPTION
System log for the ip address depends on the machine. 
- Locally we get the log "Pass-through HTTP Listener started on 192.168.0.0"
- In Jenkins we get "Pass-through HTTP Listener started on ip-192-168-0-0.xx-xxxx-1.xxxx.xxxx"

Hence disabling the test.

