### PR TITLE
Fix dataservice name duplication in Gson-testcases

### DIFF
--- a/integration/dataservice-hosting-tests/tests-integration/tests/src/test/java/org/wso2/ei/dataservice/integration/test/jira/issues/CARBON15262JsonGsonFormatterTenantModeTest.java
+++ b/integration/dataservice-hosting-tests/tests-integration/tests/src/test/java/org/wso2/ei/dataservice/integration/test/jira/issues/CARBON15262JsonGsonFormatterTenantModeTest.java
@@ -42,7 +42,7 @@ import java.util.List;
  *
  */
 public class CARBON15262JsonGsonFormatterTenantModeTest extends DSSIntegrationTest {
-	private final String serviceName = "H2SimpleJsonTest";
+	private final String serviceName = "H2SimpleJsonTest2";
 	private String serviceEndPoint;
 
 	private static final Log log = LogFactory.getLog(CARBON15262JsonGsonFormatterTenantModeTest.class);
@@ -55,7 +55,7 @@ public class CARBON15262JsonGsonFormatterTenantModeTest extends DSSIntegrationTe
 		sqlFileLis.add(selectSqlFile("Offices.sql"));
 		deployService(serviceName, createArtifact(getResourceLocation() + File.separator + "dbs" + File.separator +
 		                                          "rdbms" + File.separator + "h2" + File.separator +
-		                                          "H2SimpleJsonTest.dbs", sqlFileLis));
+		                                          "H2SimpleJsonTest2.dbs", sqlFileLis));
 		serviceEndPoint = getServiceUrlHttp(serviceName) + "/";
 
 	}

--- a/integration/dataservice-hosting-tests/tests-integration/tests/src/test/resources/artifacts/DSS/dbs/rdbms/h2/H2SimpleJsonTest2.dbs
+++ b/integration/dataservice-hosting-tests/tests-integration/tests/src/test/resources/artifacts/DSS/dbs/rdbms/h2/H2SimpleJsonTest2.dbs
@@ -1,0 +1,111 @@
+<!--
+  ~ Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied. See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<data name="H2SimpleJsonTest2" transports="http https local">
+   <config id="default">
+      <property name="org.wso2.ws.dataservice.driver">org.h2.Driver</property>
+      <property name="org.wso2.ws.dataservice.protocol">jdbc:h2:file:./samples/data-services/database/DATA_SERV_SAMP</property>
+      <property name="org.wso2.ws.dataservice.user">wso2ds</property>
+      <property name="org.wso2.ws.dataservice.password">wso2ds</property>
+      <property name="org.wso2.ws.dataservice.minpoolsize">1</property>
+      <property name="org.wso2.ws.dataservice.maxpoolsize">10</property>
+      <property name="org.wso2.ws.dataservice.validation_query"/>
+   </config>
+
+   <query id="insertBalanceQuery" returnGeneratedKeys="true" useConfig="default">
+      <sql>INSERT INTO Accounts (balance) values (:balance)</sql>
+      <result element="GeneratedKeys" rowName="Entry" useColumnNumbers="true">
+         <element column="1" name="ID" xsdType="integer"/>
+      </result>
+      <param name="balance" sqlType="DOUBLE"/>
+   </query>
+   <query id="insertQuery" useConfig="default">
+      <sql>insert into Offices values (:officeCode,:city, :telephone,:address1, :address2, :state, :country,:postalcode,:territory);</sql>
+      <param name="officeCode" sqlType="STRING"/>
+      <param name="city" sqlType="STRING"/>
+      <param name="telephone" sqlType="STRING"/>
+      <param name="address1" sqlType="STRING"/>
+      <param name="address2" sqlType="STRING"/>
+      <param name="state" sqlType="STRING"/>
+      <param name="country" sqlType="STRING"/>
+      <param name="postalcode" sqlType="STRING"/>
+      <param name="territory" sqlType="STRING"/>
+   </query>
+   <query id="selectQuery" useConfig="default">
+      <sql>SELECT country from Offices;</sql>
+      <result element="Entries" rowName="Entry">
+         <element column="country" name="country" xsdType="string"/>
+      </result>
+   </query>
+   <query id="updateQuery" useConfig="default">
+      <sql>Update Offices set city = :city, phone = :telephone , addressLine1 = :address1, addressLine2 = :address2, state = :state, country = :country , postalCode = :postalcode, territory = :territory where officeCode = :officeCode</sql>
+      <param name="city" sqlType="STRING"/>
+      <param name="address1" sqlType="STRING"/>
+      <param name="address2" sqlType="STRING"/>
+      <param name="state" sqlType="STRING"/>
+      <param name="country" sqlType="STRING"/>
+      <param name="territory" sqlType="STRING"/>
+      <param name="telephone" sqlType="STRING"/>
+      <param name="officeCode" sqlType="STRING"/>
+      <param name="postalcode" sqlType="STRING"/>
+   </query>
+   <query id="deleteQuery" useConfig="default">
+      <sql>delete from Offices where officeCode = :code ;</sql>
+      <param name="code" sqlType="STRING"/>
+   </query>
+   <resource method="GET" path="/getCountries">
+      <call-query href="selectQuery"/>
+   </resource>
+   <resource method="PUT" path="/updateOffice" returnRequestStatus="true">
+      <call-query href="updateQuery">
+         <with-param name="city" query-param="city"/>
+         <with-param name="address1" query-param="address1"/>
+         <with-param name="address2" query-param="address2"/>
+         <with-param name="state" query-param="state"/>
+         <with-param name="country" query-param="country"/>
+         <with-param name="territory" query-param="territory"/>
+         <with-param name="telephone" query-param="telephone"/>
+         <with-param name="officeCode" query-param="officeCode"/>
+         <with-param name="postalcode" query-param="postalcode"/>
+      </call-query>
+   </resource>
+   <resource method="POST" path="/insertOffice" returnRequestStatus="true">
+      <call-query href="insertQuery">
+         <with-param name="officeCode" query-param="officeCode"/>
+         <with-param name="city" query-param="city"/>
+         <with-param name="telephone" query-param="telephone"/>
+         <with-param name="address1" query-param="address1"/>
+         <with-param name="address2" query-param="address2"/>
+         <with-param name="state" query-param="state"/>
+         <with-param name="country" query-param="country"/>
+         <with-param name="postalcode" query-param="postalcode"/>
+         <with-param name="territory" query-param="territory"/>
+      </call-query>
+   </resource>
+   <resource method="DELETE" path="/deleteOffice/{code}" returnRequestStatus="true">
+      <call-query href="deleteQuery">
+         <with-param name="code" query-param="code"/>
+      </call-query>
+   </resource>
+   <resource method="POST" path="/insertBalance">
+      <call-query href="insertBalanceQuery">
+         <with-param name="balance" query-param="balance"/>
+      </call-query>
+   </resource>
+
+</data>

--- a/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/property/PropertyIntegrationDISABLE_CHUNKING_PropertyTest.java
+++ b/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/property/PropertyIntegrationDISABLE_CHUNKING_PropertyTest.java
@@ -40,7 +40,7 @@ public class PropertyIntegrationDISABLE_CHUNKING_PropertyTest extends ESBIntegra
         super.init();
         loadESBConfigurationFromClasspath
                 ("/artifacts/ESB/mediatorconfig/property/DISABLE_CHUNKING.xml");
-        wireServer = new WireMonitorServer(8991);
+        wireServer = new WireMonitorServer(8993);
     }
 
     @SetEnvironment(executionEnvironments = {ExecutionEnvironment.STANDALONE})

--- a/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/property/PropertyIntegrationForceHttpContentLengthPropertyTestCase.java
+++ b/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/property/PropertyIntegrationForceHttpContentLengthPropertyTestCase.java
@@ -44,7 +44,7 @@ public class PropertyIntegrationForceHttpContentLengthPropertyTestCase
     public void setEnvironment() throws Exception {
         super.init();
 
-        wireServer = new WireMonitorServer(8991);
+        wireServer = new WireMonitorServer(8994);
     }
 
     @AfterClass(alwaysRun = true)

--- a/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/property/PropertyIntegrationPOST_TO_URI_PropertyTestCase.java
+++ b/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/property/PropertyIntegrationPOST_TO_URI_PropertyTestCase.java
@@ -40,7 +40,7 @@ public class PropertyIntegrationPOST_TO_URI_PropertyTestCase extends ESBIntegrat
         super.init();
         loadESBConfigurationFromClasspath
                 ("/artifacts/ESB/mediatorconfig/property/POST_TO_URI.xml");
-        wireServer = new WireMonitorServer(8991);
+        wireServer = new WireMonitorServer(8992);
 
 
     }
@@ -55,7 +55,7 @@ public class PropertyIntegrationPOST_TO_URI_PropertyTestCase extends ESBIntegrat
             //ignore since wire message is captured
         }
         String response = wireServer.getCapturedMessage();
-        assertTrue(response.contains("POST http://localhost:8991"), "Faulty Response");
+        assertTrue(response.contains("POST http://localhost:8992"), "Faulty Response");
     }
 
     @AfterClass(alwaysRun = true)

--- a/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/property/PropertyIntegrationPropertyInTransportScopeTest.java
+++ b/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/property/PropertyIntegrationPropertyInTransportScopeTest.java
@@ -39,7 +39,7 @@ public class PropertyIntegrationPropertyInTransportScopeTest extends ESBIntegrat
     @BeforeClass(alwaysRun = true)
     public void setEnvironment() throws Exception {
         super.init();
-        wireServer = new WireMonitorServer(8991);
+        wireServer = new WireMonitorServer(8995);
         loadESBConfigurationFromClasspath
                 ("/artifacts/ESB/mediatorconfig/property/transport_scope_property.xml");
 

--- a/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/property/PropertyIntegrationTRANSPORT_HEADERSPropertyTest.java
+++ b/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/property/PropertyIntegrationTRANSPORT_HEADERSPropertyTest.java
@@ -37,7 +37,7 @@ public class PropertyIntegrationTRANSPORT_HEADERSPropertyTest extends ESBIntegra
     @BeforeClass(alwaysRun = true)
     public void setEnvironment() throws Exception {
         init();
-        wireServer = new WireMonitorServer(8991);
+        wireServer = new WireMonitorServer(8996);
         loadESBConfigurationFromClasspath
                 ("/artifacts/ESB/mediatorconfig/property/TRANSPORT_HEADERS.xml");
     }

--- a/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/message/store/test/JMSEndpointSuspensionViaVFSTest.java
+++ b/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/message/store/test/JMSEndpointSuspensionViaVFSTest.java
@@ -34,7 +34,8 @@ import java.util.Properties;
  */
 public class JMSEndpointSuspensionViaVFSTest extends ESBIntegrationTest {
 
-    private TestRequestInterceptor interceptor = new TestRequestInterceptor();
+    private TestRequestInterceptor interceptor1 = new TestRequestInterceptor();
+    private TestRequestInterceptor interceptor2 = new TestRequestInterceptor();
     private JMSBrokerController jmsBrokerController;
     private ServerConfigurationManager serverConfigurationManager;
 
@@ -45,19 +46,25 @@ public class JMSEndpointSuspensionViaVFSTest extends ESBIntegrationTest {
     private final String GERONIMO_JMS = "geronimo-jms_1.1_spec-1.1.1.jar";
     private final String JAR_LOCATION = "/artifacts/ESB/jar";
     private final int PORT = 9654;
-    private SimpleHttpServer httpServer;
+    private final int PORT_FAULT = 9655;
+    private SimpleHttpServer httpServerIn;
+    private SimpleHttpServer httpServerOut;
 
     @BeforeClass(alwaysRun = true)
     public void init() throws Exception {
         setUpJMSBroker();
         /* Make the port available */
         Utils.shutdownFailsafe(PORT);
-        httpServer = new SimpleHttpServer(PORT, new Properties());
-        httpServer.start();
+        httpServerIn = new SimpleHttpServer(PORT, new Properties());
+        httpServerIn.start();
+
+        Utils.shutdownFailsafe(PORT_FAULT);
+        httpServerOut = new SimpleHttpServer(PORT_FAULT, new Properties());
+        httpServerOut.start();
         Thread.sleep(5000);
 
-        interceptor = new TestRequestInterceptor();
-        httpServer.getRequestHandler().setInterceptor(interceptor);
+        interceptor1 = new TestRequestInterceptor();
+        httpServerIn.getRequestHandler().setInterceptor(interceptor1);
 
         super.init();
 
@@ -125,18 +132,18 @@ public class JMSEndpointSuspensionViaVFSTest extends ESBIntegrationTest {
 
         sendFile(outfile, afile, bfile);
 
-        Assert.assertTrue(interceptor.getPayload().contains("<address>Disney Land</address>"));
+        Assert.assertTrue(interceptor1.getPayload().contains("<address>Disney Land</address>"));
 //        String vfsOut = FileUtils.readFileToString(outfile);
 //        Assert.assertTrue(vfsOut.contains("WSO2 Company"));
 
-        interceptor = new TestRequestInterceptor();
-        httpServer.getRequestHandler().setInterceptor(interceptor);
+        interceptor2 = new TestRequestInterceptor();
+        httpServerOut.getRequestHandler().setInterceptor(interceptor2);
         jmsBrokerController.stop();
 
         sendFile(outfile, afile, bfile);
 
-        Assert.assertTrue(interceptor.getPayload().contains("Endpoint Down!"),
-                "payload received: " + interceptor.getPayload() + ". payload expected: " + "Endpoint Down!");
+        Assert.assertTrue(interceptor2.getPayload().contains("Endpoint Down!"),
+                "payload received: " + interceptor2.getPayload() + ". payload expected: " + "Endpoint Down!");
 
         deleteProxyService("VFSJMSProxy1");
     }
@@ -209,7 +216,8 @@ public class JMSEndpointSuspensionViaVFSTest extends ESBIntegrationTest {
                 log.warn("Error while shutting down the JMS Broker", e);
             }
             try {
-                httpServer.stop();
+                httpServerIn.stop();
+                httpServerOut.stop();
             } catch (Exception e) {
                 log.warn("Error while shutting down the HTTP server", e);
             }
@@ -265,7 +273,7 @@ public class JMSEndpointSuspensionViaVFSTest extends ESBIntegrationTest {
                                              "                     </makefault>\n" +
                                              "                     <send>\n" +
                                              "                          <endpoint>\n" +
-                                             "                               <address uri=\"http://localhost:9654/services/SimpleStockQuoteService\"/>" +
+                                             "                               <address uri=\"http://localhost:9655/services/SimpleStockQuoteService\"/>" +
                                              "                          </endpoint>" +
                                              "                     </send>\n" +
                                              "                  </faultSequence>" +

--- a/integration/mediation-tests/tests-mediator-1/src/test/resources/artifacts/ESB/mediatorconfig/property/DISABLE_CHUNKING.xml
+++ b/integration/mediation-tests/tests-mediator-1/src/test/resources/artifacts/ESB/mediatorconfig/property/DISABLE_CHUNKING.xml
@@ -18,7 +18,7 @@
     </proxy>
 
     <endpoint name="Axis2EP">
-        <address uri="http://localhost:8991/services/SimpleStockQuoteService"/>
+        <address uri="http://localhost:8993/services/SimpleStockQuoteService"/>
     </endpoint>
 </definitions>
 

--- a/integration/mediation-tests/tests-mediator-1/src/test/resources/artifacts/ESB/mediatorconfig/property/EnableFORCE_HTTP_CONTENT_LENGTH.xml
+++ b/integration/mediation-tests/tests-mediator-1/src/test/resources/artifacts/ESB/mediatorconfig/property/EnableFORCE_HTTP_CONTENT_LENGTH.xml
@@ -20,6 +20,6 @@
     </proxy>
 
     <endpoint name="Axis2EP">
-        <address uri="http://localhost:8991/services/SimpleStockQuoteService"/>
+        <address uri="http://localhost:8994/services/SimpleStockQuoteService"/>
     </endpoint>
 </definitions>

--- a/integration/mediation-tests/tests-mediator-1/src/test/resources/artifacts/ESB/mediatorconfig/property/TRANSPORT_HEADERS.xml
+++ b/integration/mediation-tests/tests-mediator-1/src/test/resources/artifacts/ESB/mediatorconfig/property/TRANSPORT_HEADERS.xml
@@ -15,7 +15,7 @@
     </proxy>
 
     <endpoint name="Axis2EP">
-        <address uri="http://localhost:8991/services/SimpleStockQuoteService"/>
+        <address uri="http://localhost:8996/services/SimpleStockQuoteService"/>
     </endpoint>
 </definitions>
 

--- a/integration/mediation-tests/tests-mediator-1/src/test/resources/artifacts/ESB/mediatorconfig/property/transport_scope_property.xml
+++ b/integration/mediation-tests/tests-mediator-1/src/test/resources/artifacts/ESB/mediatorconfig/property/transport_scope_property.xml
@@ -15,7 +15,7 @@
     </proxy>
 
     <endpoint name="Axis2EP">
-        <address uri="http://localhost:8991/services/SimpleStockQuoteService"/>
+        <address uri="http://localhost:8995/services/SimpleStockQuoteService"/>
     </endpoint>
 </definitions>
 


### PR DESCRIPTION
Same dataservice is used in CARBON15262JsonGsonFormatterTenantModeTest and CARBON15339JsonGsonFormatterTenantModeTest which can cause the service to be unavailable in the other testcase. Therefore since the service is not dispatched it has caused the tests in second testcase to fail. Hence adding a new data-service name for CARBON15262JsonGsonFormatterTenantModeTest.