### PR TITLE
Move BallerinaASTModelBuilder.java to common module in tools

### DIFF
--- a/tools/converter/common/src/main/java/org/wso2/ei/tools/converter/common/builder/BallerinaASTModelBuilder.java
+++ b/tools/converter/common/src/main/java/org/wso2/ei/tools/converter/common/builder/BallerinaASTModelBuilder.java
@@ -16,7 +16,7 @@
  * under the License.
  */
 
-package org.wso2.ei.tools.mule2ballerina.builder;
+package org.wso2.ei.tools.converter.common.builder;
 
 import org.ballerinalang.model.BLangPackage;
 import org.ballerinalang.model.BLangProgram;
@@ -39,14 +39,6 @@ import java.util.Stack;
  */
 public class BallerinaASTModelBuilder {
 
-    private boolean processingActionInvocationStmt = false;
-    private Stack<BLangModelBuilder.NameReference> nameReferenceStack = new Stack<>();
-    private Stack<SimpleTypeName> typeNameStack = new Stack<>();
-    private BLangProgram programScope;
-    private BLangPackage bLangPackage;
-    private BLangModelBuilder modelBuilder;
-    private Map<String, String> ballerinaPackageMap = new HashMap<String, String>();
-
     private static final PackageRepository PACKAGE_REPOSITORY = new PackageRepository() {
         @Override
         public PackageSource loadPackage(Path path) {
@@ -58,6 +50,13 @@ public class BallerinaASTModelBuilder {
             return null;
         }
     };
+    private boolean processingActionInvocationStmt = false;
+    private Stack<BLangModelBuilder.NameReference> nameReferenceStack = new Stack<>();
+    private Stack<SimpleTypeName> typeNameStack = new Stack<>();
+    private BLangProgram programScope;
+    private BLangPackage bLangPackage;
+    private BLangModelBuilder modelBuilder;
+    private Map<String, String> ballerinaPackageMap = new HashMap<String, String>();
 
     public BallerinaASTModelBuilder() {
 
@@ -127,7 +126,7 @@ public class BallerinaASTModelBuilder {
     public void createRefereceTypeName() {
         BLangModelBuilder.NameReference nameReference = nameReferenceStack.pop();
         SimpleTypeName typeName = new SimpleTypeName(nameReference.getName(), nameReference.getPackageName(),
-            nameReference.getPackagePath());
+                nameReference.getPackagePath());
 
         typeNameStack.push(typeName);
     }
@@ -191,7 +190,7 @@ public class BallerinaASTModelBuilder {
     public void initializeConnector(boolean argsAvailable) {
         BLangModelBuilder.NameReference nameReference = nameReferenceStack.pop();
         SimpleTypeName connectorTypeName = new SimpleTypeName(nameReference.getName(), nameReference.getPackageName(),
-            null);
+                null);
 
         modelBuilder.createConnectorInitExpr(null, null, connectorTypeName, argsAvailable);
     }

--- a/tools/converter/mule2ballerina/src/main/java/org/wso2/ei/tools/mule2ballerina/Main.java
+++ b/tools/converter/mule2ballerina/src/main/java/org/wso2/ei/tools/mule2ballerina/Main.java
@@ -39,7 +39,7 @@ public class Main {
 
         ConfigReader xmlParser = new ConfigReader();
         xmlParser.readXML(xmlParser.getInputStream(args[0]));
-        //xmlParser.readXML(xmlParser.getInputStream("/home/rukshani/mule2bal/muleConfig/multiConfigs.xml"));
+        //xmlParser.readXML(xmlParser.getInputStream("/home/rukshani/mule2bal/muleConfig/passThrough.xml"));
         Root muleRootObj = xmlParser.getRootObj();
 
         if (xmlParser.getUnIdentifiedElements() != null && !xmlParser.getUnIdentifiedElements().isEmpty()) {
@@ -53,7 +53,7 @@ public class Main {
 
         BallerinaSourceGenerator sourceGenerator = new BallerinaSourceGenerator();
         sourceGenerator.generate(ballerinaFile, args[1]);
-        //sourceGenerator.generate(ballerinaFile, "/home/rukshani/mule2bal/Generated/multi.bal");
+        //sourceGenerator.generate(ballerinaFile, "/home/rukshani/mule2bal/Generated/pass2.bal");
 
     }
 

--- a/tools/converter/mule2ballerina/src/main/java/org/wso2/ei/tools/mule2ballerina/visitor/TreeVisitor.java
+++ b/tools/converter/mule2ballerina/src/main/java/org/wso2/ei/tools/mule2ballerina/visitor/TreeVisitor.java
@@ -21,7 +21,7 @@ package org.wso2.ei.tools.mule2ballerina.visitor;
 import org.ballerinalang.model.BallerinaFile;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.wso2.ei.tools.mule2ballerina.builder.BallerinaASTModelBuilder;
+import org.wso2.ei.tools.converter.common.builder.BallerinaASTModelBuilder;
 import org.wso2.ei.tools.mule2ballerina.model.Flow;
 import org.wso2.ei.tools.mule2ballerina.model.GlobalConfiguration;
 import org.wso2.ei.tools.mule2ballerina.model.HttpListener;


### PR DESCRIPTION
This class can be used by any converter to talk to ballerina model API. Any additional methods that need to talk to BLangModelBuilder should be done through this class