### PR TITLE
[ESBJAVA-5108] Test cases for null transport header issue

### DIFF
--- a/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/property/NullValueTransportHeaderTestCase.java
+++ b/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/property/NullValueTransportHeaderTestCase.java
@@ -1,0 +1,65 @@
+/*
+*Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*WSO2 Inc. licenses this file to you under the Apache License,
+*Version 2.0 (the "License"); you may not use this file except
+*in compliance with the License.
+*You may obtain a copy of the License at
+*
+*http://www.apache.org/licenses/LICENSE-2.0
+*
+*Unless required by applicable law or agreed to in writing,
+*software distributed under the License is distributed on an
+*"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+*KIND, either express or implied.  See the License for the
+*specific language governing permissions and limitations
+*under the License.
+*/
+
+package org.wso2.carbon.esb.mediator.test.property;
+
+
+import org.apache.axis2.AxisFault;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import org.wso2.carbon.automation.engine.exceptions.AutomationFrameworkException;
+import org.wso2.carbon.automation.test.utils.http.client.HttpRequestUtil;
+import org.wso2.carbon.automation.test.utils.http.client.HttpResponse;
+import org.wso2.esb.integration.common.utils.ESBIntegrationTest;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Test case to check if there is any issue when a property read from call template
+ * is set as a transport header value, but the caller has not passed the value.
+ */
+public class NullValueTransportHeaderTestCase extends ESBIntegrationTest {
+
+    @BeforeClass(alwaysRun = true)
+    public void deployArtifacts() throws Exception {
+        super.init();
+        loadESBConfigurationFromClasspath("/artifacts/ESB/synapseconfig/"
+                + "configsToCheckSettingNullToTransportHeader/synapse.xml");
+    }
+
+
+    @Test(groups = "wso2.esb", description = "Property mediator test with null value set as transport header")
+    public void testRespondMediator() throws AxisFault, MalformedURLException, AutomationFrameworkException {
+        Map<String, String> requestHeader = new HashMap<>();
+        requestHeader.put("Content-type", "application/json");
+        HttpResponse response = HttpRequestUtil.doPost(new URL(getApiInvocationURL("testapi")),
+                "{\"test\" : \"nullHeaderVal\"}", requestHeader);
+        Assert.assertTrue(response.getData().contains("{\"company\" : \"wso2\"}"), "Expected response was not"
+                + "received. Got " + response.getData());
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void stop() throws Exception {
+        super.cleanup();
+    }
+}

--- a/integration/mediation-tests/tests-mediator-1/src/test/resources/artifacts/ESB/synapseconfig/configsToCheckSettingNullToTransportHeader/synapse.xml
+++ b/integration/mediation-tests/tests-mediator-1/src/test/resources/artifacts/ESB/synapseconfig/configsToCheckSettingNullToTransportHeader/synapse.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://ws.apache.org/ns/synapse">
+    <registry provider="org.wso2.carbon.mediation.registry.WSO2Registry">
+        <parameter name="cachableDuration">15000</parameter>
+    </registry>
+    <taskManager provider="org.wso2.carbon.mediation.ntask.NTaskTaskManager"/>
+    <template name="blocking_call_template">
+        <sequence>
+            <log level="full">
+                <property name="INCOMING" value="AAA"/>
+            </log>
+            <property expression="$func:basic-auth" name="Authorization"
+                      scope="transport" type="STRING"
+                      xmlns:ns="http://org.apache.synapse/xsd"
+                      xmlns:ns2="http://org.apache.synapse/xsd" xmlns:soapenv="http://www.w3.org/2003/05/soap-envelope"/>
+            <call blocking="true">
+                <endpoint>
+                    <http uri-template="http://localhost:8480/backend"/>
+                </endpoint>
+            </call>
+            <log level="full">
+                <property name="REPLY" value="BBB"/>
+            </log>
+            <respond/>
+        </sequence>
+    </template>
+    <api context="/backend" name="backEnd">
+        <resource methods="POST">
+            <inSequence>
+                <payloadFactory media-type="json">
+                    <format>{"company" : "wso2"}</format>
+                    <args/>
+                </payloadFactory>
+                <respond/>
+            </inSequence>
+        </resource>
+    </api>
+    <api context="/testapi" name="testAPI">
+        <resource methods="POST">
+            <inSequence>
+                <call-template target="blocking_call_template">
+                    <with-param name="end-point-url" value="http://localhost:8480/backend"/>
+                </call-template>
+            </inSequence>
+        </resource>
+    </api>
+    <!-- You can add any flat sequences, endpoints, etc.. to this synapse.xml file if you do
+    *not* want to keep the artifacts in several files -->
+</definitions>

--- a/integration/mediation-tests/tests-mediator-1/src/test/resources/testng.xml
+++ b/integration/mediation-tests/tests-mediator-1/src/test/resources/testng.xml
@@ -218,6 +218,7 @@
             <class name="org.wso2.carbon.esb.mediator.test.property.PropertyIntegrationXPathTrpPropertyTestCase"/>
             <class name="org.wso2.carbon.esb.mediator.test.property.PropertyIntegrationXPathExtensionTestCase"/>
             <class name="org.wso2.carbon.esb.mediator.test.property.PropertyIntegrationXPathBodyTestCase"/>
+            <class name="org.wso2.carbon.esb.mediator.test.property.NullValueTransportHeaderTestCase"/>
         </classes>
     </test>
     <test name="Property-mediator-Test-1" preserve-order="true" verbose="2">


### PR DESCRIPTION
Test case for Null pointer exception when transport header is not set via a
template. Please refer jira [1] for details.

[1]. https://wso2.org/jira/browse/ESBJAVA-5108

