### PR TITLE
 Create folder named deployment in root folder of product-ei

### DIFF
--- a/distribution/src/assembly/bin.xml
+++ b/distribution/src/assembly/bin.xml
@@ -65,6 +65,13 @@
             <fileMode>644</fileMode>
             <filtered>true</filtered>
         </fileSet>
+        <fileSet>
+            <directory>target/WSO2Carbon</directory>
+            <outputDirectory>/deployment</outputDirectory>
+            <excludes>
+                <exclude>**/*</exclude>
+            </excludes>
+        </fileSet>
     </fileSets>
 
     <files>


### PR DESCRIPTION
 This is a workaround for the issue(wso2/carbon-deployment#261) in carbon-deployment dependency used by MB