### PR TITLE
Fix wso2/product-ei#836

### DIFF
--- a/integration/pom.xml
+++ b/integration/pom.xml
@@ -32,11 +32,55 @@
     <name>WSO2 Enterprise Integrator - Integration Tests</name>
     <url>http://wso2.org</url>
 
-    <modules>
-        <module>automation-extensions</module>
-        <module>mediation-tests</module>
-        <module>business-process-tests</module>
-        <module>dataservice-hosting-tests</module>
-    </modules>
+    <profiles>
+        <profile>
+            <id>default</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <modules>
+                <module>automation-extensions</module>
+                <module>mediation-tests</module>
+                <module>business-process-tests</module>
+                <module>dataservice-hosting-tests</module>
+            </modules>
+        </profile>
+        <profile>
+            <id>mediation-tests-profile</id>
+            <activation>
+                <property>
+                    <name>mediation.integration.test.profile</name>
+                </property>
+            </activation>
+            <modules>
+                <module>automation-extensions</module>
+                <module>mediation-tests</module>
+            </modules>
+        </profile>
+        <profile>
+            <id>business-process-tests-profile</id>
+            <activation>
+                <property>
+                    <name>business-process.integration.test.profile</name>
+                </property>
+            </activation>
+            <modules>
+                <module>automation-extensions</module>
+                <module>business-process-tests</module>
+            </modules>
+        </profile>
+        <profile>
+            <id>data-service-tests-profile</id>
+            <activation>
+                <property>
+                    <name>dataservices.integration.test.profile</name>
+                </property>
+            </activation>
+            <modules>
+                <module>automation-extensions</module>
+                <module>dataservice-hosting-tests</module>
+            </modules>
+        </profile>
+    </profiles>
 
 </project>


### PR DESCRIPTION
This is to make it possible to run only the integration tests relevant to a given profile.
3 maven profiles for mediation tests, business-process tests and data-services tests were added each of them with a system property to activate the relevant profile when needed. 
A default profile was added for running all tests.