### PR TITLE
Update aggregate on timeout test error sequences

### DIFF
--- a/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/aggregate/FaultSeqInvokeWithAggregateTimeoutTestCase.java
+++ b/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/aggregate/FaultSeqInvokeWithAggregateTimeoutTestCase.java
@@ -84,8 +84,7 @@ public class FaultSeqInvokeWithAggregateTimeoutTestCase extends ESBIntegrationTe
         HttpResponse response = HttpRequestUtil.
                 doPost(new URL(getApiInvocationURL("testApiAggregate")), message, requestHeader);
 
-        Assert.assertTrue(response.getData().contains("Sequence named Value " +
-                "{name ='null', keyValue ='invalidSequence'} cannot be found"), "Expected response was not"
+        Assert.assertTrue(response.getData().contains("SEQUENCE_ERROR_HANDLER"), "Expected response was not"
                 + " received. Got " + response.getData());
     }
 

--- a/integration/mediation-tests/tests-mediator-1/src/test/resources/artifacts/ESB/mediatorconfig/aggregate/OnCompleteWithTimeoutTest.xml
+++ b/integration/mediation-tests/tests-mediator-1/src/test/resources/artifacts/ESB/mediatorconfig/aggregate/OnCompleteWithTimeoutTest.xml
@@ -33,6 +33,7 @@
                         <error-message>$2</error-message>
                         <error-detail>$3</error-detail>
                         <error-exception>$4</error-exception>
+                        <error-handler-name>SEQUENCE_ERROR_HANDLER</error-handler-name>
                     </error>
                 </response>
             </format>
@@ -61,6 +62,7 @@
                         <error-message>$2</error-message>
                         <error-detail>$3</error-detail>
                         <error-exception>$4</error-exception>
+                        <error-handler-name>API_ERROR_SEQUENCE</error-handler-name>
                     </error>
                 </response>
             </format>


### PR DESCRIPTION
- Update error sequences to return the error handler name. From the test case check the specific error handler is executed.

Issue: https://github.com/wso2/product-ei/issues/758