### PR TITLE
Fix test failure of ProxyServiceEndPointThroughURLTestCase

### DIFF
--- a/integration/mediation-tests/tests-service/src/test/java/org/wso2/carbon/esb/proxyservice/test/loggingProxy/ProxyServiceEndPointThroughURLTestCase.java
+++ b/integration/mediation-tests/tests-service/src/test/java/org/wso2/carbon/esb/proxyservice/test/loggingProxy/ProxyServiceEndPointThroughURLTestCase.java
@@ -52,10 +52,7 @@ public class ProxyServiceEndPointThroughURLTestCase extends ESBIntegrationTest {
         String symbol = response.getFirstElement().
                 getFirstChildWithName(new QName("http://services.samples/xsd", "symbol")).getText();
         assertEquals(symbol, "WSO2", "Fault: value 'symbol' mismatched");
-    }
 
-    @Test(groups = "wso2.esb", description = "VerifyLogs")
-    public void testVerifyLogs() throws Exception {
         LogViewerClient logViewerClient = new LogViewerClient(context.getContextUrls().getBackEndUrl(),
                 getSessionCookie());
         assertNotNull(logViewerClient.getRemoteLogs("INFO", "getQuote", "", ""),


### PR DESCRIPTION
ProxyServiceEndPointThroughURLTestCase was failing due to the test method 'testVerifyLogs', which only contains assertions being run after 'testLoggingProxy' which sends the request to the proxy. As the resolution, the 'testVerifyLogs' was merged into 'testLoggingProxy'.