### PR TITLE
Include dependency jars in EI_HOME/lib folder

### DIFF
--- a/distribution/src/assembly/bin.xml
+++ b/distribution/src/assembly/bin.xml
@@ -1857,6 +1857,14 @@
                 <include>org.apache.sandesha2:sandesha2-core:jar</include>
             </includes>
         </dependencySet>
+        <dependencySet>
+            <outputDirectory>wso2ei-${pom.version}/lib</outputDirectory>
+            <includes>
+                <include>org.wso2.andes.wso2:andes-client:jar</include>
+                <include>org.apache.geronimo.specs.wso2:geronimo-jms_1.1_spec:jar</include>
+                <include>org.wso2.securevault:org.wso2.securevault:jar</include>
+            </includes>
+        </dependencySet>
     </dependencySets>
 
     <files>


### PR DESCRIPTION
This PR fixes the CNF exception thrown when creating a WSO2 MB Message Store.
java.lang.ClassNotFoundException: class org.wso2.andes.jndi.PropertiesFileInitialContextFactory not found
Related git-issue : https://github.com/wso2/product-ei/issues/529