### PR TITLE
[EI-944][EI-461] Fix hard coded values in profile-creator scripts. Th…

### DIFF
--- a/distribution/src/scripts/profile-creator.bat
+++ b/distribution/src/scripts/profile-creator.bat
@@ -19,7 +19,7 @@ REM Profile creator tool for EI
 REM ---------------------------------------------------------------------------
 
 set DIR=%~dp0
-set DISTRIBUTION=wso2ei-@product.version@
+set for %%a in ("%~p0\..") do set DISTRIBUTION=%%~nxa
 REM get the desired profile
 echo ***********************************************************************************
 echo This tool will erase all the files which are not required for the selected profile.

--- a/distribution/src/scripts/profile-creator.sh
+++ b/distribution/src/scripts/profile-creator.sh
@@ -22,7 +22,8 @@
 
 
 DIR="$(dirname "${BASH_SOURCE[0]}")"
-DISTRIBUTION="wso2ei-@product.version@"
+PARENTDIR="${PWD%/*}"
+DISTRIBUTION="$(basename "$PARENTDIR")"
 #get the desired profile
 echo "*************************************************************************************"
 echo "This tool will erase all the files which are not required for the selected profile "
@@ -216,7 +217,7 @@ fi
 
 echo "Preparing a profile distribution archive."
 cd ${DIR}/../../
-zip -r ${DISTRIBUTION}${PROFILE}.zip ${DISTRIBUTION}/
+zip -r ${DISTRIBUTION}${PROFILE}.zip ${DISTRIBUTION}/ -x *profile-creator*
 
 echo "Profile creation completed successfully."
 exit 0


### PR DESCRIPTION
The distribution folder names are currently hard coded in the scripts.

 Provided a fix to take the parent folder name instead.Also added the improvement of excluding profile-creator files in newly created distribution. Related git issues #944 and #461 