### PR TITLE
Update testng to execute test-patches bpel tests

### DIFF
--- a/integration/business-process-tests/tests-patches/bpel/src/test/resources/testng.xml
+++ b/integration/business-process-tests/tests-patches/bpel/src/test/resources/testng.xml
@@ -5,7 +5,7 @@
 
     <test name="BPELTests" preserve-order="true" parallel="false">
         <packages>
-            <package name="org.wso2.bps.integration.tests.patches.bpel"/>
+            <package name="org.wso2.ei.businessprocess.integration.tests.patches.bpel"/>
         </packages>
     </test>
 


### PR DESCRIPTION
This PR changes org.wso2.bps to org.wso2.ei.businessprocess in the testng file to execute test-patches bpel tests.