### PR TITLE
Fix failure of AddressEndpointTestCase

### DIFF
--- a/integration/mediation-tests/tests-service/src/test/resources/artifacts/ESB/endpoint/addressEndpointConfig/synapse.xml
+++ b/integration/mediation-tests/tests-service/src/test/resources/artifacts/ESB/endpoint/addressEndpointConfig/synapse.xml
@@ -41,6 +41,14 @@
             <outSequence>
                 <send/>
             </outSequence>
+            <faultSequence>
+                <log level="full">
+                    <property name="MESSAGE" value="Executing invalidAddressEndPoint 'fault' sequence" />
+                    <property name="ERROR_CODE" expression="get-property('ERROR_CODE')" />
+                    <property name="ERROR_MESSAGE" expression="get-property('ERROR_MESSAGE')" />
+                </log>
+                <send/>
+            </faultSequence>
         </target>
     </proxy>
 


### PR DESCRIPTION
The test case had failed since an incompatible fault sequence which was deployed by another test case was being executed in this test case. As the resolution, a fault sequence was added to the proxy service.