### PR TITLE
Fix test failure in WSAddressingSupportTest case

### DIFF
--- a/integration/mediation-tests/tests-patches/src/test/java/org/wso2/carbon/esb/mediators/header/ESBJAVA5098_WSAddressingSupportTest.java
+++ b/integration/mediation-tests/tests-patches/src/test/java/org/wso2/carbon/esb/mediators/header/ESBJAVA5098_WSAddressingSupportTest.java
@@ -57,10 +57,10 @@ public class ESBJAVA5098_WSAddressingSupportTest extends ESBIntegrationTest {
 
         String expectedResponse = "<headerContent xmlns=\"http://ws.apache.org/ns/synapse\">" +
                                         "<soapenv:Header xmlns:wsa=\"http://www.w3.org/2005/08/addressing\">" +
-                                            "<wsa:From><wsa:Address>http://localhost:8480/test</wsa:Address></wsa:From>" +
+                                            "<wsa:From><wsa:Address>http://localhost:8480/wsaddressing-support-test</wsa:Address></wsa:From>" +
                                             "<wsa:MessageID>urn:uuid:ef503c98-f6c7-4aa4-8e91-d76a2a7efaf4</wsa:MessageID>" +
                                             "<wsa:Action>urn:anonOutInOpResponse</wsa:Action>" +
-                                            "<wsa:To>http://localhost:8480/test</wsa:To>" +
+                                            "<wsa:To>http://localhost:8480/wsaddressing-support-test</wsa:To>" +
                                         "</soapenv:Header>" +
                                     "</headerContent>";
 

--- a/integration/mediation-tests/tests-patches/src/test/resources/artifacts/ESB/mediatorconfig/header/WSAddressingSupport.xml
+++ b/integration/mediation-tests/tests-patches/src/test/resources/artifacts/ESB/mediatorconfig/header/WSAddressingSupport.xml
@@ -26,7 +26,7 @@
         <target>
             <inSequence>
                 <header scope="default">
-                    <wsa:From xmlns:wsa="http://www.w3.org/2005/08/addressing"><wsa:Address>http://localhost:8480/test</wsa:Address></wsa:From>
+                    <wsa:From xmlns:wsa="http://www.w3.org/2005/08/addressing"><wsa:Address>http://localhost:8480/wsaddressing-support-test</wsa:Address></wsa:From>
                 </header>
                 <header scope="default">
                     <wsa:MessageID xmlns:wsa="http://www.w3.org/2005/08/addressing">urn:uuid:ef503c98-f6c7-4aa4-8e91-d76a2a7efaf4</wsa:MessageID>
@@ -37,7 +37,7 @@
                 <property name="PRESERVE_WS_ADDRESSING" value="true"/>
                 <send>
                     <endpoint>
-                        <address uri="http://localhost:8480/test" format="soap11">
+                        <address uri="http://localhost:8480/wsaddressing-support-test" format="soap11">
                             <enableAddressing/>
                         </address>
                     </endpoint>
@@ -74,7 +74,7 @@
         </out>
         <description>The main sequence for the message mediation</description>
     </sequence>
-    <api context="/test" name="WSAApi">
+    <api context="/wsaddressing-support-test" name="WSAApi">
         <resource methods="POST">
             <inSequence>
                 <log level="custom">


### PR DESCRIPTION
Introduced a unique context to avoid the conflict of not getting deployed when other APIs exist with same context.