### PR TITLE
Add TestCases for headersToExcludeInHash property in CacheMediator

### DIFF
--- a/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/cache/CacheResponseCodeRegexTestCase.java
+++ b/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/cache/CacheResponseCodeRegexTestCase.java
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.esb.mediator.test.cache;
+
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import org.wso2.carbon.automation.engine.annotations.ExecutionEnvironment;
+import org.wso2.carbon.automation.engine.annotations.SetEnvironment;
+import org.wso2.carbon.automation.test.utils.http.client.HttpRequestUtil;
+import org.wso2.carbon.automation.test.utils.http.client.HttpResponse;
+import org.wso2.esb.integration.common.utils.ESBIntegrationTest;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
+import static org.testng.Assert.assertNotNull;
+
+/**
+ * Cache Mediator - verify 'responseCode' parameter with caching
+ * <p>
+ * This testcase is to verify that caching works only with the defined response code
+ */
+public class CacheResponseCodeRegexTestCase extends ESBIntegrationTest {
+
+    @BeforeClass(alwaysRun = true)
+    public void setEnvironment() throws Exception {
+        super.init();
+    }
+
+    @SetEnvironment(executionEnvironments = { ExecutionEnvironment.STANDALONE })
+    @Test(groups = "wso2.esb",
+          description = "Verify caching works for the defined response code regex")
+    public void testCachingResponseCodeRegex() throws Exception {
+
+        Map<String, String> requestHeader = new HashMap<>();
+        requestHeader.put("CODE", "202");
+        requestHeader.put("symbol", "RegexPattern");
+
+        // Backend respond with 202 status code
+        HttpResponse response1 = HttpRequestUtil.doGet((getApiInvocationURL("ResponseCodeRegex")), requestHeader);
+        assertNotNull(response1, "Response is null");
+        String[] firstmsg1 = response1.getData().split("<ax21:change>");
+        String[] secondmsg1 = firstmsg1[1].split("</ax21:change>");
+        String change1 = secondmsg1[0];
+        assertNotNull(change1, "change value is null");
+        assertEquals(response1.getResponseCode(), 202, "Unexpected response code");
+
+        HttpResponse response2 = HttpRequestUtil.doGet((getApiInvocationURL("ResponseCodeRegex")), requestHeader);
+        assertNotNull(response2, "Response is null");
+        String[] firstmsg2 = response2.getData().split("<ax21:change>");
+        String[] secondmsg2 = firstmsg2[1].split("</ax21:change>");
+        String change2 = secondmsg2[0];
+        assertNotNull(change2, "change value is null");
+        assertEquals(response2.getResponseCode(), 202, "Unexpected response code");
+
+        assertEquals(change1, change2, "Response caching did not work for the defined response code regex ");
+
+        Map<String, String> requestHeader2 = new HashMap<>();
+        requestHeader2.put("CODE", "401");
+        requestHeader2.put("symbol", "RegexPattern");
+
+        // Backend respond with 401 status code
+        HttpResponse response3 = HttpRequestUtil.doGet((getApiInvocationURL("ResponseCodeRegex")), requestHeader2);
+        assertNotNull(response3, "Response is null");
+        String[] firstmsg3 = response3.getData().split("<ax21:change>");
+        String[] secondmsg3 = firstmsg3[1].split("</ax21:change>");
+        String change3 = secondmsg3[0];
+        assertNotNull(change3, "change value is null");
+        assertEquals(response3.getResponseCode(), 401, "Unexpected response code");
+
+        HttpResponse response4 = HttpRequestUtil.doGet((getApiInvocationURL("ResponseCodeRegex")), requestHeader2);
+        assertNotNull(response4, "Response is null");
+        String[] firstmsg4 = response4.getData().split("<ax21:change>");
+        String[] secondmsg4 = firstmsg4[1].split("</ax21:change>");
+        String change4 = secondmsg4[0];
+        assertNotNull(change4, "change value is null");
+        assertEquals(response4.getResponseCode(), 401, "Unexpected response code");
+
+        assertEquals(change3, change4, "Response caching did not work for the defined response code regex ");
+
+        Map<String, String> requestHeader3 = new HashMap<>();
+        requestHeader3.put("CODE", "500");
+        requestHeader3.put("symbol", "RegexPattern");
+
+        // Backend respond with 500 status code
+        HttpResponse response5 = HttpRequestUtil.doGet((getApiInvocationURL("ResponseCodeRegex")), requestHeader3);
+        assertNotNull(response5, "Response is null");
+        String[] firstmsg5 = response5.getData().split("<ax21:change>");
+        String[] secondmsg5 = firstmsg5[1].split("</ax21:change>");
+        String change5 = secondmsg5[0];
+        assertNotNull(change5, "change value is null");
+        assertEquals(response5.getResponseCode(), 500, "Unexpected response code");
+
+        HttpResponse response6 = HttpRequestUtil.doGet((getApiInvocationURL("ResponseCodeRegex")), requestHeader3);
+        assertNotNull(response6, "Response is null");
+        String[] firstmsg6 = response6.getData().split("<ax21:change>");
+        String[] secondmsg6 = firstmsg6[1].split("</ax21:change>");
+        String change6 = secondmsg6[0];
+        assertNotNull(change6, "change value is null");
+        assertEquals(response6.getResponseCode(), 500, "Unexpected response code");
+
+        assertNotEquals(change5, change6, "Response caching works for the undefined response code");
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void close() throws Exception {
+        super.cleanup();
+    }
+}

--- a/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/cache/ExcludeHeadersWithCacheTestCase.java
+++ b/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/cache/ExcludeHeadersWithCacheTestCase.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.esb.mediator.test.cache;
+
+import org.apache.axiom.om.OMElement;
+import org.apache.axis2.AxisFault;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import org.wso2.esb.integration.common.utils.ESBIntegrationTest;
+import org.wso2.carbon.automation.engine.annotations.ExecutionEnvironment;
+import org.wso2.carbon.automation.engine.annotations.SetEnvironment;
+
+import javax.xml.namespace.QName;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
+import static org.testng.Assert.assertNotNull;
+
+/**
+ * Cache Mediator - verify 'headersToExcludeInHash' parameter
+ * <p>
+ * This testcase is to verify that a defined header can be exclude when hashing
+ */
+public class ExcludeHeadersWithCacheTestCase extends ESBIntegrationTest {
+
+    @BeforeClass(alwaysRun = true)
+    public void setEnvironment() throws Exception {
+        super.init();
+    }
+
+    @SetEnvironment(executionEnvironments = { ExecutionEnvironment.STANDALONE })
+    @Test(groups = "wso2.esb",
+          description = "Verify a header can be excluded when hasing")
+    public void testExcludingHeaders() throws AxisFault {
+        OMElement stockResponse;
+
+        // Sending a request to SimpleStockQuote Service
+        stockResponse = axis2Client
+                .sendSimpleStockQuoteRequest(getApiInvocationURL("excludeHeaders"), "", "ExcludeHeaders");
+        assertNotNull(stockResponse, "Response is null");
+        String change = stockResponse.getFirstElement()
+                .getFirstChildWithName(new QName("http://services.samples/xsd", "change")).getText();
+
+        // Sending a request to SimpleStockQuote Service with 'user' header
+        axis2Client.addHttpHeader("user", "Peter");
+        stockResponse = axis2Client
+                .sendSimpleStockQuoteRequest(getApiInvocationURL("excludeHeaders"), "", "ExcludeHeaders");
+        assertNotNull(stockResponse, "Response is null");
+        String change1 = stockResponse.getFirstElement()
+                .getFirstChildWithName(new QName("http://services.samples/xsd", "change")).getText();
+
+        assertEquals(change, change1, "Response caching did not exclude the given header value");
+
+        // Sending a request to SimpleStockQuote Service with 'user' and 'country' headers
+        axis2Client.addHttpHeader("user", "Peter");
+        axis2Client.addHttpHeader("country", "UK");
+        stockResponse = axis2Client
+                .sendSimpleStockQuoteRequest(getApiInvocationURL("excludeHeaders"), "", "ExcludeHeaders");
+        assertNotNull(stockResponse, "Response is null");
+        String change2 = stockResponse.getFirstElement()
+                .getFirstChildWithName(new QName("http://services.samples/xsd", "change")).getText();
+
+        assertNotEquals(change, change2, "Response caching works with the undefined exclude header");
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void close() throws Exception {
+        super.cleanup();
+    }
+
+}

--- a/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/cache/ExcludeMultipleHeadersWithCacheTestCase.java
+++ b/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/cache/ExcludeMultipleHeadersWithCacheTestCase.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.esb.mediator.test.cache;
+
+import org.apache.axiom.om.OMElement;
+import org.apache.axis2.AxisFault;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import org.wso2.esb.integration.common.utils.ESBIntegrationTest;
+import org.wso2.carbon.automation.engine.annotations.ExecutionEnvironment;
+import org.wso2.carbon.automation.engine.annotations.SetEnvironment;
+
+import javax.xml.namespace.QName;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
+import static org.testng.Assert.assertNotNull;
+
+/**
+ * Cache Mediator - verify 'headersToExcludeInHash' parameter
+ * <p>
+ * This testcase is to verify that multiple headers can be exclude when hashing
+ */
+public class ExcludeMultipleHeadersWithCacheTestCase extends ESBIntegrationTest {
+
+    @BeforeClass(alwaysRun = true)
+    public void setEnvironment() throws Exception {
+        super.init();
+    }
+
+    @SetEnvironment(executionEnvironments = { ExecutionEnvironment.STANDALONE })
+    @Test(groups = "wso2.esb",
+          description = "Verify multiple headers can be excluded when hasing")
+    public void testExcludingMultipleHeaders() throws AxisFault {
+        OMElement stockResponse;
+
+        // Sending a request to SimpleStockQuote Service
+        stockResponse = axis2Client.sendSimpleStockQuoteRequest(getApiInvocationURL("excludeMultipleHeaders"), "",
+                "ExcludeMultipleHeaders");
+        assertNotNull(stockResponse, "Response is null");
+        String change = stockResponse.getFirstElement()
+                .getFirstChildWithName(new QName("http://services.samples/xsd", "change")).getText();
+
+        // Sending a request to SimpleStockQuote Service with 'user' header
+        axis2Client.addHttpHeader("user", "Peter");
+        stockResponse = axis2Client.sendSimpleStockQuoteRequest(getApiInvocationURL("excludeMultipleHeaders"), "",
+                "ExcludeMultipleHeaders");
+        assertNotNull(stockResponse, "Response is null");
+        String change1 = stockResponse.getFirstElement()
+                .getFirstChildWithName(new QName("http://services.samples/xsd", "change")).getText();
+
+        assertEquals(change, change1, "Response caching did not exclude the given header value");
+
+        // Sending a request to SimpleStockQuote Service with 'country' header
+        axis2Client.addHttpHeader("COUNTRY", "UK");
+        stockResponse = axis2Client.sendSimpleStockQuoteRequest(getApiInvocationURL("excludeMultipleHeaders"), "",
+                "ExcludeMultipleHeaders");
+        assertNotNull(stockResponse, "Response is null");
+        String change2 = stockResponse.getFirstElement()
+                .getFirstChildWithName(new QName("http://services.samples/xsd", "change")).getText();
+
+        assertEquals(change, change2, "Response caching did not works when the letter case is different");
+
+        // Sending a request to SimpleStockQuote Service with 'user' and 'country' headers
+        axis2Client.addHttpHeader("user", "Peter");
+        axis2Client.addHttpHeader("country", "UK");
+        stockResponse = axis2Client.sendSimpleStockQuoteRequest(getApiInvocationURL("excludeMultipleHeaders"), "",
+                "ExcludeMultipleHeaders");
+        assertNotNull(stockResponse, "Response is null");
+        String change3 = stockResponse.getFirstElement()
+                .getFirstChildWithName(new QName("http://services.samples/xsd", "change")).getText();
+
+        assertEquals(change, change3,
+                "Response caching did not exclude all the headers defined for headersToExcludeInHash");
+
+        // Sending a request to SimpleStockQuote Service with 'user' , 'country' , 'userID' headers
+        axis2Client.addHttpHeader("user", "Peter");
+        axis2Client.addHttpHeader("country", "UK");
+        axis2Client.addHttpHeader("userID", "U001");
+        stockResponse = axis2Client.sendSimpleStockQuoteRequest(getApiInvocationURL("excludeMultipleHeaders"), "",
+                "ExcludeMultipleHeaders");
+        assertNotNull(stockResponse, "Response is null");
+        String change4 = stockResponse.getFirstElement()
+                .getFirstChildWithName(new QName("http://services.samples/xsd", "change")).getText();
+
+        assertNotEquals(change, change4, "Response caching works with the undefined exclude header");
+
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void close() throws Exception {
+        super.cleanup();
+    }
+
+}

--- a/integration/mediation-tests/tests-mediator-1/src/test/resources/artifacts/ESB/server/repository/deployment/server/synapse-configs/default/api/CacheExcludeHeaderApi.xml
+++ b/integration/mediation-tests/tests-mediator-1/src/test/resources/artifacts/ESB/server/repository/deployment/server/synapse-configs/default/api/CacheExcludeHeaderApi.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<api xmlns="http://ws.apache.org/ns/synapse" name="CacheExcludeHeaderApi.xml" context="/excludeHeaders">
+    <resource methods="POST">
+        <inSequence>
+            <cache collector="false" timeout="20">
+                <protocol type="HTTP">
+                    <methods>POST</methods>
+                    <headersToExcludeInHash>user</headersToExcludeInHash>
+                    <responseCodes>.*</responseCodes>
+                    <hashGenerator>org.wso2.carbon.mediator.cache.digest.HttpRequestHashGenerator</hashGenerator>
+                </protocol>
+            </cache>
+            <send>
+                <endpoint>
+                    <address uri="http://localhost:9000/services/SimpleStockQuoteService"
+                             format="soap11"/>
+                </endpoint>
+            </send>
+        </inSequence>
+        <outSequence>
+            <cache collector="true"/>
+            <send/>
+        </outSequence>
+    </resource>
+</api>

--- a/integration/mediation-tests/tests-mediator-1/src/test/resources/artifacts/ESB/server/repository/deployment/server/synapse-configs/default/api/CacheExcludeMultipleHeaderApi.xml
+++ b/integration/mediation-tests/tests-mediator-1/src/test/resources/artifacts/ESB/server/repository/deployment/server/synapse-configs/default/api/CacheExcludeMultipleHeaderApi.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<api xmlns="http://ws.apache.org/ns/synapse" name="CacheExcludeMultipleHeaderApi.xml" context="/excludeMultipleHeaders">
+    <resource methods="POST">
+        <inSequence>
+            <cache collector="false" timeout="20">
+                <protocol type="HTTP">
+                    <methods>POST</methods>
+                    <headersToExcludeInHash>user, country</headersToExcludeInHash>
+                    <responseCodes>.*</responseCodes>
+                    <hashGenerator>org.wso2.carbon.mediator.cache.digest.HttpRequestHashGenerator</hashGenerator>
+                </protocol>
+            </cache>
+            <send>
+                <endpoint>
+                    <address uri="http://localhost:9000/services/SimpleStockQuoteService"
+                             format="soap11"/>
+                </endpoint>
+            </send>
+        </inSequence>
+        <outSequence>
+            <cache collector="true"/>
+            <send/>
+        </outSequence>
+    </resource>
+</api>

--- a/integration/mediation-tests/tests-mediator-1/src/test/resources/artifacts/ESB/server/repository/deployment/server/synapse-configs/default/api/CacheResponseCodeRegex.xml
+++ b/integration/mediation-tests/tests-mediator-1/src/test/resources/artifacts/ESB/server/repository/deployment/server/synapse-configs/default/api/CacheResponseCodeRegex.xml
@@ -1,0 +1,24 @@
+<api xmlns="http://ws.apache.org/ns/synapse" name="CacheResponseCodeRegex" context="/ResponseCodeRegex">
+    <resource methods="GET">
+        <inSequence>
+            <header name="Accept" scope="transport" value="application/json"/>
+            <cache collector="false" timeout="5000">
+                <protocol type="HTTP">
+                    <methods>GET</methods>
+                    <headersToExcludeInHash/>
+                    <responseCodes>[2-4][0-9][0-9]</responseCodes>
+                    <hashGenerator>org.wso2.carbon.mediator.cache.digest.HttpRequestHashGenerator</hashGenerator>
+                </protocol>
+            </cache>
+            <send>
+                <endpoint>
+                    <address uri="http://localhost:8480/services/ResponseCodeGenerator"/>
+                </endpoint>
+            </send>
+        </inSequence>
+        <outSequence>
+            <cache collector="true"/>
+            <send/>
+        </outSequence>
+    </resource>
+</api>

--- a/integration/mediation-tests/tests-mediator-1/src/test/resources/artifacts/ESB/server/repository/deployment/server/synapse-configs/default/proxy-services/ResponseCodeGenerator.xml
+++ b/integration/mediation-tests/tests-mediator-1/src/test/resources/artifacts/ESB/server/repository/deployment/server/synapse-configs/default/proxy-services/ResponseCodeGenerator.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<proxy xmlns="http://ws.apache.org/ns/synapse"
+       name="ResponseCodeGenerator"
+       startOnLoad="true"
+       statistics="disable"
+       trace="disable"
+       transports="http,https">
+    <target>
+        <inSequence>
+            <property expression="$trp:CODE"
+                      name="HTTPCODE"
+                      scope="default"
+                      type="STRING"/>
+            <payloadFactory media-type="xml">
+                <format>
+                    <m0:getQuote xmlns:m0="http://services.samples">
+                        <m0:request>
+                            <m0:symbol>$1</m0:symbol>
+                        </m0:request>
+                    </m0:getQuote>
+                </format>
+                <args>
+                    <arg evaluator="xml" expression="$trp:symbol"/>
+                </args>
+            </payloadFactory>
+            <header name="Action" value="urn:getQuote"/>
+            <property name="ContentType" scope="axis2" value="text/xml;charset=UTF"/>
+            <call>
+                <endpoint>
+                    <address format="soap11"
+                             uri="http://localhost:9000/services/SimpleStockQuoteService"/>
+                </endpoint>
+            </call>
+            <property expression="get-property('HTTPCODE')"
+                      name="HTTP_SC"
+                      scope="axis2"
+                      type="STRING"/>
+            <property name="messageType"
+                      scope="axis2"
+                      type="STRING"
+                      value="application/xml"/>
+            <respond/>
+        </inSequence>
+    </target>
+    <description/>
+</proxy>


### PR DESCRIPTION
Include test cases to verify caching when the headersToExcludeInHash contains,
1. Single Header (EI6-5148)
2. Multiple Headers (EI6-5149)