### PR TITLE
Downgrade jacoco version and disable coverage

### DIFF
--- a/integration/dataservice-hosting-tests/tests-integration/tests/src/test/resources/automation.xml
+++ b/integration/dataservice-hosting-tests/tests-integration/tests/src/test/resources/automation.xml
@@ -34,7 +34,7 @@
         <!--
          Change this to true if you want to generate coverage statistics
         -->
-        <coverage>true</coverage>
+        <coverage>false</coverage>
         <!--
          Change this to true if you want to enable framework dashboard
         -->

--- a/integration/dataservice-hosting-tests/tests-ui-integration/src/test/resources/automation.xml
+++ b/integration/dataservice-hosting-tests/tests-ui-integration/src/test/resources/automation.xml
@@ -34,7 +34,7 @@
         <!--
          Change this to true if you want to generate coverage statistics
         -->
-        <coverage>true</coverage>
+        <coverage>false</coverage>
         <!--
          Change this to true if you want to enable framework dashboard
         -->

--- a/pom.xml
+++ b/pom.xml
@@ -1342,7 +1342,7 @@
         <geronimo-jms.version>1.1.1</geronimo-jms.version>
         <wss4j.version>1.5.11.wso2v17</wss4j.version>
         <!--<emma.version>2.1.5320</emma.version>-->
-        <jacoco.agent.version>0.7.9</jacoco.agent.version>
+        <jacoco.agent.version>0.7.2.201409121644</jacoco.agent.version>
         <wso2.h2.orbit.version>1.2.140.wso2v3</wso2.h2.orbit.version>
         <org.apache.cxf.version>2.7.2</org.apache.cxf.version>
         <org.springframework.version>4.1.5.RELEASE</org.springframework.version>


### PR DESCRIPTION
Downgraded the jacoco version since the newer version fails due an incompatibility of it with jdk. Also disabled coverage since it doesn't need to run by default.