### PR TITLE
Fix failing DefaultEndpointTestCase

### DIFF
--- a/integration/mediation-tests/tests-service/src/test/resources/artifacts/ESB/endpoint/defaultEndpointConfig/synapse.xml
+++ b/integration/mediation-tests/tests-service/src/test/resources/artifacts/ESB/endpoint/defaultEndpointConfig/synapse.xml
@@ -43,10 +43,16 @@
             <outSequence>
                 <send/>
             </outSequence>
+            <faultSequence>
+                <log level="full">
+                    <property name="MESSAGE" value="Executing default 'fault' sequence"/>
+                    <property name="ERROR_CODE" expression="get-property('ERROR_CODE')"/>
+                    <property name="ERROR_MESSAGE" expression="get-property('ERROR_MESSAGE')"/>
+                </log>
+                <drop/>
+            </faultSequence>
         </target>
     </proxy>
-
-
 </definitions>
 
 


### PR DESCRIPTION
Method 'testSendingToDefaultEndpointWithSuspension' of the test case 'DefaultEndpointTestCase' intermittently fails due to an incompatible fault sequence deployed in another test case is being invoked during the execution of this. As a resolution, the correct sequence was added.