### PR TITLE
Add test to verify retrieve script from registry

### DIFF
--- a/integration/mediation-tests/tests-mediator-2/src/test/java/org/wso2/carbon/esb/mediator/test/script/NashornJsScriptStoredInGovRegistryTestCase.java
+++ b/integration/mediation-tests/tests-mediator-2/src/test/java/org/wso2/carbon/esb/mediator/test/script/NashornJsScriptStoredInGovRegistryTestCase.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.esb.mediator.test.script;
+
+import org.apache.axiom.om.OMElement;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import org.wso2.carbon.registry.resource.stub.ResourceAdminServiceExceptionException;
+import org.wso2.esb.integration.common.clients.registry.ResourceAdminServiceClient;
+import org.wso2.esb.integration.common.utils.ESBIntegrationTest;
+import java.net.URL;
+import java.rmi.RemoteException;
+import javax.activation.DataHandler;
+import javax.xml.namespace.QName;
+import javax.xml.xpath.XPathExpressionException;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+
+/**
+ * This test case verifies that, mediation with NashornJs script which is stored in govrnance registry happens
+ * correctly by invoking the script with the given 'key'.
+ */
+public class NashornJsScriptStoredInGovRegistryTestCase extends ESBIntegrationTest {
+    @BeforeClass(alwaysRun = true)
+    public void setEnvironment() throws Exception {
+        super.init();
+        uploadResourcesToGovernanceRegistry();
+    }
+
+    @Test(groups = "wso2.esb", description = "Mediate with NashornJs script which is stored in governance registry by "
+            + "invoking it with the given 'key'")
+    public void testJSMediatorWithTheGivenKey() throws Exception {
+
+        OMElement response = axis2Client.sendCustomQuoteRequest(
+                getProxyServiceURLHttp("nashornJsRetrieveScriptFromGovRegistryTestProxy"), null,
+                "NashornInvokeFromRegistry");
+        assertNotNull(response, "Fault response message null");
+        assertNotNull(response.getQName().getLocalPart(), "Fault response null localpart");
+        assertEquals(response.getQName().getLocalPart(), "CheckPriceResponse", "Fault localpart mismatched");
+        assertNotNull(response.getFirstElement().getQName().getLocalPart(), " Fault response null localpart");
+        assertEquals(response.getFirstElement().getQName().getLocalPart(), "Code", "Fault localpart mismatched");
+        assertEquals(response.getFirstElement().getText(), "NashornInvokeFromRegistry", "Fault value mismatched");
+        assertNotNull(response.getFirstChildWithName(new QName("http://services.samples/xsd", "Price")), "Fault "
+                + "response null localpart");
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void destroy() throws Exception {
+        super.cleanup();
+        clearUploadedResource();
+    }
+
+    private void uploadResourcesToGovernanceRegistry() throws Exception {
+
+        ResourceAdminServiceClient resourceAdminServiceStub = new ResourceAdminServiceClient(contextUrls
+                .getBackEndUrl(), context.getContextTenant().getContextUser().getUserName(),
+                context.getContextTenant().getContextUser().getPassword());
+        resourceAdminServiceStub.deleteResource("/_system/governance/script_js");
+        resourceAdminServiceStub.addCollection("/_system/governance/", "script_js", "", "Contains test js files");
+        resourceAdminServiceStub.addResource("/_system/governance/script_js/stockquoteTransformNashorn.js",
+                "application/x-javascript", "js files", new DataHandler(new URL("file:///" + getESBResourceLocation()
+                        + "/mediatorconfig/script_js/stockquoteTransformNashorn.js")));
+    }
+
+    private void clearUploadedResource() throws InterruptedException, ResourceAdminServiceExceptionException,
+            RemoteException, XPathExpressionException {
+
+        ResourceAdminServiceClient resourceAdminServiceStub = new ResourceAdminServiceClient(contextUrls
+                .getBackEndUrl(), context.getContextTenant().getContextUser().getUserName(),
+                context.getContextTenant().getContextUser().getPassword());
+        resourceAdminServiceStub.deleteResource("/_system/governance/script_js");
+    }
+}

--- a/integration/mediation-tests/tests-mediator-2/src/test/resources/artifacts/ESB/server/repository/deployment/server/synapse-configs/default/proxy-services/nashornJsRetrieveScriptFromGovRegistryTestProxy.xml
+++ b/integration/mediation-tests/tests-mediator-2/src/test/resources/artifacts/ESB/server/repository/deployment/server/synapse-configs/default/proxy-services/nashornJsRetrieveScriptFromGovRegistryTestProxy.xml
@@ -1,0 +1,36 @@
+<!--
+  ~ Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied. See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<proxy xmlns="http://ws.apache.org/ns/synapse" name="nashornJsRetrieveScriptFromGovRegistryTestProxy" transports="http">
+    <target>
+        <inSequence>
+            <script language="nashornJs" key="gov:/script_js/stockquoteTransformNashorn.js"
+                    function="transformRequest"/>
+            <send>
+                <endpoint>
+                    <address uri="http://localhost:9000/services/SimpleStockQuoteService"/>
+                </endpoint>
+            </send>
+        </inSequence>
+        <outSequence>
+            <script language="nashornJs" key="gov:/script_js/stockquoteTransformNashorn.js"
+                    function="transformResponse"/>
+            <send/>
+        </outSequence>
+    </target>
+</proxy>


### PR DESCRIPTION
This test case verify, a script stored in governance registry
can be retrived by script mediator.