### PR TITLE
Upgrade Carbon-Kernel to 5.2.0

### DIFF
--- a/integration/test-mb/test-amqp/pom.xml
+++ b/integration/test-mb/test-amqp/pom.xml
@@ -127,6 +127,10 @@
             <groupId>org.wso2.andes.wso2</groupId>
             <artifactId>andes-client</artifactId>
         </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+        </dependency>
     </dependencies>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -312,6 +312,11 @@
                 <artifactId>json-path-assert</artifactId>
                 <version>${com.jayway.jsonpath.version}</version>
             </dependency>
+            <dependency>
+                <groupId>commons-io</groupId>
+                <artifactId>commons-io</artifactId>
+                <version>${commons.io.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -439,6 +444,7 @@
         <testng.version>6.9.10</testng.version>
         <orbit.version.geronimo-jms_1.1_spec>1.1.0.wso2v1</orbit.version.geronimo-jms_1.1_spec>
         <commons.configuration.version>1.10</commons.configuration.version>
+        <commons.io.version>2.2</commons.io.version>
         <andes.version>4.0.0-SNAPSHOT</andes.version>
         <synapse.core.version>2.1.7-wso2v16</synapse.core.version>
         <com.jayway.jsonpath.version>0.8.0</com.jayway.jsonpath.version>

--- a/pom.xml
+++ b/pom.xml
@@ -427,17 +427,17 @@
         <ballerina.runtime.version>0.92.1-SNAPSHOT</ballerina.runtime.version>
         <ballerina.core.version>0.93</ballerina.core.version>
         <carbon.p2.plugin.version>1.5.8</carbon.p2.plugin.version>
-        <carbon.messaging.version>3.0.0</carbon.messaging.version>
-        <carbon.transport.http.netty.version>5.0.0-m1</carbon.transport.http.netty.version>
-        <carbon.metrics.version>2.3.0</carbon.metrics.version>
+        <carbon.messaging.version>3.0.1</carbon.messaging.version>
+        <carbon.transport.http.netty.version>5.0.1</carbon.transport.http.netty.version>
+        <carbon.metrics.version>2.3.2</carbon.metrics.version>
         <msf4j.version>2.4.0-m1</msf4j.version>
         <carbon.feature.plugin.version>3.1.1</carbon.feature.plugin.version>
-        <carbon.kernel.version>5.2.0-beta</carbon.kernel.version>
+        <carbon.kernel.version>5.2.0</carbon.kernel.version>
         <osgi.api.version>6.0.0</osgi.api.version>
-        <carbon.jndi.version>1.0.3</carbon.jndi.version>
+        <carbon.jndi.version>1.0.4</carbon.jndi.version>
         <carbon.cache.version>1.1.3</carbon.cache.version>
-        <carbon.deployment.version>5.1.4</carbon.deployment.version>
-        <carbon.datasources.version>1.1.2</carbon.datasources.version>
+        <carbon.deployment.version>5.1.5</carbon.deployment.version>
+        <carbon.datasources.version>1.1.3</carbon.datasources.version>
         <carbon.business.messaging.version>4.0.3-SNAPSHOT</carbon.business.messaging.version>
         <maven.shadeplugin.version>2.4.1</maven.shadeplugin.version>
         <slf4j.version>1.7.22</slf4j.version>
@@ -449,7 +449,7 @@
         <synapse.core.version>2.1.7-wso2v16</synapse.core.version>
         <com.jayway.jsonpath.version>0.8.0</com.jayway.jsonpath.version>
         <slf4j.api.version>1.7.12</slf4j.api.version>
-        <carbon.config.version>2.0.5</carbon.config.version>
+        <carbon.config.version>2.1.2</carbon.config.version>
         <carbon.secvault.version>5.0.8</carbon.secvault.version>
         <carbon.utils.version>2.0.2</carbon.utils.version>
         <carbon.touchpoint.version>1.1.0</carbon.touchpoint.version>


### PR DESCRIPTION
## Purpose
Upgrade Carbon-Kernel and related dependencies to latest

## Approach
Following components are updated,

- Carbon-Kernel    5.2.0
- Carbon-Messaging   3.0.1
- Carbon-Transport   5.0.1
- Carbon-Metrics     2.3.2
- Carbon-Jndi        1.0.4
- Carbon-Deployment  5.1.5
- Carbon-Datasources 1.1.3
- Carbon-Config      2.1.2