### PR TITLE
 Enable code coverage with integration tests

### DIFF
--- a/integration/mediation-tests/coverage-report/pom.xml
+++ b/integration/mediation-tests/coverage-report/pom.xml
@@ -29,6 +29,7 @@
                     </execution>
                 </executions>
                 <configuration>
+                    <skip>${maven.test.skip}</skip>
                     <executable>java</executable>
                     <arguments>
                         <argument>-Dcarbon.zip=${basedir}/../../../distribution/target/wso2ei-${product.ei.version}.zip</argument>

--- a/integration/mediation-tests/pom.xml
+++ b/integration/mediation-tests/pom.xml
@@ -43,6 +43,7 @@
         <module>tests-other</module>
         <module>tests-ui</module>
         <module>tests-platform</module>
+        <module>coverage-report</module>
     </modules>
 
 </project>

--- a/integration/mediation-tests/tests-mediator-1/src/test/resources/automation.xml
+++ b/integration/mediation-tests/tests-mediator-1/src/test/resources/automation.xml
@@ -33,7 +33,7 @@
         <!--
          Change this to true if you want to generate coverage statistics
         -->
-        <coverage>false</coverage>
+        <coverage>true</coverage>
         <!--
          Change this to true if you want to enable framework dashboard
         -->

--- a/integration/mediation-tests/tests-mediator-2/src/test/resources/automation.xml
+++ b/integration/mediation-tests/tests-mediator-2/src/test/resources/automation.xml
@@ -33,7 +33,7 @@
         <!--
          Change this to true if you want to generate coverage statistics
         -->
-        <coverage>false</coverage>
+        <coverage>true</coverage>
         <!--
          Change this to true if you want to enable framework dashboard
         -->

--- a/integration/mediation-tests/tests-other/src/test/resources/automation.xml
+++ b/integration/mediation-tests/tests-other/src/test/resources/automation.xml
@@ -33,7 +33,7 @@
         <!--
          Change this to true if you want to generate coverage statistics
         -->
-        <coverage>false</coverage>
+        <coverage>true</coverage>
         <!--
          Change this to true if you want to enable framework dashboard
         -->

--- a/integration/mediation-tests/tests-patches/src/test/resources/automation.xml
+++ b/integration/mediation-tests/tests-patches/src/test/resources/automation.xml
@@ -33,7 +33,7 @@
         <!--
          Change this to true if you want to generate coverage statistics
         -->
-        <coverage>false</coverage>
+        <coverage>true</coverage>
         <!--
          Change this to true if you want to enable framework dashboard
         -->

--- a/integration/mediation-tests/tests-platform/tests-rabbitmq/src/test/resources/automation.xml
+++ b/integration/mediation-tests/tests-platform/tests-rabbitmq/src/test/resources/automation.xml
@@ -33,7 +33,7 @@
         <!--
          Change this to true if you want to generate coverage statistics
         -->
-        <coverage>false</coverage>
+        <coverage>true</coverage>
         <!--
          Change this to true if you want to enable framework dashboard
         -->

--- a/integration/mediation-tests/tests-platform/tests-wso2mb/src/test/resources/automation.xml
+++ b/integration/mediation-tests/tests-platform/tests-wso2mb/src/test/resources/automation.xml
@@ -33,7 +33,7 @@
         <!--
          Change this to true if you want to generate coverage statistics
         -->
-        <coverage>false</coverage>
+        <coverage>true</coverage>
         <!--
          Change this to true if you want to enable framework dashboard
         -->

--- a/integration/mediation-tests/tests-sample/src/test/resources/automation.xml
+++ b/integration/mediation-tests/tests-sample/src/test/resources/automation.xml
@@ -33,7 +33,7 @@
         <!--
          Change this to true if you want to generate coverage statistics
         -->
-        <coverage>false</coverage>
+        <coverage>true</coverage>
         <!--
          Change this to true if you want to enable framework dashboard
         -->

--- a/integration/mediation-tests/tests-service/src/test/resources/automation.xml
+++ b/integration/mediation-tests/tests-service/src/test/resources/automation.xml
@@ -33,7 +33,7 @@
         <!--
          Change this to true if you want to generate coverage statistics
         -->
-        <coverage>false</coverage>
+        <coverage>true</coverage>
         <!--
          Change this to true if you want to enable framework dashboard
         -->

--- a/integration/mediation-tests/tests-transport/src/test/resources/automation.xml
+++ b/integration/mediation-tests/tests-transport/src/test/resources/automation.xml
@@ -33,7 +33,7 @@
         <!--
          Change this to true if you want to generate coverage statistics
         -->
-        <coverage>false</coverage>
+        <coverage>true</coverage>
         <!--
          Change this to true if you want to enable framework dashboard
         -->


### PR DESCRIPTION
## Purpose
> Enable the code coverage with integration tests by default

## Goals
> To generate the coverage stat for each build 

## Approach
> collecting the coverage by instrumenting the server jar file using jacoco agent

## User stories
> N/A

## Release note
> N/A
## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - N/A

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> JDK 1.8.0_144
 
## Learning
> N/A