### PR TITLE
Improve tests for RestAPIAdminService

### DIFF
--- a/integration/mediation-tests/tests-common/admin-clients/src/main/java/org/wso2/esb/integration/common/clients/rest/api/RestApiAdminClient.java
+++ b/integration/mediation-tests/tests-common/admin-clients/src/main/java/org/wso2/esb/integration/common/clients/rest/api/RestApiAdminClient.java
@@ -23,6 +23,7 @@ import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.rest.api.stub.RestApiAdminAPIException;
 import org.wso2.carbon.rest.api.stub.RestApiAdminStub;
+import org.wso2.carbon.rest.api.stub.types.carbon.APIData;
 import org.wso2.esb.integration.common.clients.client.utils.AuthenticateStub;
 
 import java.rmi.RemoteException;
@@ -39,8 +40,7 @@ public class RestApiAdminClient {
         AuthenticateStub.authenticateStub(sessionCookie, restApiAdminStub);
     }
 
-    public RestApiAdminClient(String backEndUrl, String userName, String password)
-            throws AxisFault {
+    public RestApiAdminClient(String backEndUrl, String userName, String password) throws AxisFault {
         String endPoint = backEndUrl + serviceName;
         restApiAdminStub = new RestApiAdminStub(endPoint);
         AuthenticateStub.authenticateStub(userName, password, restApiAdminStub);
@@ -54,10 +54,55 @@ public class RestApiAdminClient {
         return restApiAdminStub.deleteApi(apiName);
     }
 
+    public boolean deleteApiForTenant(String apiName, String tenant) throws RestApiAdminAPIException, RemoteException {
+        return restApiAdminStub.deleteApiForTenant(apiName, tenant);
+    }
+
     public String[] getApiNames() throws RestApiAdminAPIException, RemoteException {
         return restApiAdminStub.getApiNames();
     }
+
     public String getServerContext() throws RestApiAdminAPIException, RemoteException {
         return restApiAdminStub.getServerContext();
+    }
+
+    public boolean addAPI(APIData apiData) throws RestApiAdminAPIException, RemoteException {
+        return restApiAdminStub.addApi(apiData);
+    }
+
+    public boolean addAPIFromTenant(String apiData, String tenantDomain)
+            throws RestApiAdminAPIException, RemoteException {
+        return restApiAdminStub.addApiForTenant(apiData, tenantDomain);
+    }
+
+    public APIData getAPIbyName(String apiName) throws RestApiAdminAPIException, RemoteException {
+        return restApiAdminStub.getApiByName(apiName);
+    }
+
+    public APIData getAPIForTenantByName(String apiName, String tenantDomain)
+            throws RestApiAdminAPIException, RemoteException {
+        return restApiAdminStub.getApiForTenant(apiName, tenantDomain);
+    }
+
+    public boolean updateAPIFromString(String apiName, String updateData)
+            throws RestApiAdminAPIException, RemoteException {
+        return restApiAdminStub.updateApiFromString(apiName, updateData);
+    }
+
+    public boolean updateAPIForTenant(String apiName, String updateData, String tenant)
+            throws RestApiAdminAPIException, RemoteException {
+        return restApiAdminStub.updateApiForTenant(apiName, updateData, tenant);
+    }
+
+    public void deleteAllApis() throws RestApiAdminAPIException, RemoteException {
+        restApiAdminStub.deleteAllApi();
+    }
+
+    public int getAPICount() throws RestApiAdminAPIException, RemoteException {
+        return restApiAdminStub.getAPICount();
+    }
+
+    public String getAPISource(APIData apiData) throws RestApiAdminAPIException, RemoteException {
+        return restApiAdminStub.getApiSource(apiData);
     }
 }

--- a/integration/mediation-tests/tests-service/src/test/java/org/wso2/carbon/esb/rest/test/api/RestApiAdminServiceTestCase.java
+++ b/integration/mediation-tests/tests-service/src/test/java/org/wso2/carbon/esb/rest/test/api/RestApiAdminServiceTestCase.java
@@ -1,0 +1,152 @@
+/*
+ *Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *WSO2 Inc. licenses this file to you under the Apache License,
+ *Version 2.0 (the "License"); you may not use this file except
+ *in compliance with the License.
+ *You may obtain a copy of the License at
+ *
+ *http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *Unless required by applicable law or agreed to in writing,
+ *software distributed under the License is distributed on an
+ *"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *KIND, either express or implied.  See the License for the
+ *specific language governing permissions and limitations
+ *under the License.
+ */
+package org.wso2.carbon.esb.rest.test.api;
+
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import org.wso2.carbon.rest.api.stub.types.carbon.APIData;
+import org.wso2.carbon.rest.api.stub.types.carbon.ResourceData;
+import org.wso2.esb.integration.common.clients.rest.api.RestApiAdminClient;
+import org.wso2.esb.integration.common.utils.ESBIntegrationTest;
+
+/**
+ * Testcase for RestAPIAdminService
+ */
+public class RestApiAdminServiceTestCase extends ESBIntegrationTest {
+
+    private RestApiAdminClient restAdminClient;
+    private APIData api1, api2;
+    private static final String tenantAPIName = "TenantServiceAPI";
+    private static final String tenantDomain = "carbon.super";
+
+    @BeforeClass(alwaysRun = true)
+    public void init() throws Exception {
+        super.init();
+        restAdminClient = new RestApiAdminClient(context.getContextUrls().getBackEndUrl(), getSessionCookie());
+        api1 = new APIData();
+        api2 = new APIData();
+        //  sample API resource
+        ResourceData resource = new ResourceData();
+        String[] methods = { "POST" };
+        resource.setMethods(methods);
+        resource.setUrlMapping("/usage");
+        ResourceData[] resourceList = new ResourceData[] { resource };
+
+        api1.setName("SampleServiceAPI");
+        api1.setContext("/createApi");
+        api1.setHost("localhost");
+        api1.setPort(8480);
+        api1.setResources(resourceList);
+
+        api2 = new APIData();
+        api2.setName("TenantServiceAPI");
+        api2.setContext("/tenant");
+        api2.setHost("localhost");
+        api2.setPort(8480);
+        api2.setResources(resourceList);
+
+    }
+
+    @Test(groups = { "wso2.esb" },
+          description = "Test API creation service",
+          priority = 1)
+    public void testCreateAPI() throws Exception {
+        boolean apiAdded = restAdminClient.addAPI(api1);
+        Assert.assertEquals(apiAdded, true, "API was not created");
+
+    }
+
+    @Test(groups = { "wso2.esb" },
+          description = "Test API creation service under given tenant",
+          priority = 2)
+    public void testCreateAPIForTenant() throws Exception {
+        String tenantAPISource = restAdminClient.getAPISource(api2);
+        boolean apiAdded = restAdminClient.addAPIFromTenant(tenantAPISource, tenantDomain);
+        Assert.assertEquals(apiAdded, true, "API was not created for tenant");
+
+    }
+
+    @Test(groups = { "wso2.esb" },
+          description = "Test API list service ",
+          priority = 3)
+    public void testGetAPI() throws Exception {
+        APIData apiResult = restAdminClient.getAPIbyName(api1.getName());
+        Assert.assertEquals(apiResult.getName(), api1.getName(), "API was not retrieved");
+
+    }
+
+    @Test(groups = { "wso2.esb" },
+          description = "Test API list service of a given tenant",
+          priority = 4)
+    public void testGetAPIForTenant() throws Exception {
+        APIData apiResult = restAdminClient.getAPIForTenantByName(tenantAPIName, tenantDomain);
+        Assert.assertEquals(apiResult.getName(), tenantAPIName, "API for tenant was not retrieved");
+    }
+
+    @Test(groups = { "wso2.esb" },
+          description = "Test API update service",
+          priority = 5)
+    public void testUpdateAPI() throws Exception {
+        String updateData =
+                "<api xmlns=\"http://ws.apache.org/ns/synapse\" name=\"SampleServiceAPI\" context=\"/createApi\">\n"
+                        + "    <resource methods=\"POST PUT\" uri-template=\"/\"> </resource></api>";
+        boolean apiUpdated = restAdminClient.updateAPIFromString(api1.getName(), updateData);
+        Assert.assertEquals(apiUpdated, true, "API was not updated");
+    }
+
+    @Test(groups = { "wso2.esb" },
+          description = "Test API update service for tenant",
+          priority = 6)
+    public void testUpdateAPIForTenant() throws Exception {
+        String updateData =
+                "<api xmlns=\"http://ws.apache.org/ns/synapse\" name=\"TenantServiceAPI\" context=\"/tenant\">\n"
+                        + "    <resource methods=\"POST\" uri-template=\"/\"> </resource></api>";
+        boolean apiUpdated = restAdminClient.updateAPIForTenant(tenantAPIName, updateData, "carbon.super");
+        Assert.assertEquals(apiUpdated, true, "API was not updated for tenant");
+    }
+
+    @Test(groups = { "wso2.esb" },
+          description = "Test API delete service ",
+          priority = 7)
+    public void testDeleteAPI() throws Exception {
+        boolean apiResult = restAdminClient.deleteApi(api1.getName());
+        Assert.assertEquals(apiResult, true, "API was not removed");
+
+    }
+
+    @Test(groups = { "wso2.esb" },
+          description = "Test API delete service for tenant ",
+          priority = 8)
+    public void testDeleteAPIForTenant() throws Exception {
+        boolean apiResult = restAdminClient.deleteApiForTenant(tenantAPIName, tenantDomain);
+        Assert.assertEquals(apiResult, true, "API was not removed");
+
+    }
+
+    @AfterClass(groups = "wso2.esb")
+    public void close() throws Exception {
+        if (restAdminClient.getAPICount() > 0) {
+            restAdminClient.deleteAllApis();
+        }
+        restAdminClient = null;
+        super.cleanup();
+    }
+
+}

--- a/integration/mediation-tests/tests-service/src/test/java/org/wso2/carbon/esb/rest/test/api/RestApiAdminServiceTestCase.java
+++ b/integration/mediation-tests/tests-service/src/test/java/org/wso2/carbon/esb/rest/test/api/RestApiAdminServiceTestCase.java
@@ -70,7 +70,7 @@ public class RestApiAdminServiceTestCase extends ESBIntegrationTest {
     public void testCreateAPI() throws Exception {
         boolean apiAdded = restAdminClient.addAPI(api1);
         Assert.assertEquals(apiAdded, true, "API was not created");
-
+        verifyAPIExistence(api1.getName());
     }
 
     @Test(groups = { "wso2.esb" },
@@ -80,7 +80,7 @@ public class RestApiAdminServiceTestCase extends ESBIntegrationTest {
         String tenantAPISource = restAdminClient.getAPISource(api2);
         boolean apiAdded = restAdminClient.addAPIFromTenant(tenantAPISource, tenantDomain);
         Assert.assertEquals(apiAdded, true, "API was not created for tenant");
-
+        verifyAPIExistence(api2.getName());
     }
 
     @Test(groups = { "wso2.esb" },


### PR DESCRIPTION
## Purpose
Includes test coverage for rest-api Admin service which handles API config related operations.Following cases are covered so far.
1. Adding an API ( String API element, OM API element, APIData element)
2. Get an API 
3. Update an API (String API element)
4. Delete an API 
5. Add/Get/Update/Delete an API for a given tenant.
6. Delete all API
7. Check for API count