### PR TITLE
Add RabbitMQ inbound endpoint test case

### DIFF
--- a/integration/mediation-tests/tests-common/integration-test-utils/src/main/java/org/wso2/esb/integration/common/utils/ESBTestCaseUtils.java
+++ b/integration/mediation-tests/tests-common/integration-test-utils/src/main/java/org/wso2/esb/integration/common/utils/ESBTestCaseUtils.java
@@ -97,6 +97,7 @@ public class ESBTestCaseUtils {
 	private static final String KEY = "key";
 	private static final String NAME = "name";
 	private static final String TASK = "task";
+	private static final String INBOUND_ENDPOINT = "inboundEndpoint";
 
 
 	/**
@@ -227,6 +228,7 @@ public class ESBTestCaseUtils {
         RestApiAdminClient apiAdminClient = new RestApiAdminClient(backendURL, sessionCookie);
         PriorityMediationAdminClient priorityMediationAdminClient = new PriorityMediationAdminClient(backendURL, sessionCookie);
         TaskAdminClient taskAdminClient = new TaskAdminClient(backendURL, sessionCookie);
+        InboundAdminClient inboundAdminClient = new InboundAdminClient(backendURL, sessionCookie);
 
         Iterator<OMElement> localEntries = synapseConfig.getChildrenWithLocalName(LOCAL_ENTRY);
         while (localEntries.hasNext()) {
@@ -372,6 +374,18 @@ public class ESBTestCaseUtils {
             taskAdminClient.addTask(task);
             Assert.assertTrue(isScheduleTaskDeployed(backendURL, sessionCookie, taskName), " Task deployment failed");
             log.info(taskName + " Task Uploaded");
+        }
+
+        Iterator<OMElement> inboundEndpoints = synapseConfig.getChildrenWithLocalName(INBOUND_ENDPOINT);
+        while (inboundEndpoints.hasNext()) {
+            OMElement inboundEndpoint = inboundEndpoints.next();
+            String inboundEP = inboundEndpoint.getAttributeValue(new QName(NAME));
+            if (ArrayUtils.contains(inboundAdminClient.getAllInboundEndpointNames(), inboundEP)) {
+                Assert.fail("Inbound Endpoint already exist " + inboundEP + ". Use different name");
+            }
+            inboundAdminClient.addInboundEndpoint(inboundEndpoint.toString());
+            isInboundEndpointDeployed(backendURL, sessionCookie, inboundEP);
+            log.info(inboundEP + " Inbound endpoint Uploaded");
         }
 
         Thread.sleep(1000);

--- a/integration/mediation-tests/tests-platform/tests-rabbitmq/src/test/java/org/wso2/carbon/esb/rabbitmq/inbound/RabbitMQInboundTestCase.java
+++ b/integration/mediation-tests/tests-platform/tests-rabbitmq/src/test/java/org/wso2/carbon/esb/rabbitmq/inbound/RabbitMQInboundTestCase.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c)2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.esb.rabbitmq.inbound;
+
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import org.wso2.carbon.esb.rabbitmq.utils.RabbitMQServerInstance;
+import org.wso2.carbon.esb.rabbitmq.utils.RabbitMQTestUtils;
+import org.wso2.carbon.integration.common.admin.client.LogViewerClient;
+import org.wso2.esb.integration.common.utils.ESBIntegrationTest;
+import org.wso2.esb.integration.common.utils.clients.rabbitmqclient.RabbitMQProducerClient;
+import org.wso2.carbon.logging.view.stub.types.carbon.LogEvent;
+
+import java.io.File;
+
+/**
+ * Includes a test case which deploys a simple rabbitmq inbound endpoint and tests for message consumption through
+ * that.
+ */
+public class RabbitMQInboundTestCase extends ESBIntegrationTest {
+
+    private LogViewerClient logViewer;
+    private RabbitMQProducerClient sender;
+
+    @BeforeClass(alwaysRun = true)
+    public void init() throws Exception {
+        super.init();
+        //The inbound endpoint cannot be pre-deployed because it will cause unnecessary message polling.
+        loadESBConfigurationFromClasspath(File.separator + "artifacts" + File.separator + "ESB" + File.separator
+                                          + "inbound" + File.separator + "rabbitmq_inbound_endpoint.xml");
+        logViewer = new LogViewerClient(contextUrls.getBackEndUrl(), getSessionCookie());
+    }
+
+    /**
+     * Publishes 200 messages to the queue 'simple_inbound_endpoint_test' and asserts for the log
+     * 'received by inbound endpoint = true' which is logged once a message is picked up by the inbound endpoint.
+     *
+     * @throws Exception if an error occurs while accessing the logViewer client or while publishing messages.
+     */
+    @Test(groups = {"wso2.esb"}, description = "Test ESB as a RabbitMQ inbound endpoint ")
+    public void testRabbitMQInboundEndpoint() throws Exception {
+        sender = RabbitMQServerInstance.createProducerWithDeclaration("exchange", "simple_inbound_endpoint_test");
+
+        logViewer.clearLogs();
+        int messageCount = 2;
+
+        String message = "<ser:placeOrder xmlns:ser=\"http://services.samples\">\n" + "<ser:order>\n"
+                         + "<ser:price>100</ser:price>\n" + "<ser:quantity>2000</ser:quantity>\n"
+                         + "<ser:symbol>RMQ</ser:symbol>\n" + "</ser:order>\n" + "</ser:placeOrder>";
+        for (int i = 0; i < messageCount; i++) {
+            sender.sendMessage(message, "text/plain");
+        }
+
+        RabbitMQTestUtils.waitForLogToGetUpdated();
+
+        LogEvent[] logs = logViewer.getAllRemoteSystemLogs();
+        int count = 0;
+
+        for (LogEvent logEvent : logs) {
+            if (logEvent == null) {
+                continue;
+            }
+            String logMessage = logEvent.getMessage();
+            if (logMessage.contains("received by inbound endpoint = true")) {
+                count++;
+            }
+        }
+        Assert.assertEquals(count, messageCount, "All messages are not received from queue");
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void end() throws Exception {
+        super.cleanup();
+        sender.disconnect();
+        sender = null;
+        logViewer = null;
+    }
+}

--- a/integration/mediation-tests/tests-platform/tests-rabbitmq/src/test/resources/artifacts/ESB/inbound/rabbitmq_inbound_endpoint.xml
+++ b/integration/mediation-tests/tests-platform/tests-rabbitmq/src/test/resources/artifacts/ESB/inbound/rabbitmq_inbound_endpoint.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c)2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<definitions xmlns="http://ws.apache.org/ns/synapse">
+    <sequence name="logSequence">
+        <log level="full">
+            <property name="received by inbound endpoint" value="true"/>
+        </log>
+    </sequence>
+    <inboundEndpoint xmlns="http://ws.apache.org/ns/synapse" name="RabbitMQConsumerInboundEP" sequence="logSequence"
+                     onError="fault" protocol="rabbitmq" suspend="false">
+        <parameters>
+            <parameter name="sequential">true</parameter>
+            <parameter name="coordination">true</parameter>
+            <parameter name="rabbitmq.connection.factory">AMQPConnectionFactory</parameter>
+            <parameter name="rabbitmq.server.host.name">localhost</parameter>
+            <parameter name="rabbitmq.server.port">5672</parameter>
+            <parameter name="rabbitmq.server.user.name">guest</parameter>
+            <parameter name="rabbitmq.server.password">guest</parameter>
+            <parameter name="rabbitmq.queue.name">simple_inbound_endpoint_test</parameter>
+            <parameter name="rabbitmq.exchange.name">exchange</parameter>
+            <parameter name="rabbitmq.connection.ssl.enabled">false</parameter>
+        </parameters>
+    </inboundEndpoint>
+</definitions>

--- a/integration/mediation-tests/tests-platform/tests-rabbitmq/src/test/resources/testng.xml
+++ b/integration/mediation-tests/tests-platform/tests-rabbitmq/src/test/resources/testng.xml
@@ -51,5 +51,11 @@
         </classes>
     </test>
 
+    <test name="RabbitMQ-Inbound-Endpoint-test" preserve-order="true" verbose="2">
+        <classes>
+            <class name="org.wso2.carbon.esb.rabbitmq.inbound.RabbitMQInboundTestCase"/>
+        </classes>
+    </test>
+
 </suite>
 


### PR DESCRIPTION
## Purpose
Adds an integration for RabbitMQ based inbound endpoints.

## Approach
Added test case 'RabbitMQInboundTestCase' which includes the test method 'testRabbitMQInboundEndpoint' that publishes 200 messages to a rabbitmq queue and asserts for the message consumption.