### PR TITLE
Add test case for web socket transport

### DIFF
--- a/integration/mediation-tests/tests-transport/pom.xml
+++ b/integration/mediation-tests/tests-transport/pom.xml
@@ -306,6 +306,35 @@
         <artifactId>mqtt-client</artifactId>
         </dependency>
 
+        <!--Netty Dependency-->
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-buffer</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-transport</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-handler</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-codec</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-codec-http</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-resolver</artifactId>
+        </dependency>
     </dependencies>
 
 </project>

--- a/integration/mediation-tests/tests-transport/src/test/java/org/wso2/carbon/esb/websocket/client/WebSocketClientHandler.java
+++ b/integration/mediation-tests/tests-transport/src/test/java/org/wso2/carbon/esb/websocket/client/WebSocketClientHandler.java
@@ -1,0 +1,178 @@
+/*
+ *  Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ *
+ */
+
+package org.wso2.carbon.esb.websocket.client;
+
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.ChannelPromise;
+import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.websocketx.BinaryWebSocketFrame;
+import io.netty.handler.codec.http.websocketx.CloseWebSocketFrame;
+import io.netty.handler.codec.http.websocketx.PongWebSocketFrame;
+import io.netty.handler.codec.http.websocketx.TextWebSocketFrame;
+import io.netty.handler.codec.http.websocketx.WebSocketClientHandshaker;
+import io.netty.handler.codec.http.websocketx.WebSocketFrame;
+import io.netty.util.CharsetUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.nio.ByteBuffer;
+import java.util.concurrent.CountDownLatch;
+
+/**
+ * WebSocket Client Handler for Testing.
+ */
+public class WebSocketClientHandler extends SimpleChannelInboundHandler<Object> {
+
+    private static final Logger logger = LoggerFactory.getLogger(WebSocketClientHandler.class);
+
+    private final WebSocketClientHandshaker handshaker;
+    private ChannelPromise handshakeFuture;
+    private ChannelHandlerContext ctx;
+
+    private String textReceived = "";
+    private ByteBuffer bufferReceived = null;
+    private boolean isOpen;
+    private CountDownLatch latch;
+
+    public WebSocketClientHandler(WebSocketClientHandshaker handshaker, CountDownLatch latch) {
+        this.handshaker = handshaker;
+        this.latch = latch;
+        this.isOpen = true;
+    }
+
+    public ChannelFuture handshakeFuture() {
+        return handshakeFuture;
+    }
+
+    @Override
+    public void handlerAdded(ChannelHandlerContext ctx) {
+        handshakeFuture = ctx.newPromise();
+        this.ctx = ctx;
+    }
+
+    @Override
+    public void channelActive(ChannelHandlerContext ctx) {
+        handshaker.handshake(ctx.channel());
+    }
+
+    @Override
+    public void channelInactive(ChannelHandlerContext ctx) throws InterruptedException {
+        if (logger.isDebugEnabled()) {
+            logger.debug("WebSocket Client disconnected!");
+        }
+        ctx.channel().close().sync();
+        isOpen = false;
+    }
+
+    @Override
+    public void channelRead0(ChannelHandlerContext ctx, Object msg) throws Exception {
+        Channel ch = ctx.channel();
+        if (!handshaker.isHandshakeComplete()) {
+            handshaker.finishHandshake(ch, (FullHttpResponse) msg);
+            if (logger.isDebugEnabled()) {
+                logger.debug("WebSocket Client connected!");
+            }
+            handshakeFuture.setSuccess();
+            return;
+        }
+
+        if (msg instanceof FullHttpResponse) {
+            FullHttpResponse response = (FullHttpResponse) msg;
+            throw new IllegalStateException(
+                    "Unexpected FullHttpResponse (getStatus=" + response.status() +
+                            ", content=" + response.content().toString(CharsetUtil.UTF_8) + ')');
+        }
+
+        WebSocketFrame frame = (WebSocketFrame) msg;
+        if (frame instanceof TextWebSocketFrame) {
+            TextWebSocketFrame textFrame = (TextWebSocketFrame) frame;
+            if (logger.isDebugEnabled()) {
+                logger.debug("WebSocket Client received text message: " + textFrame.text());
+            }
+            textReceived = textFrame.text();
+        } else if (frame instanceof BinaryWebSocketFrame) {
+            BinaryWebSocketFrame binaryFrame = (BinaryWebSocketFrame) frame;
+            bufferReceived = binaryFrame.content().nioBuffer();
+            if (logger.isDebugEnabled()) {
+                logger.debug("WebSocket Client received  binary message: " + bufferReceived.toString());
+            }
+        } else if (frame instanceof PongWebSocketFrame) {
+            if (logger.isDebugEnabled()) {
+                logger.debug("WebSocket Client received pong");
+            }
+            PongWebSocketFrame pongFrame = (PongWebSocketFrame) frame;
+            bufferReceived = pongFrame.content().nioBuffer();
+        } else if (frame instanceof CloseWebSocketFrame) {
+            if (logger.isDebugEnabled()) {
+                logger.debug("WebSocket Client received closing");
+            }
+            isOpen = false;
+        }
+        countDownLatch();
+    }
+
+    /**
+     * @return the text received from the server.
+     */
+    public String getTextReceived() {
+        return textReceived;
+    }
+
+    /**
+     * @return the binary data received from the server.
+     */
+    public ByteBuffer getBufferReceived() {
+        return bufferReceived;
+    }
+
+    /**
+     * Check whether the connection is still open or not.
+     *
+     * @return true if connection is still open.
+     */
+    public boolean isOpen() {
+        return isOpen;
+    }
+
+    @Override
+    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+        if (!handshakeFuture.isDone()) {
+            handshakeFuture.setFailure(cause);
+        }
+        ctx.close();
+    }
+
+    public void shutDown() throws InterruptedException {
+        ctx.channel().writeAndFlush(new CloseWebSocketFrame());
+        ctx.channel().closeFuture().sync();
+    }
+
+    private void countDownLatch() {
+        if (this.latch == null) {
+            return;
+        }
+        latch.countDown();
+    }
+
+
+}

--- a/integration/mediation-tests/tests-transport/src/test/java/org/wso2/carbon/esb/websocket/client/WebSocketTestClient.java
+++ b/integration/mediation-tests/tests-transport/src/test/java/org/wso2/carbon/esb/websocket/client/WebSocketTestClient.java
@@ -1,0 +1,242 @@
+/*
+ *  Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ *
+ */
+
+package org.wso2.carbon.esb.websocket.client;
+
+import io.netty.bootstrap.Bootstrap;
+import io.netty.buffer.Unpooled;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.channel.socket.nio.NioSocketChannel;
+import io.netty.handler.codec.http.DefaultHttpHeaders;
+import io.netty.handler.codec.http.HttpClientCodec;
+import io.netty.handler.codec.http.HttpHeaders;
+import io.netty.handler.codec.http.HttpObjectAggregator;
+import io.netty.handler.codec.http.websocketx.BinaryWebSocketFrame;
+import io.netty.handler.codec.http.websocketx.PingWebSocketFrame;
+import io.netty.handler.codec.http.websocketx.TextWebSocketFrame;
+import io.netty.handler.codec.http.websocketx.WebSocketClientHandshakerFactory;
+import io.netty.handler.codec.http.websocketx.WebSocketVersion;
+import io.netty.handler.codec.http.websocketx.extensions.compression.WebSocketClientCompressionHandler;
+import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.SslContextBuilder;
+import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.net.ProtocolException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.ByteBuffer;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import javax.net.ssl.SSLException;
+
+/**
+ * WebSocket client class for test
+ */
+public class WebSocketTestClient {
+
+    private static final Logger logger = LoggerFactory.getLogger(WebSocketTestClient.class);
+
+    private String url = null;
+    private final String subProtocol;
+    private Map<String, String> customHeaders = new HashMap<>();
+
+    private Channel channel = null;
+    private WebSocketClientHandler handler;
+    private EventLoopGroup group;
+    private CountDownLatch latch;
+
+    public WebSocketTestClient(String url) {
+        this.url = url;
+        this.subProtocol = null;
+    }
+
+    public WebSocketTestClient(String url, String subProtocol, Map<String, String> customHeaders) {
+        this.url = url;
+        this.subProtocol = subProtocol;
+        this.customHeaders = customHeaders;
+
+    }
+
+    public WebSocketTestClient(String url, CountDownLatch latch) {
+        this.url = url;
+        this.subProtocol = null;
+        this.latch = latch;
+    }
+
+    public WebSocketTestClient(String url, String subProtocol, Map<String, String> customHeaders,
+            CountDownLatch latch) {
+        this.url = url;
+        this.subProtocol = subProtocol;
+        this.customHeaders = customHeaders;
+        this.latch = latch;
+    }
+
+    /**
+     * @return true if the handshake is done properly.
+     * @throws URISyntaxException   throws if there is an error in the URI syntax.
+     * @throws InterruptedException throws if the connecting the server is interrupted.
+     */
+    public boolean handhshake() throws InterruptedException, URISyntaxException, SSLException, ProtocolException {
+        boolean isSuccess;
+        URI uri = new URI(url);
+        String scheme = uri.getScheme() == null ? "ws" : uri.getScheme();
+        final String host = uri.getHost() == null ? "127.0.0.1" : uri.getHost();
+        final int port;
+        if (uri.getPort() == -1) {
+            if ("ws" .equalsIgnoreCase(scheme)) {
+                port = 80;
+            } else if ("wss" .equalsIgnoreCase(scheme)) {
+                port = 443;
+            } else {
+                port = -1;
+            }
+        } else {
+            port = uri.getPort();
+        }
+
+        if (!"ws" .equalsIgnoreCase(scheme) && !"wss" .equalsIgnoreCase(scheme)) {
+            logger.error("Only WS(S) is supported.");
+            return false;
+        }
+
+        final boolean ssl = "wss" .equalsIgnoreCase(scheme);
+        final SslContext sslCtx;
+        if (ssl) {
+            sslCtx = SslContextBuilder.forClient().trustManager(InsecureTrustManagerFactory.INSTANCE).build();
+        } else {
+            sslCtx = null;
+        }
+
+        group = new NioEventLoopGroup();
+
+        HttpHeaders headers = new DefaultHttpHeaders();
+        for (Map.Entry<String, String> entry : customHeaders.entrySet()) {
+            headers.add(entry.getKey(), entry.getValue());
+        }
+        try {
+            // Connect with V13 (RFC 6455 aka HyBi-17). You can change it to V08 or V00.
+            // If you change it to V00, ping is not supported and remember to change
+            // HttpResponseDecoder to WebSocketHttpResponseDecoder in the pipeline.
+            handler = new WebSocketClientHandler(WebSocketClientHandshakerFactory
+                    .newHandshaker(uri, WebSocketVersion.V13, subProtocol, true, headers), latch);
+
+            Bootstrap b = new Bootstrap();
+            b.group(group).channel(NioSocketChannel.class).handler(new ChannelInitializer<SocketChannel>() {
+                @Override
+                protected void initChannel(SocketChannel ch) {
+                    ChannelPipeline p = ch.pipeline();
+                    if (sslCtx != null) {
+                        p.addLast(sslCtx.newHandler(ch.alloc(), host, port));
+                    }
+                    p.addLast(new HttpClientCodec(), new HttpObjectAggregator(8192),
+                            WebSocketClientCompressionHandler.INSTANCE, handler);
+                }
+            });
+
+            channel = b.connect(uri.getHost(), port).sync().channel();
+            isSuccess = handler.handshakeFuture().sync().isSuccess();
+            logger.info("WebSocket Handshake successful : " + isSuccess);
+            return isSuccess;
+        } catch (Exception e) {
+            logger.error("Handshake unsuccessful : " + e.getMessage());
+            throw new ProtocolException("Protocol exception: " + e.getMessage());
+        }
+    }
+
+    /**
+     * Send text to the server.
+     *
+     * @param text text need to be sent.
+     */
+    public void sendText(String text) {
+        if (channel == null) {
+            logger.error("Channel is null. Cannot send text.");
+            throw new IllegalArgumentException("Cannot find the channel to write");
+        }
+        channel.writeAndFlush(new TextWebSocketFrame(text));
+    }
+
+    /**
+     * Send binary data to server.
+     *
+     * @param buf buffer containing the data need to be sent.
+     */
+    public void sendBinary(ByteBuffer buf) throws IOException {
+        if (channel == null) {
+            logger.error("Channel is null. Cannot send text.");
+            throw new IllegalArgumentException("Cannot find the channel to write");
+        }
+        channel.writeAndFlush(new BinaryWebSocketFrame(Unpooled.wrappedBuffer(buf)));
+    }
+
+    /**
+     * Send a ping message to the server.
+     *
+     * @param buf content of the ping message to be sent.
+     */
+    public void sendPing(ByteBuffer buf) throws IOException {
+        if (channel == null) {
+            logger.error("Channel is null. Cannot send text.");
+            throw new IllegalArgumentException("Cannot find the channel to write");
+        }
+        channel.writeAndFlush(new PingWebSocketFrame(Unpooled.wrappedBuffer(buf)));
+    }
+
+    /**
+     * @return the text received from the server.
+     */
+    public String getTextReceived() {
+        return handler.getTextReceived();
+    }
+
+    /**
+     * @return the binary data received from the server.
+     */
+    public ByteBuffer getBufferReceived() {
+        return handler.getBufferReceived();
+    }
+
+    /**
+     * Check whether the connection is still open or not.
+     *
+     * @return true if connection is still open.
+     */
+    public boolean isOpen() {
+        return handler.isOpen();
+    }
+
+    /**
+     * Shutdown the WebSocket Client.
+     */
+    public void shutDown() throws InterruptedException {
+        logger.info("Shutting Down WebSocket Client....");
+        handler.shutDown();
+        group.shutdownGracefully();
+    }
+
+}

--- a/integration/mediation-tests/tests-transport/src/test/java/org/wso2/carbon/esb/websocket/inbound/transport/test/WebSocketInboundTestCase.java
+++ b/integration/mediation-tests/tests-transport/src/test/java/org/wso2/carbon/esb/websocket/inbound/transport/test/WebSocketInboundTestCase.java
@@ -1,0 +1,76 @@
+/*
+*Copyright (c) 2005-2010, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*WSO2 Inc. licenses this file to you under the Apache License,
+*Version 2.0 (the "License"); you may not use this file except
+*in compliance with the License.
+*You may obtain a copy of the License at
+*
+*http://www.apache.org/licenses/LICENSE-2.0
+*
+*Unless required by applicable law or agreed to in writing,
+*software distributed under the License is distributed on an
+*"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+*KIND, either express or implied.  See the License for the
+*specific language governing permissions and limitations
+*under the License.
+*/
+package org.wso2.carbon.esb.websocket.inbound.transport.test;
+
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import org.wso2.carbon.esb.websocket.client.WebSocketTestClient;
+import org.wso2.carbon.esb.websocket.server.WebSocketServer;
+import org.wso2.esb.integration.common.utils.ESBIntegrationTest;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+public class WebSocketInboundTestCase extends ESBIntegrationTest {
+
+    private WebSocketServer webSocketServer;
+    private WebSocketTestClient webSocketTestClient;
+
+    @BeforeClass(alwaysRun = true)
+    public void setEnvironment() throws Exception {
+        webSocketServer = new WebSocketServer(7474);
+        webSocketServer.run();
+        super.init();
+        loadESBConfigurationFromClasspath("/artifacts/ESB/websocket/synapse-websocket-inbound.xml");
+    }
+
+    @Test(groups = "wso2.esb",
+          description = "Web Socket transport test", timeOut = 60000)
+    public void webSocketInboundTest() throws Exception {
+        int latchCountDownInSecs = 30;
+        CountDownLatch latch = new CountDownLatch(1);
+        webSocketTestClient = new WebSocketTestClient("ws://localhost:9091/", latch);
+        webSocketTestClient.handhshake();
+        String text = "{message:\"hello web socket test\"}";
+        webSocketTestClient.sendText(text);
+        latch.await(latchCountDownInSecs, TimeUnit.SECONDS);
+        Assert.assertEquals(webSocketTestClient.getTextReceived(), text);
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void destroy() throws Exception {
+        try {
+            if (webSocketTestClient != null) {
+                webSocketTestClient.shutDown();
+            }
+        } catch (InterruptedException e) {
+            log.error("Error while closing the Web Socket Client");
+            //ignore
+        }
+        try {
+            super.cleanup();
+        } finally {
+            if (webSocketServer != null) {
+                webSocketServer.stop();
+            }
+        }
+
+    }
+}

--- a/integration/mediation-tests/tests-transport/src/test/java/org/wso2/carbon/esb/websocket/inbound/transport/test/WebSocketInboundTestCase.java
+++ b/integration/mediation-tests/tests-transport/src/test/java/org/wso2/carbon/esb/websocket/inbound/transport/test/WebSocketInboundTestCase.java
@@ -1,20 +1,21 @@
 /*
-*Copyright (c) 2005-2010, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
-*
-*WSO2 Inc. licenses this file to you under the Apache License,
-*Version 2.0 (the "License"); you may not use this file except
-*in compliance with the License.
-*You may obtain a copy of the License at
-*
-*http://www.apache.org/licenses/LICENSE-2.0
-*
-*Unless required by applicable law or agreed to in writing,
-*software distributed under the License is distributed on an
-*"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-*KIND, either express or implied.  See the License for the
-*specific language governing permissions and limitations
-*under the License.
-*/
+ *  Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ *
+ */
 package org.wso2.carbon.esb.websocket.inbound.transport.test;
 
 import org.testng.Assert;

--- a/integration/mediation-tests/tests-transport/src/test/java/org/wso2/carbon/esb/websocket/inbound/transport/test/WebSocketInboundTestCase.java
+++ b/integration/mediation-tests/tests-transport/src/test/java/org/wso2/carbon/esb/websocket/inbound/transport/test/WebSocketInboundTestCase.java
@@ -29,6 +29,9 @@ import org.wso2.esb.integration.common.utils.ESBIntegrationTest;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
+/**
+ * Test the wes socket transport functionality with inbound endpoint.
+ */
 public class WebSocketInboundTestCase extends ESBIntegrationTest {
 
     private WebSocketServer webSocketServer;

--- a/integration/mediation-tests/tests-transport/src/test/java/org/wso2/carbon/esb/websocket/server/WebSocketRemoteServerFrameHandler.java
+++ b/integration/mediation-tests/tests-transport/src/test/java/org/wso2/carbon/esb/websocket/server/WebSocketRemoteServerFrameHandler.java
@@ -1,0 +1,73 @@
+/*
+ *  Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ *
+ */
+
+package org.wso2.carbon.esb.websocket.server;
+
+import io.netty.channel.ChannelHandlerContext;
+import io.netty.channel.SimpleChannelInboundHandler;
+import io.netty.handler.codec.http.websocketx.BinaryWebSocketFrame;
+import io.netty.handler.codec.http.websocketx.CloseWebSocketFrame;
+import io.netty.handler.codec.http.websocketx.TextWebSocketFrame;
+import io.netty.handler.codec.http.websocketx.WebSocketFrame;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Simple WebSocket frame handler for testing
+ */
+public class WebSocketRemoteServerFrameHandler extends SimpleChannelInboundHandler<WebSocketFrame> {
+
+    private static final Logger log = LoggerFactory.getLogger(WebSocketRemoteServerFrameHandler.class);
+
+    @Override
+    public void channelActive(ChannelHandlerContext ctx) throws Exception {
+        if (log.isDebugEnabled()) {
+            log.debug("channel is active");
+        }
+    }
+
+    @Override
+    public void channelInactive(ChannelHandlerContext ctx) throws Exception {
+        if (log.isDebugEnabled()) {
+            log.debug("channel is inactive");
+        }
+    }
+
+    @Override
+    protected void channelRead0(ChannelHandlerContext ctx, WebSocketFrame frame) throws Exception {
+        if (frame instanceof TextWebSocketFrame) {
+            // Echos the same text
+            String text = ((TextWebSocketFrame) frame).text();
+            ctx.channel().writeAndFlush(new TextWebSocketFrame(text));
+        } else if (frame instanceof BinaryWebSocketFrame) {
+            ctx.channel().writeAndFlush(frame.retain());
+        } else if (frame instanceof CloseWebSocketFrame) {
+            ctx.close();
+        } else {
+            String message = "unsupported frame type: " + frame.getClass().getName();
+            throw new UnsupportedOperationException(message);
+        }
+    }
+
+    @Override
+    public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) {
+        log.error("Exception Caught: " + cause.getMessage());
+        ctx.close();
+    }
+}

--- a/integration/mediation-tests/tests-transport/src/test/java/org/wso2/carbon/esb/websocket/server/WebSocketRemoteServerInitializer.java
+++ b/integration/mediation-tests/tests-transport/src/test/java/org/wso2/carbon/esb/websocket/server/WebSocketRemoteServerInitializer.java
@@ -1,0 +1,57 @@
+/*
+ *  Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ *
+ */
+
+package org.wso2.carbon.esb.websocket.server;
+
+import io.netty.channel.ChannelInitializer;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.handler.codec.http.HttpObjectAggregator;
+import io.netty.handler.codec.http.HttpServerCodec;
+import io.netty.handler.codec.http.websocketx.WebSocketServerProtocolHandler;
+import io.netty.handler.codec.http.websocketx.extensions.compression.WebSocketServerCompressionHandler;
+import io.netty.handler.ssl.SslContext;
+
+/**
+ * Initializer for WebSocket server for Testing.
+ */
+public class WebSocketRemoteServerInitializer extends ChannelInitializer<SocketChannel> {
+
+    private static final String WEBSOCKET_PATH = "/websocket";
+    private final String subProtocols;
+    private final SslContext sslCtx;
+
+    public WebSocketRemoteServerInitializer(SslContext sslCtx, String subProtocols) {
+        this.sslCtx = sslCtx;
+        this.subProtocols = subProtocols;
+    }
+
+    @Override
+    public void initChannel(SocketChannel ch) throws Exception {
+        ChannelPipeline pipeline = ch.pipeline();
+        if (sslCtx != null) {
+            pipeline.addLast(sslCtx.newHandler(ch.alloc()));
+        }
+        pipeline.addLast(new HttpServerCodec());
+        pipeline.addLast(new HttpObjectAggregator(65536));
+        pipeline.addLast(new WebSocketServerCompressionHandler());
+        pipeline.addLast(new WebSocketServerProtocolHandler(WEBSOCKET_PATH, subProtocols, true));
+        pipeline.addLast(new WebSocketRemoteServerFrameHandler());
+    }
+}

--- a/integration/mediation-tests/tests-transport/src/test/java/org/wso2/carbon/esb/websocket/server/WebSocketServer.java
+++ b/integration/mediation-tests/tests-transport/src/test/java/org/wso2/carbon/esb/websocket/server/WebSocketServer.java
@@ -1,0 +1,70 @@
+/*
+ *  Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ *
+ */
+
+package org.wso2.carbon.esb.websocket.server;
+
+import io.netty.bootstrap.ServerBootstrap;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.socket.nio.NioServerSocketChannel;
+import io.netty.handler.ssl.SslContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Simple WebSocket server for Test cases.
+ */
+public final class WebSocketServer {
+
+    private static final Logger logger = LoggerFactory.getLogger(WebSocketServer.class);
+
+    private final int port;
+    private String subProtocols = null;
+    private EventLoopGroup bossGroup;
+    private EventLoopGroup workerGroup;
+
+    public WebSocketServer(int port) {
+        this.port = port;
+    }
+
+    public WebSocketServer(int port, String subProtocols) {
+        this.port = port;
+        this.subProtocols = subProtocols;
+    }
+
+    public void run() throws InterruptedException {
+        final SslContext sslCtx = null;
+        bossGroup = new NioEventLoopGroup(1);
+        workerGroup = new NioEventLoopGroup(2);
+
+        ServerBootstrap b = new ServerBootstrap();
+        b.group(bossGroup, workerGroup)
+         .channel(NioServerSocketChannel.class)
+         .childHandler(new WebSocketRemoteServerInitializer(sslCtx, subProtocols));
+
+        b.bind(port).sync();
+        logger.info("WebSocket remote server started listening on port " + port);
+    }
+
+    public void stop() {
+        bossGroup.shutdownGracefully();
+        workerGroup.shutdownGracefully();
+        logger.info("WebSocket remote server stopped listening  on port " + port);
+    }
+}

--- a/integration/mediation-tests/tests-transport/src/test/resources/artifacts/ESB/server/conf/axis2/axis2.xml
+++ b/integration/mediation-tests/tests-transport/src/test/resources/artifacts/ESB/server/conf/axis2/axis2.xml
@@ -488,10 +488,10 @@
 
     <!--<transportSender name="mqtt" class="org.apache.axis2.transport.mqtt.MqttSender"/>-->
     
-    <!--<transportSender name="ws" class="org.wso2.carbon.websocket.transport.WebsocketTransportSender">
+    <transportSender name="ws" class="org.wso2.carbon.websocket.transport.WebsocketTransportSender">
         <parameter name="ws.outflow.dispatch.sequence" locked="false">outflowDispatchSeq</parameter>
         <parameter name="ws.outflow.dispatch.fault.sequence" locked="false">outflowFaultSeq</parameter>       
-    </transportSender>-->
+    </transportSender>
     
     <!--<transportSender name="wss" class="org.wso2.carbon.websocket.transport.WebsocketTransportSender">
         <parameter name="ws.outflow.dispatch.sequence" locked="false">outflowDispatchSeq</parameter>

--- a/integration/mediation-tests/tests-transport/src/test/resources/artifacts/ESB/websocket/synapse-websocket-inbound.xml
+++ b/integration/mediation-tests/tests-transport/src/test/resources/artifacts/ESB/websocket/synapse-websocket-inbound.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<definitions xmlns="http://ws.apache.org/ns/synapse">
+    <sequence name="dispatchSeq" xmlns="http://ws.apache.org/ns/synapse">
+        <property name="OUT_ONLY" value="true"/>
+        <log level="full">
+            <property name="LOGGED_MESSAGE" value="LOGGED"/>
+        </log>
+        <send>
+            <endpoint>
+                <address uri="ws://localhost:7474/websocket"/>
+            </endpoint>
+        </send>
+    </sequence>
+    <sequence name="outDispatchSeq" trace="enable" xmlns="http://ws.apache.org/ns/synapse">
+        <log level="full"/>
+        <respond/>
+    </sequence>
+    <inboundEndpoint name="websocketTestInbound" onError="fault" protocol="ws"
+                     sequence="dispatchSeq" suspend="false">
+        <parameters>
+            <parameter name="inbound.ws.port">9091</parameter>
+            <parameter name="ws.outflow.dispatch.sequence">outDispatchSeq</parameter>
+            <parameter name="ws.client.side.broadcast.level">0</parameter>
+            <parameter name="ws.outflow.dispatch.fault.sequence">fault</parameter>
+        </parameters>
+    </inboundEndpoint>
+</definitions>
+
+

--- a/integration/mediation-tests/tests-transport/src/test/resources/testng.xml
+++ b/integration/mediation-tests/tests-transport/src/test/resources/testng.xml
@@ -162,6 +162,12 @@
         </packages>
     </test>
 
+    <test name="WebSocket-Inbound-Test" preserve-order="true" verbose="2">
+        <packages>
+            <package name="org.wso2.carbon.esb.websocket.inbound.transport.test"/>
+        </packages>
+    </test>
+
     <test name="nhttp-Transport-Test" preserve-order="true" verbose="2">
         <classes>
             <class name="org.wso2.carbon.esb.nhttp.transport.test.NhttpBaseTestCase"/>

--- a/pom.xml
+++ b/pom.xml
@@ -1164,6 +1164,41 @@
                 <artifactId>jackson-core</artifactId>
                 <version>${fasterxml.jackson.version}</version>
             </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-common</artifactId>
+                <version>${netty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-buffer</artifactId>
+                <version>${netty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-transport</artifactId>
+                <version>${netty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-handler</artifactId>
+                <version>${netty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-codec</artifactId>
+                <version>${netty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-codec-http</artifactId>
+                <version>${netty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-resolver</artifactId>
+                <version>${netty.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 
@@ -1379,6 +1414,7 @@
         <cipher.tool.version>1.0.0-wso2v6</cipher.tool.version>
         <commons.io.version>2.2</commons.io.version>
         <commons-httpclient.version>3.1.0.wso2v2</commons-httpclient.version>
+        <netty.version>4.1.7.Final</netty.version>
 
         <!-- auto Framework versions -->
         <automation.framework.version>4.4.3</automation.framework.version>


### PR DESCRIPTION
## Purpose
> Adding Integration test for web socket transport
1) Start a Web Socket Sample Server
2) Configure EI with Web Socket and deploy inbound endpoint
3) Send a web socket request to the EI inbound endpoint and verify the response


## Goals
> To Test the functionality of web socket transport in EI


## Test environment
> JDK 1.8
 
## Learning
> Web Socket Transport in EI