### PR TITLE
Fix status code on execution of the main sequence

### DIFF
--- a/distribution/src/conf/synapse-configs/default/sequences/main.xml
+++ b/distribution/src/conf/synapse-configs/default/sequences/main.xml
@@ -19,19 +19,14 @@
 
 <!-- Default main sequence shipped with the WSO2 EI -->
 <sequence xmlns="http://ws.apache.org/ns/synapse" name="main">
-    <description>The main sequence for the message mediation</description>
+    <description>The main sequence for the message mediation - this sequence will get invoked if there is no other
+        artifact to process the message</description>
     <in>
-        <!-- Log all messages passing through -->
-        <log level="full"/>
-
-        <!-- ensure that the default configuration only sends if it is one of samples -->
-        <!-- Otherwise Synapse would be an open proxy by default (BAD!)               -->
-        <filter source="get-property('To')" regex="http://localhost:9000.*">
-            <!-- Send the messages where they have been sent (i.e. implicit "To" EPR) -->
-            <send/>
-        </filter>
+        <log level="custom">
+            <property name="main sequence executed for call to non-existent" expression="get-property('To')"/>
+        </log>
+        <property name="NO_ENTITY_BODY" scope="axis2" value="true" type="BOOLEAN"/>
+        <property name="HTTP_SC" scope="axis2" value="404"/>
+        <respond/>
     </in>
-    <out>
-        <send/>
-    </out>
 </sequence>


### PR DESCRIPTION
## Purpose
> Fix EI sending 202 Accepted for non-existent services by default. Resolves https://github.com/wso2/product-ei/issues/1029.

## Goals
> Introduce a suitable status code on execution of the default main sequence.

## Approach
> If the default main sequence is executed, for a call to a non-existent resource (service, API, etc.), a 404 Not Found status code is set, instead of the current 202 Accepted.

## User stories
> N/A

## Release note
> Change status code on execution of the default main sequence to 404.

## Documentation
> N/A - changes default main sequence

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
> N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? N/A
 - Ran FindSecurityBugs plugin and verified report? N/A
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> N/A
 
## Learning
> N/A