### PR TITLE
Add rabbitmq invalid broker config test

### DIFF
--- a/integration/mediation-tests/tests-platform/tests-rabbitmq/src/test/resources/artifacts/ESB/inbound/rabbitmq_inbound_endpoint_invalid.xml
+++ b/integration/mediation-tests/tests-platform/tests-rabbitmq/src/test/resources/artifacts/ESB/inbound/rabbitmq_inbound_endpoint_invalid.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<definitions xmlns="http://ws.apache.org/ns/synapse">
+    <sequence name="rabbitmq_inbound_endpoint_invalid_sequence">
+        <log level="full">
+            <property name="received by invalid inbound endpoint" value="true"/>
+        </log>
+    </sequence>
+    <inboundEndpoint xmlns="http://ws.apache.org/ns/synapse" name="RabbitMQInvalidInboundEP"
+                     sequence="rabbitmq_inbound_endpoint_invalid_sequence"
+                     onError="fault" protocol="rabbitmq" suspend="false">
+        <parameters>
+            <parameter name="sequential">true</parameter>
+            <parameter name="coordination">true</parameter>
+            <parameter name="rabbitmq.connection.factory">AMQPConnectionFactory</parameter>
+            <parameter name="rabbitmq.server.host.name">localhost</parameter>
+            <parameter name="rabbitmq.server.port">5673</parameter>
+            <parameter name="rabbitmq.server.user.name">guest</parameter>
+            <parameter name="rabbitmq.server.password">guest</parameter>
+            <parameter name="rabbitmq.queue.name">simple_inbound_endpoint_test</parameter>
+            <parameter name="rabbitmq.exchange.name">exchange</parameter>
+            <parameter name="rabbitmq.connection.ssl.enabled">false</parameter>
+            <parameter name="rabbitmq.queue.durable">false</parameter>
+            <parameter name="rabbitmq.connection.retry.count">3</parameter>
+            <parameter name="rabbitmq.connection.retry.interval">500</parameter>
+        </parameters>
+    </inboundEndpoint>
+</definitions>


### PR DESCRIPTION
## Goals
Adds the test method, 'testRabbitMQInboundEndpointDeploymentWithInvalidServerConfigs' which deployes a rabbitmq inbound endpoint with invalid rabbitmq server port.

## Approach
The server retries for a number of times that is set by the parameter 'rabbitmq.connection.retry.count' with a delay of 'rabbitmq.connection.retry.interval'. The assertions are done on the logs printed to evaluate above properties. 