### PR TITLE
Disable statistic/tracing related tests in RestAPIAdminService

### DIFF
--- a/integration/mediation-tests/tests-service/src/test/java/org/wso2/carbon/esb/rest/test/api/RestApiAdminServiceTestCase.java
+++ b/integration/mediation-tests/tests-service/src/test/java/org/wso2/carbon/esb/rest/test/api/RestApiAdminServiceTestCase.java
@@ -180,48 +180,45 @@ public class RestApiAdminServiceTestCase extends ESBIntegrationTest {
         Assert.fail("Expected exception not thrown for non-existent API");
 
     }
-
+//TODO: Enable after mediation 4.6.27 release
     @Test(groups = { "wso2.esb" },
           description = "Test API statistics enable operation",
-          priority = 10)
+          priority = 10,
+          enabled = false)
     public void testEnableAPIStatistics() throws Exception {
         restAdminClient.enableStatisticsForAPI(tenantAPIName);
-        APIData statEnabledAPI = getAPIFromList(tenantAPIName);
+        APIData statEnabledAPI = restAdminClient.getAPIbyName(tenantAPIName);
         Assert.assertEquals(statEnabledAPI.getStatisticsEnable(), true, "Statistics not enabled for API");
-
     }
-
+    //TODO: Enable after mediation 4.6.27 release
     @Test(groups = { "wso2.esb" },
           description = "Test API statistics disable operation ",
-          priority = 11)
+          priority = 11,
+          enabled = false)
     public void testDisabledAPIStatistics() throws Exception {
         restAdminClient.disableStatisticsForAPI(tenantAPIName);
-        APIData statDisabledAPI = getAPIFromList(tenantAPIName);
-        Assert.assertNotNull(statDisabledAPI, "Unable to get requested API");
+        APIData statDisabledAPI = restAdminClient.getAPIbyName(tenantAPIName);
         Assert.assertEquals(statDisabledAPI.getStatisticsEnable(), false, "Statistics not disabled for API");
-
     }
-
+    //TODO: Enable after mediation 4.6.27 release
     @Test(groups = { "wso2.esb" },
           description = "Test API tracing enable operation",
-          priority = 12)
+          priority = 12,
+          enabled = false)
     public void testEnableAPITracing() throws Exception {
         restAdminClient.enableTracingForAPI(tenantAPIName);
-        APIData traceEnabledAPI = getAPIFromList(tenantAPIName);
-        Assert.assertNotNull(traceEnabledAPI, "Unable to get requested API");
+        APIData traceEnabledAPI = restAdminClient.getAPIbyName(tenantAPIName);
         Assert.assertEquals(traceEnabledAPI.getTracingEnable(), true, "Tracing not enabled for API");
-
     }
-
+    //TODO: Enable after mediation 4.6.27 release
     @Test(groups = { "wso2.esb" },
           description = "Test API tracing disable operation",
-          priority = 13)
+          priority = 13,
+          enabled = false)
     public void testDisableAPITracing() throws Exception {
         restAdminClient.disableTracingForAPI(tenantAPIName);
-        APIData traceDisabledAPI = getAPIFromList(tenantAPIName);
-        Assert.assertNotNull(traceDisabledAPI, "Unable to get requested API");
+        APIData traceDisabledAPI = restAdminClient.getAPIbyName(tenantAPIName);
         Assert.assertEquals(traceDisabledAPI.getTracingEnable(), false, "Tracing not disabled for API");
-
     }
 
     @Test(groups = { "wso2.esb" },
@@ -246,7 +243,7 @@ public class RestApiAdminServiceTestCase extends ESBIntegrationTest {
           description = "Test fault handling for empty API update ",
           priority = 16,
           expectedExceptions = RestApiAdminAPIException.class)
-    public void testAPIUpdateWithEmptyAPIName() throws Exception {
+    public void testAPIUpdateWithEmptyAgetAPIFromListPIName() throws Exception {
         String emptyAPIName = "";
         restAdminClient.updateAPIFromAPIData(emptyAPIName, api3);
         Assert.fail("Expected exception not thrown for updating empty API");

--- a/integration/mediation-tests/tests-service/src/test/java/org/wso2/carbon/esb/rest/test/api/RestApiAdminServiceTestCase.java
+++ b/integration/mediation-tests/tests-service/src/test/java/org/wso2/carbon/esb/rest/test/api/RestApiAdminServiceTestCase.java
@@ -243,7 +243,7 @@ public class RestApiAdminServiceTestCase extends ESBIntegrationTest {
           description = "Test fault handling for empty API update ",
           priority = 16,
           expectedExceptions = RestApiAdminAPIException.class)
-    public void testAPIUpdateWithEmptyAgetAPIFromListPIName() throws Exception {
+    public void testAPIUpdateWithEmptyAPIFromListPIName() throws Exception {
         String emptyAPIName = "";
         restAdminClient.updateAPIFromAPIData(emptyAPIName, api3);
         Assert.fail("Expected exception not thrown for updating empty API");


### PR DESCRIPTION
## Purpose
Updated statistic/tracing test-cases to use 'getAPIByName' method which will set the necessary setters for statistics and tracing with PR https://github.com/wso2/carbon-mediation/pull/892.
## Goals
Remove intermittent failures that can occur when accessing the API through getAPIListing.

## Approach
Updated the relevant tests, to use getAPIByName() method. Disabled those tests until next mediation release is available.
