### PR TITLE
Add test cases for XML to Json transformation

### DIFF
--- a/integration/mediation-tests/tests-other/src/test/java/org/wso2/carbon/esb/contenttype/json/XMLToJsonTestCase.java
+++ b/integration/mediation-tests/tests-other/src/test/java/org/wso2/carbon/esb/contenttype/json/XMLToJsonTestCase.java
@@ -1,0 +1,135 @@
+/*
+*Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*WSO2 Inc. licenses this file to you under the Apache License,
+*Version 2.0 (the "License"); you may not use this file except
+*in compliance with the License.
+*You may obtain a copy of the License at
+*
+*http://www.apache.org/licenses/LICENSE-2.0
+*
+*Unless required by applicable law or agreed to in writing,
+*software distributed under the License is distributed on an
+*"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+*KIND, either express or implied.  See the License for the
+*specific language governing permissions and limitations
+*under the License.
+*/
+
+package org.wso2.carbon.esb.contenttype.json;
+
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import org.wso2.carbon.automation.test.utils.http.client.HttpRequestUtil;
+import org.wso2.carbon.automation.test.utils.http.client.HttpResponse;
+import org.wso2.esb.integration.common.utils.ESBIntegrationTest;
+
+import java.net.URL;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Test case for transforming XML payload to JSON
+ */
+public class XMLToJsonTestCase extends ESBIntegrationTest {
+
+    @BeforeClass(alwaysRun = true)
+    public void initialize() throws Exception {
+        super.init();
+        verifyProxyServiceExistence("xmlToJsonTestProxy");
+    }
+
+    @Test(groups = {"wso2.esb"}, description = "Test XML to JSON conversion")
+    public void testXmlToJson() throws Exception {
+
+        String xmlPayload = "<location>\n" +
+                "               <name>Bermuda Triangle</name>\n" +
+                "               <n>25.0000</n>\n" +
+                "               <w>71.0000</w>\n" +
+                "            </location>";
+        Map<String, String> requestHeader = new HashMap<>();
+        requestHeader.put("Content-Type", "text/xml");
+        HttpResponse response = HttpRequestUtil.
+                doPost(new URL(getProxyServiceURLHttp("xmlToJsonTestProxy")), xmlPayload, requestHeader);
+
+        Assert.assertEquals(response.getData(), "{\"location\":{\"name\":\"Bermuda Triangle\",\"n\":25.0000,\"w\":71.0000}}",
+                "Invalid XML to JSON conversion. " + response.getData());
+    }
+
+    @Test(groups = {"wso2.esb"}, description = "Test XML to JSON Array conversion")
+    public void testXmlToJsonArray() throws Exception {
+
+        String xmlPayload = "<coordinates>\n" +
+                "    <location>\n" +
+                "        <name>Bermuda Triangle</name>\n" +
+                "        <n>25.0000</n>\n" +
+                "        <w>71.0000</w>\n" +
+                "    </location>\n" +
+                "    <location>\n" +
+                "        <name>Eiffel Tower</name>\n" +
+                "        <n>48.8582</n>\n" +
+                "        <e>2.2945</e>\n" +
+                "    </location>\n" +
+                " </coordinates>";
+        Map<String, String> requestHeader = new HashMap<>();
+        requestHeader.put("Content-Type", "text/xml");
+        HttpResponse response = HttpRequestUtil.
+                doPost(new URL(getProxyServiceURLHttp("xmlToJsonTestProxy")), xmlPayload, requestHeader);
+
+        Assert.assertTrue(response.getData().contains("{\"coordinates\":{\"location\":[{"),
+                "Invalid XML to JSON array conversion . " + response.getData());
+    }
+
+    @Test(groups = {"wso2.esb"}, description = "Test XML with attributes to JSON conversion")
+    public void testXmlAttributesToJson() throws Exception {
+
+        String xmlPayload = "<location id=\"1\">\n" +
+                "               <name>Bermuda Triangle</name>\n" +
+                "               <n>25.0000</n>\n" +
+                "               <w>71.0000</w>\n" +
+                "            </location>";
+        Map<String, String> requestHeader = new HashMap<>();
+        requestHeader.put("Content-Type", "text/xml");
+        HttpResponse response = HttpRequestUtil.
+                doPost(new URL(getProxyServiceURLHttp("xmlToJsonTestProxy")), xmlPayload, requestHeader);
+
+        Assert.assertEquals(response.getData(), "{\"location\":{\"@id\":\"1\",\"name\":\"Bermuda Triangle\",\"n\":25.0000,\"w\":71.0000}}",
+                "Invalid XML to JSON attribute conversion . " + response.getData());
+    }
+
+    @Test(groups = {"wso2.esb"}, description = "Test XML text nodes with attributes to JSON conversion")
+    public void testXmlTextNodesWithAttributesToJson() throws Exception {
+
+        String xmlPayload = "<location id=\"1\">Bermuda Triangle</location>";
+        Map<String, String> requestHeader = new HashMap<>();
+        requestHeader.put("Content-Type", "text/xml");
+        HttpResponse response = HttpRequestUtil.
+                doPost(new URL(getProxyServiceURLHttp("xmlToJsonTestProxy")), xmlPayload, requestHeader);
+
+        Assert.assertEquals(response.getData(), "{\"location\":{\"@id\":\"1\",\"$\":\"Bermuda Triangle\"}}",
+                "Invalid XML to JSON attribute conversion . " + response.getData());
+    }
+
+    @Test(groups = {"wso2.esb"}, description = "Test empty XML node to JSON conversion")
+    public void testEmptyXmlNodeToJson() throws Exception {
+
+        String xmlPayload = "<location>\n" +
+                "<name>Bermuda Triangle</name>\n" +
+                "<description></description>\n" +
+                "</location>";
+        Map<String, String> requestHeader = new HashMap<>();
+        requestHeader.put("Content-Type", "text/xml");
+        HttpResponse response = HttpRequestUtil.
+                doPost(new URL(getProxyServiceURLHttp("xmlToJsonTestProxy")), xmlPayload, requestHeader);
+
+        Assert.assertEquals(response.getData(), "{\"location\":{\"name\":\"Bermuda Triangle\",\"description\":null}}",
+                "Invalid empty XML to JSON conversion . " + response.getData());
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void stop() throws Exception {
+        super.cleanup();
+    }
+}

--- a/integration/mediation-tests/tests-other/src/test/java/org/wso2/carbon/esb/contenttype/json/XMLToJsonTransformationPropertiesTestCase.java
+++ b/integration/mediation-tests/tests-other/src/test/java/org/wso2/carbon/esb/contenttype/json/XMLToJsonTransformationPropertiesTestCase.java
@@ -1,0 +1,151 @@
+/*
+*Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*WSO2 Inc. licenses this file to you under the Apache License,
+*Version 2.0 (the "License"); you may not use this file except
+*in compliance with the License.
+*You may obtain a copy of the License at
+*
+*http://www.apache.org/licenses/LICENSE-2.0
+*
+*Unless required by applicable law or agreed to in writing,
+*software distributed under the License is distributed on an
+*"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+*KIND, either express or implied.  See the License for the
+*specific language governing permissions and limitations
+*under the License.
+*/
+
+package org.wso2.carbon.esb.contenttype.json;
+
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import org.wso2.carbon.automation.engine.context.AutomationContext;
+import org.wso2.carbon.automation.engine.context.TestUserMode;
+import org.wso2.carbon.automation.test.utils.http.client.HttpRequestUtil;
+import org.wso2.carbon.automation.test.utils.http.client.HttpResponse;
+import org.wso2.esb.integration.common.utils.ESBIntegrationTest;
+import org.wso2.esb.integration.common.utils.common.ServerConfigurationManager;
+
+import java.io.File;
+import java.net.URL;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Test case for XML to JSON transformation parameters
+ */
+public class XMLToJsonTransformationPropertiesTestCase extends ESBIntegrationTest {
+
+    private ServerConfigurationManager serverConfigurationManager;
+
+    @BeforeClass(alwaysRun = true)
+    public void initialize() throws Exception {
+        super.init();
+        serverConfigurationManager = new ServerConfigurationManager(new AutomationContext("ESB", TestUserMode.SUPER_TENANT_ADMIN));
+        serverConfigurationManager.applyConfiguration(new File(getESBResourceLocation() + File.separator + "json" +
+                File.separator + "jsonTransformationConfig" + File.separator + "synapse.properties"));
+        super.init();
+        verifyProxyServiceExistence("xmlToJsonTestProxy");
+    }
+
+    /**
+     * Test the below properties
+     * synapse.commons.json.preserve.namespace=true
+     * synapse.commons.json.output.enableNSDeclarations=true
+     * Preserve namespaces in XML payload
+     * Add XML namespace declarations in the JSON
+     * @throws Exception
+     */
+    @Test(groups = {"wso2.esb"}, description = "Test XML to JSON preserve namespace")
+    public void testXmlToJsonPreserveNamespace() throws Exception {
+
+        String xmlPayload = "<ns:stock xmlns:ns='http://services.samples'>\n" +
+                "               <ns:name>WSO2</ns:name>\n" +
+                "            </ns:stock>";
+        Map<String, String> requestHeader = new HashMap<>();
+        requestHeader.put("Content-Type", "text/xml");
+        HttpResponse response = HttpRequestUtil.
+                doPost(new URL(getProxyServiceURLHttp("xmlToJsonTestProxy")), xmlPayload, requestHeader);
+
+        Assert.assertEquals(response.getData(), "{\"ns_stock\":{\"@xmlns_ns\":\"http://services.samples\",\"ns_name\":\"WSO2\"}}",
+                "Invalid XML to JSON conversion. " + response.getData());
+    }
+
+    /**
+     * Test the property synapse.commons.json.buildValidNCNames=true
+     * Replace "_JsonReader_32_" in XML payload with spaces in Json
+     * @throws Exception
+     */
+    @Test(groups = {"wso2.esb"}, description = "Test XML to JSON build Valid NC Names")
+    public void testXmlToJsonBuildValidNCNames() throws Exception {
+
+        String xmlPayload = "<stock_JsonReader_32_quote>\n" +
+                "               <name>WSO2</name>\n" +
+                "            </stock_JsonReader_32_quote>";
+        Map<String, String> requestHeader = new HashMap<>();
+        requestHeader.put("Content-Type", "text/xml");
+        HttpResponse response = HttpRequestUtil.
+                doPost(new URL(getProxyServiceURLHttp("xmlToJsonTestProxy")), xmlPayload, requestHeader);
+
+        Assert.assertEquals(response.getData(), "{\"stock quote\":{\"name\":\"WSO2\"}}",
+                "Invalid XML to JSON conversion. " + response.getData());
+    }
+
+    /**
+     * Test the property synapse.commons.json.output.autoPrimitive=false
+     * Add double quotes around the primitive values
+     * @throws Exception
+     */
+    @Test(groups = {"wso2.esb"}, description = "Test XML to JSON auto primitive")
+    public void testXmlToJsonAutoPrimitive() throws Exception {
+
+        String xmlPayload = "<stock>\n" +
+                "               <name>WSO2</name>\n" +
+                "               <price>10</price>\n" +
+                "            </stock>";
+        Map<String, String> requestHeader = new HashMap<>();
+        requestHeader.put("Content-Type", "text/xml");
+        HttpResponse response = HttpRequestUtil.
+                doPost(new URL(getProxyServiceURLHttp("xmlToJsonTestProxy")), xmlPayload, requestHeader);
+
+        Assert.assertEquals(response.getData(), "{\"stock\":{\"name\":\"WSO2\",\"price\":\"10\"}}",
+                "Invalid XML to JSON conversion. " + response.getData());
+    }
+
+    /**
+     * Test the property synapse.commons.json.output.jsonoutAutoArray=false
+     * @throws Exception
+     */
+    @Test(groups = {"wso2.esb"}, description = "Test XML to JSON Array conversion")
+    public void testXmlToJsonArray() throws Exception {
+
+        String xmlPayload = "<stocks>" +
+                "               <stock>\n" +
+                "                   <name>WSO2</name>\n" +
+                "                   <price>10</price>\n" +
+                "               </stock>\n"             +
+                "               <stock>\n"              +
+                "                   <name>IBM</name>\n" +
+                "                   <price>15</price>\n" +
+                "               </stock>" +
+                "            </stocks>";
+        Map<String, String> requestHeader = new HashMap<>();
+        requestHeader.put("Content-Type", "text/xml");
+        HttpResponse response = HttpRequestUtil.
+                doPost(new URL(getProxyServiceURLHttp("xmlToJsonTestProxy")), xmlPayload, requestHeader);
+
+        Assert.assertEquals(response.getData(),
+                "{\"stocks\":{\"stock\":{\"name\":\"WSO2\",\"price\":\"10\"},\"stock\":{\"name\":\"IBM\",\"price\":\"15\"}}}",
+                "Invalid XML to JSON array conversion. " + response.getData());
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void stop() throws Exception {
+        super.cleanup();
+        serverConfigurationManager.restoreToLastConfiguration();
+        serverConfigurationManager = null;
+    }
+}

--- a/integration/mediation-tests/tests-other/src/test/resources/artifacts/ESB/json/jsonTransformationConfig/synapse.properties
+++ b/integration/mediation-tests/tests-other/src/test/resources/artifacts/ESB/json/jsonTransformationConfig/synapse.properties
@@ -1,0 +1,83 @@
+#
+# Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+#
+# WSO2 Inc. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+#synapse.threads.core = 20
+#synapse.threads.max = 100
+#synapse.threads.keepalive = 5
+#synapse.threads.qlen = 10
+#synapse.threads.group = synapse-thread-group
+#synapse.threads.idprefix = SynapseWorker
+
+#inbound.threads.core = 20
+#inbound.threads.max = 100
+
+synapse.sal.endpoints.sesssion.timeout.default=600000
+synapse.global_timeout_interval=120000
+#In memory statistics cleaning state
+statistics.clean.enable=true
+statistics.clean.interval=1000
+
+# Dependency tracking Synapse observer
+# Comment out to disable dependency management
+synapse.observers=org.wso2.carbon.mediation.dependency.mgt.DependencyTracker
+
+#preserve namespace when converting XML to JSON
+synapse.commons.json.preserve.namespace=true
+
+#add XML namespace declarations in the JSON
+synapse.commons.json.output.enableNSDeclarations=true
+
+#build valid XML NCNames when converting XML to JSON
+synapse.commons.json.buildValidNCNames=true
+
+# User defined wsdlLocator/Schema Resolver Implementations.
+# synapse.wsdl.resolver=org.wso2.carbon.mediation.initializer.RegistryWSDLLocator
+# synapse.schema.resolver=org.wso2.carbon.mediation.initializer.RegistryXmlSchemaURIResolver
+
+# Uncomment following to support fallback XPATH 2.0 support with DOM and Saxon
+#synapse.xpath.dom.failover.enabled=true
+synapse.temp_data.chunk.size=3072
+
+# A configurator to add tenant information to the out thread local carbon context
+synapse.carbon.ext.tenant.info=org.wso2.carbon.mediation.initializer.handler.CarbonTenantInfoConfigurator
+# An initiator to initialize thread local carbon context with tenant information
+synapse.carbon.ext.tenant.info.initiator=org.wso2.carbon.mediation.initializer.handler.CarbonTenantInfoInitiator
+
+#external componenent registration for secure vault xpath funtion lookup
+synapse.xpath.func.extensions=org.wso2.carbon.mediation.security.vault.xpath.SecureVaultLookupXPathFunctionProvider
+
+#configuration for the external debugger channels if server is started in debug mode
+synapse.debugger.port.command=9005
+synapse.debugger.port.event=9006
+
+# Configuration to enable mediation flow analytics
+mediation.flow.statistics.enable=false
+mediation.flow.statistics.tracer.collect.payloads=false
+mediation.flow.statistics.tracer.collect.properties=false
+mediation.flow.statistics.event.consume.interval=1000
+mediation.flow.statistics.event.clean.interval=15000
+
+# Configuration to enable statistics globally irrespective of the individual artifact level setting
+mediation.flow.statistics.collect.all=false
+
+# Script Mediator Pool (impatcts only external scripts)
+#synapse.script.mediator.pool.size=15
+
+synapse.commons.json.output.autoPrimitive=false
+
+synapse.commons.json.output.jsonoutAutoArray=false

--- a/integration/mediation-tests/tests-other/src/test/resources/artifacts/ESB/server/repository/deployment/server/synapse-configs/default/proxy-services/xmlToJsonTestProxy.xml
+++ b/integration/mediation-tests/tests-other/src/test/resources/artifacts/ESB/server/repository/deployment/server/synapse-configs/default/proxy-services/xmlToJsonTestProxy.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied. See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  ~
+  -->
+<proxy xmlns="http://ws.apache.org/ns/synapse"
+       name="xmlToJsonTestProxy"
+       transports="https,http"
+       statistics="disable"
+       trace="disable"
+       startOnLoad="true">
+    <target>
+        <inSequence>
+            <property name="messageType" value="application/json" scope="axis2"/>
+            <respond/>
+        </inSequence>
+        <outSequence/>
+    </target>
+    <description/>
+</proxy>

--- a/integration/mediation-tests/tests-other/src/test/resources/testng.xml
+++ b/integration/mediation-tests/tests-other/src/test/resources/testng.xml
@@ -65,6 +65,7 @@
 
     <test name="Content-Type-Test" preserve-order="true" verbose="2">
         <classes>
+            <class name="org.wso2.carbon.esb.contenttype.json.XMLToJsonTestCase"/>
             <class name="org.wso2.carbon.esb.contenttype.json.XMLToJsonNilTestCase"/>
         </classes>
     </test>

--- a/integration/mediation-tests/tests-other/src/test/resources/testng.xml
+++ b/integration/mediation-tests/tests-other/src/test/resources/testng.xml
@@ -67,6 +67,7 @@
         <classes>
             <class name="org.wso2.carbon.esb.contenttype.json.XMLToJsonTestCase"/>
             <class name="org.wso2.carbon.esb.contenttype.json.XMLToJsonNilTestCase"/>
+            <class name="org.wso2.carbon.esb.contenttype.json.XMLToJsonTransformationPropertiesTestCase"/>
         </classes>
     </test>
 


### PR DESCRIPTION
## Purpose
> Add test cases for XML to Json transformation

## Approach
> Following test cases are added
1. Simple XML payload to Json conversion
2. XML to Json array conversion
3. XML with attributes to Json conversion
4. XML text nodes with attributes to Json conversion
5. XML empty elements to Json conversion
6. XML to JSON transformation parameters
    > synapse.commons.json.preserve.namespace=true
    > synapse.commons.json.output.enableNSDeclarations=true
    > synapse.commons.json.buildValidNCNames=true
    > synapse.commons.json.output.autoPrimitive=false
    > synapse.commons.json.output.jsonoutAutoArray=false
