### PR TITLE
[EI-821] Fix issue with blocking call invoke on dynamic endpoint

### DIFF
--- a/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/call/CallMediatorBlockingAPITestCase.java
+++ b/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/call/CallMediatorBlockingAPITestCase.java
@@ -44,9 +44,9 @@ public class CallMediatorBlockingAPITestCase extends ESBIntegrationTest {
     public void callMediatorBlockingAPITest() throws Exception {
         OMElement response = axis2Client
                 .sendSimpleStockQuoteRequest(getApiInvocationURL("testBlockingApi"), null, "WSO2");
-        boolean responseContainsWSO2 = response.getFirstElement().toString().contains("WSO2");
         assertNotNull(response, "Empty response received");
-        assertTrue(responseContainsWSO2, "Response does not contain expected output");
+        boolean responseContainsWSO2 = response.getFirstElement().toString().contains("WSO2");
+        assertTrue(responseContainsWSO2, "Response does not contain expected output.Received: " + response);
     }
 
     @AfterClass(alwaysRun = true)

--- a/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/call/CallMediatorBlockingAPITestCase.java
+++ b/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/call/CallMediatorBlockingAPITestCase.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package org.wso2.carbon.esb.mediator.test.call;
+
+import org.apache.axiom.om.OMElement;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import org.wso2.esb.integration.common.utils.ESBIntegrationTest;
+
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Tests using Call mediator with blocking true, when a dynamic (resolving endpoint with a payload returned) endpoint
+ * is called, the response payload is received.
+ */
+public class CallMediatorBlockingAPITestCase extends ESBIntegrationTest {
+
+    @BeforeClass(alwaysRun = true)
+    public void setEnvironment() throws Exception {
+        super.init();
+        verifyAPIExistence("CallBlockingPayloadAPI");
+    }
+
+    @Test(groups = { "wso2.esb" },
+          description = "Test invoking dynamic endpoint with blocking call")
+    public void callMediatorBlockingAPITest() throws Exception {
+        OMElement response = axis2Client
+                .sendSimpleStockQuoteRequest(getApiInvocationURL("testBlockingApi"), null, "WSO2");
+        boolean responseContainsWSO2 = response.getFirstElement().toString().contains("WSO2");
+        assertNotNull(response, "Empty response received");
+        assertTrue(responseContainsWSO2, "Response does not contain expected output");
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void destroy() throws Exception {
+        super.cleanup();
+    }
+}

--- a/integration/mediation-tests/tests-mediator-1/src/test/resources/artifacts/ESB/server/repository/deployment/server/synapse-configs/default/api/CallBlockingPayloadAPI.xml
+++ b/integration/mediation-tests/tests-mediator-1/src/test/resources/artifacts/ESB/server/repository/deployment/server/synapse-configs/default/api/CallBlockingPayloadAPI.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied. See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  ~
+  -->
+<api xmlns="http://ws.apache.org/ns/synapse" name="CallBlockingPayloadAPI" context="/testBlockingApi" ransports="https http"
+     startOnLoad="true" trace="disable">
+        <resource methods="POST">
+            <inSequence>
+                <header name="Action" value="urn:getQuote"/>
+                <payloadFactory media-type="xml">
+                    <format>
+                        <m0:getQuote xmlns:m0="http://services.samples">
+                            <m0:request>
+                                <m0:symbol>WSO2</m0:symbol>
+                            </m0:request>
+                        </m0:getQuote>
+                    </format>
+                    <args/>
+                </payloadFactory>
+                <call-template target="callBlocking-template">
+                    <with-param name="endpoint" value="Reply_EP"/>
+                </call-template>
+                <respond/>
+            </inSequence>
+        </resource>
+    </api>

--- a/integration/mediation-tests/tests-mediator-1/src/test/resources/artifacts/ESB/server/repository/deployment/server/synapse-configs/default/endpoints/Reply_EP.xml
+++ b/integration/mediation-tests/tests-mediator-1/src/test/resources/artifacts/ESB/server/repository/deployment/server/synapse-configs/default/endpoints/Reply_EP.xml
@@ -1,0 +1,11 @@
+<endpoint xmlns="http://ws.apache.org/ns/synapse" name="Reply_EP">
+    <http uri-template="http://localhost:8480/reply" method="post">
+        <suspendOnFailure>
+            <progressionFactor>1.0</progressionFactor>
+        </suspendOnFailure>
+        <markForSuspension>
+            <retriesBeforeSuspension>0</retriesBeforeSuspension>
+            <retryDelay>0</retryDelay>
+        </markForSuspension>
+    </http>
+</endpoint>

--- a/integration/mediation-tests/tests-mediator-1/src/test/resources/artifacts/ESB/server/repository/deployment/server/synapse-configs/default/templates/callBlocking-template.xml
+++ b/integration/mediation-tests/tests-mediator-1/src/test/resources/artifacts/ESB/server/repository/deployment/server/synapse-configs/default/templates/callBlocking-template.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied. See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  ~
+  -->
+<template name="callBlocking-template" xmlns="http://ws.apache.org/ns/synapse">
+    <parameter name="endpoint"/>
+    <sequence>
+        <call blocking="true">
+            <endpoint key-expression="$func:endpoint" xmlns:ns="http://org.apache.synapse/xsd"/>
+        </call>
+        <respond/>
+    </sequence>
+</template>

--- a/integration/mediation-tests/tests-mediator-1/src/test/resources/testng.xml
+++ b/integration/mediation-tests/tests-mediator-1/src/test/resources/testng.xml
@@ -74,6 +74,7 @@
     <test name="Call-mediator-Test" preserve-order="true" verbose="2">
         <classes>
             <!--<class name="org.wso2.carbon.esb.mediator.test.call.CallMediatorAPIWithNamedSeqCase"/>-->
+            <class name="org.wso2.carbon.esb.mediator.test.call.CallMediatorBlockingAPITestCase"/>
             <class name="org.wso2.carbon.esb.mediator.test.call.CallMediatorBlockingDirectEndpointTestCase"/>
             <class name="org.wso2.carbon.esb.mediator.test.call.CallMediatorBlockingFilterTestCase"/>
             <!--<class name="org.wso2.carbon.esb.mediator.test.call.CallMediatorBlockingInboundOutboundPolicySecurityTestCase"/>-->


### PR DESCRIPTION
## Purpose
Test the fix for empty response sent when invoking a dynamic endpoint with blocking call mediator.  This needs to be merged after the merge of PR  https://github.com/wso2/wso2-synapse/pull/859.


## Approach
1. Deployed API invokes a sequence template which resolves the endpoint with call blocking true.
2. Check for the response payload received from endpoint.

