### PR TITLE
Fix wait time in DefaultEndpointTestCase

### DIFF
--- a/integration/mediation-tests/tests-service/src/test/java/org/wso2/carbon/esb/endpoint/test/DefaultEndpointTestCase.java
+++ b/integration/mediation-tests/tests-service/src/test/java/org/wso2/carbon/esb/endpoint/test/DefaultEndpointTestCase.java
@@ -34,14 +34,14 @@ import org.wso2.esb.integration.common.utils.ESBIntegrationTest;
 import org.wso2.esb.integration.common.utils.ESBTestConstant;
 import org.wso2.esb.integration.common.utils.servers.axis2.SampleAxis2Server;
 
-import javax.activation.DataHandler;
-import javax.xml.stream.XMLStreamException;
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 import java.rmi.RemoteException;
 import java.util.Arrays;
 import java.util.List;
+import javax.activation.DataHandler;
+import javax.xml.stream.XMLStreamException;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
@@ -139,7 +139,8 @@ public class DefaultEndpointTestCase extends ESBIntegrationTest {
             Assert.assertTrue(e instanceof org.apache.axis2.AxisFault);
         }
         Assert.assertNull(response);
-        Thread.sleep(10000);
+        //Increasing wait time than suspendDuration value
+        Thread.sleep(15000);
         response = axis2Client.sendSimpleStockQuoteRequest(getProxyServiceURLHttp("defaultEndPoint_Config_Reg"),
                                                            "http://localhost:9001/services/SimpleStockQuoteService", "WSO2");
         Assert.assertNotNull(response);

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2</groupId>
         <artifactId>wso2</artifactId>
-        <version>1</version>
+        <version>1.1</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>


### PR DESCRIPTION
## Purpose
> Currently the thread wait time and endpoint suspendDuration is similar, which causes intermittent failures due to endpoint been inactive. Therefore increase the wait time to a higher value than suspendDuration.

