### PR TITLE
Fix failure of PropertyIntegrationDISABLE_CHUNKING_PropertyTest

### DIFF
--- a/integration/mediation-tests/tests-common/integration-test-utils/src/main/java/org/wso2/esb/integration/common/utils/servers/WireMonitor.java
+++ b/integration/mediation-tests/tests-common/integration-test-utils/src/main/java/org/wso2/esb/integration/common/utils/servers/WireMonitor.java
@@ -34,6 +34,7 @@ class WireMonitor extends Thread {
     private ServerSocket providerSocket;
     private Socket connection = null;
     private WireMonitorServer trigger;
+    private boolean started;
 
     public void run() {
         try {
@@ -42,9 +43,9 @@ class WireMonitor extends Thread {
 
             log.info("WireMonitor Server started on port " + port);
             log.info("Waiting for connection");
+            started = true;
             connection = providerSocket.accept();
-            log.info("Connection received from " +
-                     connection.getInetAddress().getHostName());
+            log.info("Connection received from " + connection.getInetAddress().getHostName());
             InputStream in = connection.getInputStream();
             int ch;
             StringBuffer buffer = new StringBuffer();
@@ -105,6 +106,15 @@ class WireMonitor extends Thread {
     public WireMonitor(int listenPort, WireMonitorServer trigger) {
         port = listenPort;
         this.trigger = trigger;
+    }
+
+    /**
+     * Method to return the status of the wire monitor.
+     *
+     * @return true is the wire monitor is started and accepting connections
+     */
+    public boolean isStarted() {
+        return started;
     }
 
 }

--- a/integration/mediation-tests/tests-common/integration-test-utils/src/main/java/org/wso2/esb/integration/common/utils/servers/WireMonitorServer.java
+++ b/integration/mediation-tests/tests-common/integration-test-utils/src/main/java/org/wso2/esb/integration/common/utils/servers/WireMonitorServer.java
@@ -21,6 +21,8 @@ package org.wso2.esb.integration.common.utils.servers;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
+import java.util.concurrent.TimeUnit;
+
 /**
  * This class can be used to capture wire messages
  */
@@ -43,8 +45,17 @@ public class WireMonitorServer {
 
     public void start() {
         response = "";
-        Thread thread = new WireMonitor(port, this);
-        thread.start();
+        WireMonitor wireMonitor = new WireMonitor(port, this);
+        wireMonitor.start();
+        while (!wireMonitor.isStarted()) {
+            try {
+                //wait until the wire monitor is started
+                TimeUnit.MILLISECONDS.sleep(100);
+                log.info("Waiting for wire monitor to start...");
+            } catch (InterruptedException e) {
+                //Continue looping until the server is started
+            }
+        }
     }
 
 


### PR DESCRIPTION
Fix failure of PropertyIntegrationDISABLE_CHUNKING_PropertyTest due to
the request being sent before the wire monitor is started.

## Purpose
Fix failure of PropertyIntegrationDISABLE_CHUNKING_PropertyTest.

## Goals
Block the wire monitor server startup until the underlying wire monitor starts accepting connections.

## Approach
Looped the wire monitor server startup until the underlying wire monitor's 'started' state is set to true. This will only be when the monitor is accepting connections.

## User stories
N/A, this is a util used for test cases.

## Release note
N/A, this is a util used for test cases.

## Documentation
N/A, this is a util used for test cases.

## Training
N/A, this is a util used for test cases.

## Certification
N/A, this is a util used for test cases.

## Marketing
N/A, this is a util used for test cases.

## Automation tests
N/A, this is a util used for test cases.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A, this is a util used for test cases.

## Related PRs
N/A, this is a util used for test cases.

## Migrations (if applicable)
N/A, this is a util used for test cases.

## Test environment
jdk1.8.0_131
 
## Learning
N/A, this is a util used for test cases.