### PR TITLE
[EI-7] Update pom dependency versions to latest 

### DIFF
--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -66,7 +66,7 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>${slf4j.api.version}</version>
+            <version>${slf4j.version}</version>
         </dependency>
         <dependency>
             <groupId>org.wso2.carbon.secvault</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -302,11 +302,6 @@
                 <artifactId>json-path</artifactId>
                 <version>${com.jayway.jsonpath.version}</version>
             </dependency>
-            <!--<dependency>-->
-                <!--<groupId>org.slf4j</groupId>-->
-                <!--<artifactId>slf4j-api</artifactId>-->
-                <!--<version>${slf4j.version}</version>-->
-            <!--</dependency>-->
             <dependency>
                 <groupId>com.jayway.jsonpath</groupId>
                 <artifactId>json-path-assert</artifactId>
@@ -449,7 +444,6 @@
         <andes.version>4.0.0-SNAPSHOT</andes.version>
         <synapse.core.version>2.1.7-wso2v16</synapse.core.version>
         <com.jayway.jsonpath.version>0.8.0</com.jayway.jsonpath.version>
-        <!--<slf4j.api.version>1.7.12</slf4j.api.version>-->
         <carbon.config.version>2.1.4</carbon.config.version>
         <carbon.secvault.version>5.0.10</carbon.secvault.version>
         <carbon.utils.version>2.0.4</carbon.utils.version>

--- a/pom.xml
+++ b/pom.xml
@@ -302,11 +302,11 @@
                 <artifactId>json-path</artifactId>
                 <version>${com.jayway.jsonpath.version}</version>
             </dependency>
-            <dependency>
-                <groupId>org.slf4j</groupId>
-                <artifactId>slf4j-api</artifactId>
-                <version>${slf4j.api.version}</version>
-            </dependency>
+            <!--<dependency>-->
+                <!--<groupId>org.slf4j</groupId>-->
+                <!--<artifactId>slf4j-api</artifactId>-->
+                <!--<version>${slf4j.version}</version>-->
+            <!--</dependency>-->
             <dependency>
                 <groupId>com.jayway.jsonpath</groupId>
                 <artifactId>json-path-assert</artifactId>
@@ -427,17 +427,18 @@
         <ballerina.runtime.version>0.92.1-SNAPSHOT</ballerina.runtime.version>
         <ballerina.core.version>0.93</ballerina.core.version>
         <carbon.p2.plugin.version>1.5.8</carbon.p2.plugin.version>
-        <carbon.messaging.version>3.0.1</carbon.messaging.version>
+        <carbon.messaging.version>3.0.2</carbon.messaging.version>
+        <!-- TODO: Can't update to latest version since msf4j uses 5.0,6 version range-->
         <carbon.transport.http.netty.version>5.0.1</carbon.transport.http.netty.version>
-        <carbon.metrics.version>2.3.2</carbon.metrics.version>
-        <msf4j.version>2.4.0-m1</msf4j.version>
+        <carbon.metrics.version>2.3.3</carbon.metrics.version>
+        <msf4j.version>2.4.2</msf4j.version>
         <carbon.feature.plugin.version>3.1.1</carbon.feature.plugin.version>
         <carbon.kernel.version>5.2.0</carbon.kernel.version>
         <osgi.api.version>6.0.0</osgi.api.version>
-        <carbon.jndi.version>1.0.4</carbon.jndi.version>
+        <carbon.jndi.version>1.0.5</carbon.jndi.version>
         <carbon.cache.version>1.1.3</carbon.cache.version>
-        <carbon.deployment.version>5.1.5</carbon.deployment.version>
-        <carbon.datasources.version>1.1.3</carbon.datasources.version>
+        <carbon.deployment.version>5.1.7</carbon.deployment.version>
+        <carbon.datasources.version>1.1.4</carbon.datasources.version>
         <carbon.business.messaging.version>4.0.3-SNAPSHOT</carbon.business.messaging.version>
         <maven.shadeplugin.version>2.4.1</maven.shadeplugin.version>
         <slf4j.version>1.7.22</slf4j.version>
@@ -448,10 +449,10 @@
         <andes.version>4.0.0-SNAPSHOT</andes.version>
         <synapse.core.version>2.1.7-wso2v16</synapse.core.version>
         <com.jayway.jsonpath.version>0.8.0</com.jayway.jsonpath.version>
-        <slf4j.api.version>1.7.12</slf4j.api.version>
-        <carbon.config.version>2.1.2</carbon.config.version>
-        <carbon.secvault.version>5.0.8</carbon.secvault.version>
-        <carbon.utils.version>2.0.2</carbon.utils.version>
+        <!--<slf4j.api.version>1.7.12</slf4j.api.version>-->
+        <carbon.config.version>2.1.4</carbon.config.version>
+        <carbon.secvault.version>5.0.10</carbon.secvault.version>
+        <carbon.utils.version>2.0.4</carbon.utils.version>
         <carbon.touchpoint.version>1.1.0</carbon.touchpoint.version>
     </properties>
 </project>


### PR DESCRIPTION
## Purpose
Update root pom dependency versions to latest and fix warnings printed when building.


## Approach
Updated root pom dependency versions   to latest released.
Remove duplicated dependency which causes warn logs printed while building.

