### PR TITLE
Add missing API for CallMediatorBlockingAPITestCase

### DIFF
--- a/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/call/CallMediatorBlockingAPITestCase.java
+++ b/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/call/CallMediatorBlockingAPITestCase.java
@@ -37,6 +37,7 @@ public class CallMediatorBlockingAPITestCase extends ESBIntegrationTest {
     public void setEnvironment() throws Exception {
         super.init();
         verifyAPIExistence("CallBlockingPayloadAPI");
+        verifyAPIExistence("replyAPI");
     }
 
     @Test(groups = { "wso2.esb" },

--- a/integration/mediation-tests/tests-mediator-1/src/test/resources/artifacts/ESB/server/repository/deployment/server/synapse-configs/default/api/replyAPI.xml
+++ b/integration/mediation-tests/tests-mediator-1/src/test/resources/artifacts/ESB/server/repository/deployment/server/synapse-configs/default/api/replyAPI.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied. See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  ~
+  -->
+<api xmlns="http://ws.apache.org/ns/synapse" name="replyAPI" context="/reply">
+    <resource methods="POST">
+        <inSequence>
+            <payloadFactory media-type="xml">
+                <format>
+                    <m0:getQuote xmlns:m0="http://services.samples">
+                        <m0:request>
+                            <m0:symbol>WSO2</m0:symbol>
+                        </m0:request>
+                    </m0:getQuote>
+                </format>
+                <args/>
+            </payloadFactory>
+            <respond/>
+        </inSequence>
+    </resource>
+</api>


### PR DESCRIPTION
## Purpose
Response API was missing in the test-case which caused the test to fail.

