### PR TITLE
Fix failure of testInboundEnpointReadFile_ContentType_Plain

### DIFF
--- a/integration/mediation-tests/tests-transport/src/test/java/org/wso2/carbon/esb/file/inbound/transport/test/InboundEndpointContentTypePlainTest.java
+++ b/integration/mediation-tests/tests-transport/src/test/java/org/wso2/carbon/esb/file/inbound/transport/test/InboundEndpointContentTypePlainTest.java
@@ -70,9 +70,8 @@ public class InboundEndpointContentTypePlainTest extends ESBIntegrationTest {
 
     @SetEnvironment(executionEnvironments = {ExecutionEnvironment.STANDALONE})
     @Test(groups = "wso2.esb", description = "Inbound endpoint Reading file with Content type Plain Test Case")
-    public void testInboundEnpointReadFile_ContentType_Plain() throws Exception {
+    public void testInboundEnpointReadFileContentTypePlain() throws Exception {
 
-        addInboundEndpoint(addEndpoint());
 
         File sourceFile = new File(pathToFtpDir + File.separator + "test.txt");
         File targetFolder = new File(InboundFileFolder + File.separator + "in");
@@ -80,12 +79,13 @@ public class InboundEndpointContentTypePlainTest extends ESBIntegrationTest {
 
         try {
             FileUtils.copyFile(sourceFile, targetFile);
+            addInboundEndpoint(addEndpoint());
+            boolean isFileRead = Utils.checkForLog(logViewerClient, "WSO2 Lanka Pvt Ltd", 2);
+            Assert.assertTrue(isFileRead, "The Text file is not getting read");
         } finally {
             deleteFile(targetFile);
         }
 
-        boolean isFileRead = Utils.checkForLog(logViewerClient, "WSO2 Lanka Pvt Ltd", 2000);
-        Assert.assertTrue(isFileRead, "The Text file is not getting read");
     }
 
     private OMElement addEndpoint() throws Exception {


### PR DESCRIPTION
## Purpose
Fix failure of testInboundEnpointReadFile_ContentType_Plain

## Goals
Fix failure of testInboundEnpointReadFile_ContentType_Plain

## Approach
Asserts the existence of the target file before deleting the source file.

## User stories
N/A, this is a failure of a test case.

## Release note
N/A, this is a failure of a test case.

## Documentation
N/A, this is a failure of a test case.

## Training
N/A, this is a failure of a test case.

## Certification
N/A, this is a failure of a test case.

## Marketing
N/A, this is a failure of a test case.

## Automation tests
N/A, this is a test case itself.

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A, this is a failure of a test case.

## Related PRs
N/A, this is a failure of a test case.

## Migrations (if applicable)
N/A, this is a failure of a test case.

## Test environment
java version "1.8.0_131"
 
## Learning
N/A, this is a failure of a test case.