### PR TITLE
[EI-1299] Fix broker startup error due to missing feature

### DIFF
--- a/distribution/pom.xml
+++ b/distribution/pom.xml
@@ -426,73 +426,6 @@
                         </configuration>
                     </execution>
                     <execution>
-                        <id>materialize-product-msf4j</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>generate-runtime</goal>
-                        </goals>
-                        <configuration>
-                            <repositoryURL>file:${basedir}/target/p2-repo</repositoryURL>
-                            <targetPath>file:${basedir}/target/WSO2Carbon/wso2</targetPath>
-                            <runtime>msf4j</runtime>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>feature-installation-msf4j</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>install</goal>
-                        </goals>
-                        <configuration>
-                            <runtime>msf4j</runtime>
-                            <repositoryURL>file:${basedir}/target/p2-repo</repositoryURL>
-                            <destination>${basedir}/target/WSO2Carbon/wso2</destination>
-                            <deleteOldRuntimeFiles>true</deleteOldRuntimeFiles>
-                            <features>
-                                <feature>
-                                    <id>org.wso2.carbon.config.feature</id>
-                                    <version>${carbon.config.version}</version>
-                                </feature>
-                                <feature>
-                                    <id>org.wso2.carbon.secvault.feature</id>
-                                    <version>${carbon.secvault.version}</version>
-                                </feature>
-                                <feature>
-                                    <id>org.wso2.carbon.utils.feature</id>
-                                    <version>${carbon.utils.version}</version>
-                                </feature>
-                                <feature>
-                                    <id>org.wso2.carbon.server.feature.group</id>
-                                    <version>${carbon.kernel.version}</version>
-                                </feature>
-                                <feature>
-                                    <id>org.wso2.carbon.osgi.feature</id>
-                                    <version>${carbon.kernel.version}</version>
-                                </feature>
-                                <feature>
-                                    <id>org.wso2.carbon.deployment.engine.feature</id>
-                                    <version>${carbon.deployment.version}</version>
-                                </feature>
-                                <feature>
-                                    <id>org.wso2.msf4j.feature</id>
-                                    <version>${msf4j.version}</version>
-                                </feature>
-                                <!--<feature>-->
-                                    <!--<id>org.wso2.ei.converter.tools.synapse2ballerina.feature.group</id>-->
-                                    <!--<version>${product.ei.version}</version>-->
-                                <!--</feature>-->
-                                <!--<feature>-->
-                                    <!--<id>org.wso2.ei.converter.tools.mule2ballerina.feature.group</id>-->
-                                    <!--<version>${product.ei.version}</version>-->
-                                <!--</feature>-->
-                                <!--<feature>-->
-                                    <!--<id>org.wso2.ei.converter.tools.ds2ballerina.feature.group</id>-->
-                                    <!--<version>${product.ei.version}</version>-->
-                                <!--</feature>-->
-                            </features>
-                        </configuration>
-                    </execution>
-                    <execution>
                         <id>materialize-product-broker</id>
                         <phase>package</phase>
                         <goals>
@@ -516,6 +449,10 @@
                             <destination>${basedir}/target/WSO2Carbon/wso2</destination>
                             <deleteOldRuntimeFiles>true</deleteOldRuntimeFiles>
                             <features>
+                                <feature>
+                                    <id>org.wso2.carbon.osgi.feature</id>
+                                    <version>${carbon.kernel.version}</version>
+                                </feature>
                                 <feature>
                                     <id>org.wso2.carbon.config.feature</id>
                                     <version>${carbon.config.version}</version>


### PR DESCRIPTION
## Purpose
Fix https://github.com/wso2/product-ei/issues/1299.broker feature installation was missing 'org.wso2.carbon.osgi.feature' dependency, and the current build was passing due to the same feature been available through msf4j.Hence removing msf4j profile caused broker startup issues. 

## Approach
1. Add 'org.wso2.carbon.osgi.feature' under broker feature installation.
2. Remove msf4j related profile creation.
