### PR TITLE
Fix test failure

### DIFF
--- a/integration/mediation-tests/tests-service/src/test/resources/artifacts/ESB/proxyconfig/proxy/customProxy/insequence_inline_endpoint_from_registry.xml
+++ b/integration/mediation-tests/tests-service/src/test/resources/artifacts/ESB/proxyconfig/proxy/customProxy/insequence_inline_endpoint_from_registry.xml
@@ -21,7 +21,6 @@
     <registry provider="org.wso2.carbon.mediation.registry.WSO2Registry">
         <parameter name="cachableDuration">15000</parameter>
     </registry>
-    <localEntry key="proxy_wsdl" src="file:samples/service-bus/resources/proxy/sample_proxy_1.wsdl"/>
     <proxy name="StockQuoteProxy123" transports="https http" startOnLoad="true" trace="disable">
         <description/>
         <target>

--- a/integration/mediation-tests/tests-service/src/test/resources/artifacts/ESB/proxyconfig/proxy/customProxy/outsequence_faultsequence.xml
+++ b/integration/mediation-tests/tests-service/src/test/resources/artifacts/ESB/proxyconfig/proxy/customProxy/outsequence_faultsequence.xml
@@ -121,7 +121,6 @@
         </target>
         <publishWSDL uri="file:samples/service-bus/resources/proxy/sample_proxy_1.wsdl"/>
     </proxy>
-    <localEntry key="proxy_wsdl" src="file:samples/service-bus/resources/proxy/sample_proxy_1.wsdl"/>
     <sequence name="fault">
         <log level="full">
             <property name="MESSAGE" value="Executing default &quot;fault&quot; sequence"/>

--- a/integration/mediation-tests/tests-service/src/test/resources/artifacts/ESB/proxyconfig/proxy/loggingProxy/proxy_service_enabling_only_http.xml
+++ b/integration/mediation-tests/tests-service/src/test/resources/artifacts/ESB/proxyconfig/proxy/loggingProxy/proxy_service_enabling_only_http.xml
@@ -21,7 +21,6 @@
     <registry provider="org.wso2.carbon.mediation.registry.WSO2Registry">
         <parameter name="cachableDuration">15000</parameter>
     </registry>
-    <localEntry key="proxy_wsdl" src="file:samples/service-bus/resources/proxy/sample_proxy_1.wsdl"/>
     <proxy name="enableHttpLoggingProxy" transports="http" startOnLoad="true" trace="disable">
         <target>
             <endpoint>

--- a/integration/mediation-tests/tests-service/src/test/resources/artifacts/ESB/proxyconfig/proxy/transformerProxy/wsdl_options_specified_source_url.xml
+++ b/integration/mediation-tests/tests-service/src/test/resources/artifacts/ESB/proxyconfig/proxy/transformerProxy/wsdl_options_specified_source_url.xml
@@ -21,7 +21,6 @@
     <registry provider="org.wso2.carbon.mediation.registry.WSO2Registry">
         <parameter name="cachableDuration">15000</parameter>
     </registry>
-    <localEntry key="proxy_wsdl" src="file:samples/service-bus/resources/proxy/sample_proxy_1.wsdl"/>
     <proxy name="wsdlOptionsFromSourceUrlTransformerProxy" transports="https http" startOnLoad="true" trace="disable">
         <description/>
         <target>

--- a/integration/mediation-tests/tests-service/src/test/resources/artifacts/ESB/proxyconfig/proxy/wsdlBasedProxy/proxy_service_enabling_only_http.xml
+++ b/integration/mediation-tests/tests-service/src/test/resources/artifacts/ESB/proxyconfig/proxy/wsdlBasedProxy/proxy_service_enabling_only_http.xml
@@ -21,7 +21,6 @@
     <registry provider="org.wso2.carbon.mediation.registry.WSO2Registry">
         <parameter name="cachableDuration">15000</parameter>
     </registry>
-    <localEntry key="proxy_wsdl" src="file:samples/service-bus/resources/proxy/sample_proxy_1.wsdl"/>
     <proxy name="enableHttpWsdlBasedProxy" transports="http" startOnLoad="true" trace="disable">
         <target>
             <endpoint>

--- a/integration/mediation-tests/tests-service/src/test/resources/artifacts/ESB/server/repository/deployment/server/synapse-configs/default/local-entries/sampleProxy1WsdlLE.xml
+++ b/integration/mediation-tests/tests-service/src/test/resources/artifacts/ESB/server/repository/deployment/server/synapse-configs/default/local-entries/sampleProxy1WsdlLE.xml
@@ -1,0 +1,20 @@
+<!--
+  ~ Copyright (c)2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<localEntry xmlns="http://ws.apache.org/ns/synapse" key="proxy_wsdl"
+            src="file:samples/service-bus/resources/proxy/sample_proxy_1.wsdl"/>


### PR DESCRIPTION
## Purpose
Resolves https://github.com/wso2/product-ei/issues/1315

## Goals
Fixes the failure of wsdlBasedProxy.ProxyServiceEnablingHTTPTestCase because of the coflict of the local entry it tries to upload and an already existing one. 

## Approach
Fixed the issue by moving the common local entry to the resources/server folder so that it in being uploaded by different test cases.

## User stories
N/A, this is a modification of multiple test cases.

## Test environment
1.8.0_131
 