### PR TITLE
Add test case to check whether Expires header accepts comma

### DIFF
--- a/integration/mediation-tests/tests-transport/src/test/java/org/wso2/carbon/esb/passthru/transport/test/CookieHeaderExpiresHavingCommaTestCase.java
+++ b/integration/mediation-tests/tests-transport/src/test/java/org/wso2/carbon/esb/passthru/transport/test/CookieHeaderExpiresHavingCommaTestCase.java
@@ -1,0 +1,56 @@
+/*
+*  Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+package org.wso2.carbon.esb.passthru.transport.test;
+
+import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.DefaultHttpClient;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import org.wso2.esb.integration.common.utils.ESBIntegrationTest;
+
+import java.io.IOException;
+
+/**
+ * Insert a comma in the 'Expires' cookie header and check whether it is processed.
+ */
+public class CookieHeaderExpiresHavingCommaTestCase extends ESBIntegrationTest {
+
+    @BeforeClass
+    public void init() throws Exception {
+        super.init();
+    }
+
+    @Test(groups = "wso2.esb",
+          description = "Test SetCookieHeader With Expires having a comma")
+    public void testSetCookieHeaderWithExpires() throws IOException {
+        DefaultHttpClient httpclient = new DefaultHttpClient();
+        HttpGet httpGet = new HttpGet(getApiInvocationURL("cookieHeaderTestAPI"));
+        HttpResponse httpResponse = httpclient.execute(httpGet);
+        Assert.assertEquals(httpResponse.getStatusLine().getStatusCode(), 200,
+                "Request failed. Response received is : " + httpResponse.toString());
+    }
+
+    @AfterClass
+    public void cleanUp() throws Exception {
+        super.cleanup();
+    }
+}

--- a/integration/mediation-tests/tests-transport/src/test/resources/artifacts/ESB/server/repository/deployment/server/synapse-configs/default/api/CookieHeaderTestAPI.xml
+++ b/integration/mediation-tests/tests-transport/src/test/resources/artifacts/ESB/server/repository/deployment/server/synapse-configs/default/api/CookieHeaderTestAPI.xml
@@ -1,0 +1,38 @@
+<!--
+ ~  Copyright (c) 2017, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+ ~
+ ~  WSO2 Inc. licenses this file to you under the Apache License,
+ ~  Version 2.0 (the "License"); you may not use this file except
+ ~  in compliance with the License.
+ ~  You may obtain a copy of the License at
+ ~
+ ~    http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~  Unless required by applicable law or agreed to in writing,
+ ~  software distributed under the License is distributed on an
+ ~  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ ~  KIND, either express or implied.  See the License for the
+ ~  specific language governing permissions and limitations
+ ~  under the License.
+ ~
+ -->
+
+<api xmlns="http://ws.apache.org/ns/synapse" name="CookieHeaderTestAPI" context="/cookieHeaderTestAPI" >
+    <resource methods="GET">
+        <inSequence>
+            <call blocking="true">
+                <endpoint>
+                    <http method="GET" uri-template="http://localhost:8480/cookieHeaderThirdPartyTestAPI"/>
+                </endpoint>
+            </call>
+            <payloadFactory media-type="json">
+                <format>$1</format>
+                <args>
+                    <arg evaluator="json" expression="$."/>
+                </args>
+            </payloadFactory>
+            <property name="messageType" value="application/json" scope="axis2"/>
+            <respond/>
+        </inSequence>
+    </resource>
+</api>

--- a/integration/mediation-tests/tests-transport/src/test/resources/artifacts/ESB/server/repository/deployment/server/synapse-configs/default/api/CookieHeaderThirdPartyTestAPI.xml
+++ b/integration/mediation-tests/tests-transport/src/test/resources/artifacts/ESB/server/repository/deployment/server/synapse-configs/default/api/CookieHeaderThirdPartyTestAPI.xml
@@ -1,0 +1,33 @@
+<!--
+ ~  Copyright (c) 2017, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+ ~
+ ~  WSO2 Inc. licenses this file to you under the Apache License,
+ ~  Version 2.0 (the "License"); you may not use this file except
+ ~  in compliance with the License.
+ ~  You may obtain a copy of the License at
+ ~
+ ~    http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~  Unless required by applicable law or agreed to in writing,
+ ~  software distributed under the License is distributed on an
+ ~  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ ~  KIND, either express or implied.  See the License for the
+ ~  specific language governing permissions and limitations
+ ~  under the License.
+ ~
+ -->
+
+<api xmlns="http://ws.apache.org/ns/synapse" name="CookieHeaderThirdPartyTestAPI" context="/cookieHeaderThirdPartyTestAPI">
+    <resource methods="GET">
+        <inSequence>
+            <payloadFactory media-type="json">
+                <format>{"key1":"value1"}</format>
+                <args/>
+            </payloadFactory>
+            <property name="messageType" value="application/json" scope="axis2"/>
+            <header name="Set-Cookie" scope="transport"
+                    value="NSC_ESNS=003f89c8-bbc9-17e0-9678-00e0ed2b4efe_4040064315_1537360564_00000000000003409346; Path=/; Expires=Tue, 20-Sep-2016 04:32:24 GMT"/>
+            <respond/>
+        </inSequence>
+    </resource>
+</api>

--- a/integration/mediation-tests/tests-transport/src/test/resources/testng.xml
+++ b/integration/mediation-tests/tests-transport/src/test/resources/testng.xml
@@ -37,6 +37,7 @@
             <class name="org.wso2.carbon.esb.passthru.transport.test.ESBJAVA5135ResponseBodyWith202TestCase"/>
             <class name="org.wso2.carbon.esb.passthru.transport.test.HTTPDeleteTestCases"/>
             <class name="org.wso2.carbon.esb.passthru.transport.test.MTOMMIMEBoundaryWhenContentTypePreservedTestCase"/>
+            <class name="org.wso2.carbon.esb.passthru.transport.test.CookieHeaderExpiresHavingCommaTestCase"/>
         </classes>
     </test>
 


### PR DESCRIPTION
## Purpose
> Adding test case to check whether it is possible to have comma in Expires cookie header.
PR sent to ESB : https://github.com/wso2/product-esb/pull/607