### PR TITLE
Add test case for handling empty response from an endpoint by callout mediator

### DIFF
--- a/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/callOut/CalloutMediatorHandlingEmptySuccessResponseTestCase.java
+++ b/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/callOut/CalloutMediatorHandlingEmptySuccessResponseTestCase.java
@@ -1,0 +1,54 @@
+/*
+*  Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*  WSO2 Inc. licenses this file to you under the Apache License,
+*  Version 2.0 (the "License"); you may not use this file except
+*  in compliance with the License.
+*  You may obtain a copy of the License at
+*
+*    http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*/
+
+package org.wso2.carbon.esb.mediator.test.callOut;
+
+import org.apache.http.HttpResponse;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import org.wso2.esb.integration.common.utils.ESBIntegrationTest;
+import org.wso2.esb.integration.common.utils.clients.SimpleHttpClient;
+
+import static org.testng.Assert.assertEquals;
+
+/**
+ * Test case to check whether callout mediator is handling an empty reponse from the endpoint
+ */
+public class CalloutMediatorHandlingEmptySuccessResponseTestCase extends ESBIntegrationTest {
+    @BeforeClass(alwaysRun = true)
+    public void setEnvironment() throws Exception {
+        super.init();
+    }
+
+    @Test(groups = "wso2.esb")
+    public void testForwardingWithInMemoryStore() throws Exception {
+        String requestPayload = "{\"hello\":\"world\"}";
+        SimpleHttpClient httpClient = new SimpleHttpClient();
+        String url = getApiInvocationURL("callouttest");
+        HttpResponse httpResponse = httpClient.doPost(url, null, requestPayload, "application/json");
+        String responsePayload = httpClient.getResponsePayload(httpResponse);
+        assertEquals(responsePayload, requestPayload,
+                "Response not matching with the request! Response received is :" + responsePayload);
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void destroy() throws Exception {
+        super.cleanup();
+    }
+}

--- a/integration/mediation-tests/tests-mediator-1/src/test/resources/artifacts/ESB/server/repository/deployment/server/synapse-configs/default/api/ESBJAVA4452TestAPI.xml
+++ b/integration/mediation-tests/tests-mediator-1/src/test/resources/artifacts/ESB/server/repository/deployment/server/synapse-configs/default/api/ESBJAVA4452TestAPI.xml
@@ -1,0 +1,28 @@
+<!--
+ ~ Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ ~
+ ~ WSO2 Inc. licenses this file to you under the Apache License,
+ ~ Version 2.0 (the "License"); you may not use this file except
+ ~ in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~    http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing,
+ ~ software distributed under the License is distributed on an
+ ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ ~ KIND, either express or implied.  See the License for the
+ ~ specific language governing permissions and limitations
+ ~ under the License.
+ -->
+
+<api xmlns="http://ws.apache.org/ns/synapse" name="ESBJAVA4452TestAPI" context="/callouttest">
+    <resource methods="POST">
+        <inSequence>
+            <callout serviceURL="http://localhost:8480/mockresponse">
+                <source type="envelope"/>
+            </callout>
+            <respond/>
+        </inSequence>
+    </resource>
+</api>

--- a/integration/mediation-tests/tests-mediator-1/src/test/resources/artifacts/ESB/server/repository/deployment/server/synapse-configs/default/api/MockResponseTestAPI.xml
+++ b/integration/mediation-tests/tests-mediator-1/src/test/resources/artifacts/ESB/server/repository/deployment/server/synapse-configs/default/api/MockResponseTestAPI.xml
@@ -1,0 +1,37 @@
+<!--
+ ~ Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ ~
+ ~ WSO2 Inc. licenses this file to you under the Apache License,
+ ~ Version 2.0 (the "License"); you may not use this file except
+ ~ in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~    http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing,
+ ~ software distributed under the License is distributed on an
+ ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ ~ KIND, either express or implied.  See the License for the
+ ~ specific language governing permissions and limitations
+ ~ under the License.
+ -->
+
+<api xmlns="http://ws.apache.org/ns/synapse" name="MockResponseTestAPI" context="/mockresponse">
+    <resource methods="POST">
+        <inSequence>
+            <payloadFactory media-type="xml">
+                <format>
+                    <soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/">
+                        <soapenv:Body/>
+                    </soapenv:Envelope>
+                </format>
+                <args/>
+            </payloadFactory>
+            <property name="messageType" value="text/xml" scope="axis2"/>
+            <property name="DISABLE_CHUNKING" value="true" scope="axis2"/>
+            <property name="HTTP_SC" value="200" scope="axis2"/>
+            <property name="Content-Length" value="0" scope="transport"/>
+            <respond/>
+        </inSequence>
+    </resource>
+</api>


### PR DESCRIPTION
## Purpose
> Adding test case to check whether callout mediator is handling an empty response from the endpoint.
PR sent to ESB : https://github.com/wso2/product-esb/pull/460
