### PR TITLE
Add test case for message processor processing messages with dynamically added WSA headers

### DIFF
--- a/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/message/processor/test/DynamicallySettingWSAHeadersTestCase.java
+++ b/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/message/processor/test/DynamicallySettingWSAHeadersTestCase.java
@@ -1,0 +1,66 @@
+/*
+*Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+*
+*WSO2 Inc. licenses this file to you under the Apache License,
+*Version 2.0 (the "License"); you may not use this file except
+*in compliance with the License.
+*You may obtain a copy of the License at
+*
+*http://www.apache.org/licenses/LICENSE-2.0
+*
+*Unless required by applicable law or agreed to in writing,
+*software distributed under the License is distributed on an
+*"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+*KIND, either express or implied.  See the License for the
+*specific language governing permissions and limitations
+*under the License.
+*/
+package org.wso2.carbon.esb.message.processor.test;
+
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import org.wso2.carbon.automation.test.utils.http.client.HttpURLConnectionClient;
+import org.wso2.carbon.integration.common.admin.client.LogViewerClient;
+import org.wso2.esb.integration.common.utils.ESBIntegrationTest;
+import org.wso2.esb.integration.common.utils.Utils;
+
+import java.io.Reader;
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.io.Writer;
+import java.net.URL;
+
+/**
+ * Test case to test whether message processor is able to handle messages when their WSA headers are set dynamically.
+ */
+public class DynamicallySettingWSAHeadersTestCase extends ESBIntegrationTest {
+
+    private LogViewerClient logViewer;
+
+    @BeforeClass(alwaysRun = true)
+    public void setEnvironment() throws Exception {
+        super.init();
+    }
+
+    @Test(groups = "wso2.esb",
+          description = "Testing message Processor handling message when setting wsa headers dynamically")
+    public void testForwardingWithInMemoryStore() throws Exception {
+
+        logViewer = new LogViewerClient(contextUrls.getBackEndUrl(), getSessionCookie());
+        logViewer.clearLogs();
+        Reader data = new StringReader("<request><element>Test</element></request>");
+        Writer writer = new StringWriter();
+        HttpURLConnectionClient
+                .sendPostRequestAndReadResponse(data, new URL(getProxyServiceURLHttp("MessageProcessorWSATestProxy")),
+                        writer, "application/xml");
+        Assert.assertTrue(Utils.checkForLog(logViewer, "MessageProcessorWSAProxy Request Received", 20),
+                "Message processor unable to handle the message!");
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void destroy() throws Exception {
+        super.cleanup();
+    }
+}

--- a/integration/mediation-tests/tests-mediator-1/src/test/resources/artifacts/ESB/server/repository/deployment/server/synapse-configs/default/api/MessageProcessorWSATestAPI.xml
+++ b/integration/mediation-tests/tests-mediator-1/src/test/resources/artifacts/ESB/server/repository/deployment/server/synapse-configs/default/api/MessageProcessorWSATestAPI.xml
@@ -1,0 +1,33 @@
+<!--
+ ~  Copyright (c) 2017, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+ ~
+ ~  WSO2 Inc. licenses this file to you under the Apache License,
+ ~  Version 2.0 (the "License"); you may not use this file except
+ ~  in compliance with the License.
+ ~  You may obtain a copy of the License at
+ ~
+ ~    http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~  Unless required by applicable law or agreed to in writing,
+ ~  software distributed under the License is distributed on an
+ ~  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ ~  KIND, either express or implied.  See the License for the
+ ~  specific language governing permissions and limitations
+ ~  under the License.
+ ~
+ -->
+
+<api xmlns="http://ws.apache.org/ns/synapse" name="MessageProcessorWSATestAPI" context="/testWSA">
+    <resource methods="POST">
+        <inSequence>
+            <payloadFactory media-type="xml">
+                <format>
+                    <response xmlns="">MessageProcessorWSAProxy Request Received</response>
+                </format>
+                <args/>
+            </payloadFactory>
+            <log level="full"/>
+            <respond/>
+        </inSequence>
+    </resource>
+</api>

--- a/integration/mediation-tests/tests-mediator-1/src/test/resources/artifacts/ESB/server/repository/deployment/server/synapse-configs/default/endpoints/MessageProcessorWSATestEP.xml
+++ b/integration/mediation-tests/tests-mediator-1/src/test/resources/artifacts/ESB/server/repository/deployment/server/synapse-configs/default/endpoints/MessageProcessorWSATestEP.xml
@@ -1,0 +1,24 @@
+<!--
+ ~  Copyright (c) 2017, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+ ~
+ ~  WSO2 Inc. licenses this file to you under the Apache License,
+ ~  Version 2.0 (the "License"); you may not use this file except
+ ~  in compliance with the License.
+ ~  You may obtain a copy of the License at
+ ~
+ ~    http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~  Unless required by applicable law or agreed to in writing,
+ ~  software distributed under the License is distributed on an
+ ~  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ ~  KIND, either express or implied.  See the License for the
+ ~  specific language governing permissions and limitations
+ ~  under the License.
+ ~
+ -->
+
+<endpoint xmlns="http://ws.apache.org/ns/synapse" name="MessageProcessorWSATestEP">
+    <address uri="http://localhost:8480/testWSA">
+        <enableAddressing/>
+    </address>
+</endpoint>

--- a/integration/mediation-tests/tests-mediator-1/src/test/resources/artifacts/ESB/server/repository/deployment/server/synapse-configs/default/message-processors/MessageProcessorWSATestProcessor.xml
+++ b/integration/mediation-tests/tests-mediator-1/src/test/resources/artifacts/ESB/server/repository/deployment/server/synapse-configs/default/message-processors/MessageProcessorWSATestProcessor.xml
@@ -1,0 +1,30 @@
+<!--
+ ~  Copyright (c) 2017, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+ ~
+ ~  WSO2 Inc. licenses this file to you under the Apache License,
+ ~  Version 2.0 (the "License"); you may not use this file except
+ ~  in compliance with the License.
+ ~  You may obtain a copy of the License at
+ ~
+ ~    http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~  Unless required by applicable law or agreed to in writing,
+ ~  software distributed under the License is distributed on an
+ ~  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ ~  KIND, either express or implied.  See the License for the
+ ~  specific language governing permissions and limitations
+ ~  under the License.
+ ~
+ -->
+
+<messageProcessor xmlns="http://ws.apache.org/ns/synapse"
+        class="org.apache.synapse.message.processor.impl.forwarder.ScheduledMessageForwardingProcessor"
+        messageStore="MessageProcessorWSATestStore" name="MessageProcessorWSATestProcessor" targetEndpoint="MessageProcessorWSATestEP">
+    <parameter name="client.retry.interval">1000</parameter>
+    <parameter name="throttle">false</parameter>
+    <parameter name="max.delivery.attempts">2</parameter>
+    <parameter name="member.count">1</parameter>
+    <parameter name="max.delivery.drop">Disabled</parameter>
+    <parameter name="interval">1000</parameter>
+    <parameter name="is.active">true</parameter>
+</messageProcessor>

--- a/integration/mediation-tests/tests-mediator-1/src/test/resources/artifacts/ESB/server/repository/deployment/server/synapse-configs/default/message-stores/MessageProcessorWSATestStore.xml
+++ b/integration/mediation-tests/tests-mediator-1/src/test/resources/artifacts/ESB/server/repository/deployment/server/synapse-configs/default/message-stores/MessageProcessorWSATestStore.xml
@@ -1,0 +1,20 @@
+<!--
+ ~  Copyright (c) 2017, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+ ~
+ ~  WSO2 Inc. licenses this file to you under the Apache License,
+ ~  Version 2.0 (the "License"); you may not use this file except
+ ~  in compliance with the License.
+ ~  You may obtain a copy of the License at
+ ~
+ ~    http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~  Unless required by applicable law or agreed to in writing,
+ ~  software distributed under the License is distributed on an
+ ~  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ ~  KIND, either express or implied.  See the License for the
+ ~  specific language governing permissions and limitations
+ ~  under the License.
+ ~
+ -->
+
+<messageStore xmlns="http://ws.apache.org/ns/synapse" name="MessageProcessorWSATestStore"/>

--- a/integration/mediation-tests/tests-mediator-1/src/test/resources/artifacts/ESB/server/repository/deployment/server/synapse-configs/default/proxy-services/MessageProcessorWSATestProxy.xml
+++ b/integration/mediation-tests/tests-mediator-1/src/test/resources/artifacts/ESB/server/repository/deployment/server/synapse-configs/default/proxy-services/MessageProcessorWSATestProxy.xml
@@ -1,0 +1,48 @@
+<!--
+ ~  Copyright (c) 2017, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+ ~
+ ~  WSO2 Inc. licenses this file to you under the Apache License,
+ ~  Version 2.0 (the "License"); you may not use this file except
+ ~  in compliance with the License.
+ ~  You may obtain a copy of the License at
+ ~
+ ~    http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~  Unless required by applicable law or agreed to in writing,
+ ~  software distributed under the License is distributed on an
+ ~  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ ~  KIND, either express or implied.  See the License for the
+ ~  specific language governing permissions and limitations
+ ~  under the License.
+ ~
+ -->
+
+<proxy xmlns="http://ws.apache.org/ns/synapse" name="MessageProcessorWSATestProxy" startOnLoad="true" trace="disable" transports="http https">
+    <description/>
+    <target>
+        <inSequence>
+            <log/>
+            <property name="FORCE_SC_ACCEPTED" scope="axis2"
+                      type="STRING" value="true"/>
+            <payloadFactory media-type="xml">
+                <format>
+                    <greet>
+                        <name>MessageProcessorWSA</name>
+                    </greet>
+                </format>
+                <args/>
+            </payloadFactory>
+            <header scope="default">
+                <wsa:MessageID xmlns:wsa="http://www.w3.org/2005/08/addressing">uuid:d7f2e040-e298-49f2-9c73-99273f15f9d5</wsa:MessageID>
+            </header>
+            <header scope="default">
+                <wsa:To xmlns:wsa="http://www.w3.org/2005/08/addressing">http://localhost:8480/test</wsa:To>
+            </header>
+            <log level="full">
+                <property name="BeforeSendingToStore" value="Before Sending to Message Store"/>
+            </log>
+            <property name="PRESERVE_WS_ADDRESSING" value="true"/>
+            <store messageStore="MessageProcessorWSATestStore"/>
+        </inSequence>
+    </target>
+</proxy>

--- a/integration/mediation-tests/tests-mediator-1/src/test/resources/testng.xml
+++ b/integration/mediation-tests/tests-mediator-1/src/test/resources/testng.xml
@@ -312,6 +312,7 @@
         <classes>
             <!--TODO Uncomment following test case after wso2-synapse 2.1.7-wso2v22 upgrade
             <class name="org.wso2.carbon.esb.message.processor.test.MessageProcessorSOAPHeadersTestcase"/-->
+            <class name="org.wso2.carbon.esb.message.processor.test.DynamicallySettingWSAHeadersTestCase"/>
         </classes>
     </test>
 


### PR DESCRIPTION
## Purpose
> Adding test case to test whether message processor is handling messages when the WSA headers of the messages are set dynamically.
PR sent to ESB : https://github.com/wso2/product-esb/pull/584
