### PR TITLE
Add execution scripts for integrator profile

### DIFF
--- a/distribution/src/assembly/bin.xml
+++ b/distribution/src/assembly/bin.xml
@@ -104,6 +104,18 @@
             <filtered>true</filtered>
         </file>
         <file>
+            <source>src/scripts/integrator.sh</source>
+            <outputDirectory>bin/</outputDirectory>
+            <fileMode>755</fileMode>
+            <filtered>true</filtered>
+        </file>
+        <file>
+            <source>src/scripts/integrator.bat</source>
+            <outputDirectory>bin/</outputDirectory>
+            <fileMode>755</fileMode>
+            <filtered>true</filtered>
+        </file>
+        <file>
             <source>src/conf/broker/deployment.yaml</source>
             <outputDirectory>conf/broker/</outputDirectory>
             <fileMode>644</fileMode>

--- a/distribution/src/scripts/integrator.bat
+++ b/distribution/src/scripts/integrator.bat
@@ -1,0 +1,28 @@
+@echo off
+
+REM ---------------------------------------------------------------------------
+REM   Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+REM
+REM   Licensed under the Apache License, Version 2.0 (the "License");
+REM   you may not use this file except in compliance with the License.
+REM   You may obtain a copy of the License at
+REM
+REM   http://www.apache.org/licenses/LICENSE-2.0
+REM
+REM   Unless required by applicable law or agreed to in writing, software
+REM   distributed under the License is distributed on an "AS IS" BASIS,
+REM   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+REM   See the License for the specific language governing permissions and
+REM   limitations under the License.
+
+rem ---------------------------------------------------------------------------
+rem Main Script for Integrator
+rem
+rem Environment Variable Prerequisites
+rem
+rem   JAVA_HOME       Must point at your Java Development Kit installation.
+rem
+rem   JAVA_OPTS       (Optional) Java runtime options used when the commands
+rem                   is executed.
+rem ---------------------------------------------------------------------------
+..\wso2\ballerina\bin\ballerina.bat run %1

--- a/distribution/src/scripts/integrator.sh
+++ b/distribution/src/scripts/integrator.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# ---------------------------------------------------------------------------
+#  Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+# ----------------------------------------------------------------------------
+# Startup Script for Integrator
+#
+# Environment Variable Prerequisites
+#
+#   JAVA_HOME           Must point at your Java Development Kit installation.
+#
+#   JAVA_OPTS           (Optional) Java runtime options used when the commands
+#                       is executed.
+#
+# -----------------------------------------------------------------------------
+sh ./../wso2/ballerina/bin/ballerina run $1


### PR DESCRIPTION
## Purpose
EI 7.0.x Integration profile need to have execution scripts for unix and windows environments.

Resolves #1375 

## Goals
Introducing execution scripts for integrator profile for unix and windows environments.

## Approach
Two new script files integrator.sh (for unix) and integrator.bat (for windows) are added.
Scripts are copied to the bin directory of the distribution.
Internally they are pointing to the ballerina scripts resides in wso2/ballerina/bin directory of the distribution.

## Release note
Execution scripts for integration profile (integrator.sh and integrator.bat) were added.

## Samples
In unix environment, use following command to start integrator with a ballerina program file.
sh integrator.sh <location of the .balx file>

In windows environment, use following command to start integrator with a ballerina program file.
integrator.bat <location of the .balx file>

integrator.sh and integrator.bat are located at bin directory.



