### PR TITLE
Migrate product-esb test case for Http eTag to product-ei

### DIFF
--- a/integration/mediation-tests/tests-transport/src/test/java/org/wso2/carbon/esb/passthru/transport/test/ETagSupportTestCase.java
+++ b/integration/mediation-tests/tests-transport/src/test/java/org/wso2/carbon/esb/passthru/transport/test/ETagSupportTestCase.java
@@ -35,7 +35,7 @@ public class ETagSupportTestCase extends ESBIntegrationTest {
 
     //TODO: Enable tests after fixing fixing SimpleHttpClient issue TA-945
 
-    private final String epr;
+    private String epr;
     private SimpleHttpClient httpClient;
     private Map<String, String> headers;
     private Header eTagHeader;

--- a/integration/mediation-tests/tests-transport/src/test/java/org/wso2/carbon/esb/passthru/transport/test/ETagSupportTestCase.java
+++ b/integration/mediation-tests/tests-transport/src/test/java/org/wso2/carbon/esb/passthru/transport/test/ETagSupportTestCase.java
@@ -1,0 +1,141 @@
+package org.wso2.carbon.esb.passthru.transport.test;
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.http.Header;
+import org.apache.http.HttpResponse;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import org.wso2.carbon.automation.extensions.servers.httpserver.SimpleHttpClient;
+import org.wso2.esb.integration.common.utils.ESBIntegrationTest;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
+
+public class ETagSupportTestCase extends ESBIntegrationTest {
+
+    //TODO: Enable tests after fixing fixing SimpleHttpClient issue TA-945
+
+    private final String epr;
+    private SimpleHttpClient httpClient;
+    private Map<String, String> headers;
+    private Header eTagHeader;
+
+    private String payload;
+    @BeforeClass(alwaysRun = true)
+    public void init() throws Exception {
+
+        super.init();
+        httpClient = new SimpleHttpClient();
+        epr = getProxyServiceURLHttp("ETagTestProxy");
+
+        // Setting initial http headers
+        headers = new HashMap<String, String>();
+        headers.put("action", "urn:echoString");
+        headers.put("Content-Type", "application/soap+xml");
+        headers.put("charset", "UTF-8");
+
+        payload = "<soapenv:Envelope xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\">" +
+                  "<soapenv:Body>" +
+                  "<p:echoInt xmlns:p=\"http://echo.services.core.carbon.wso2.org\">" +
+                  "<in>1</in>" +
+                  "</p:echoInt>" +
+                  "</soapenv:Body>" +
+                  "</soapenv:Envelope>";
+
+    }
+
+    @Test(groups = "wso2.esb", description = "ETag enable test for a pass-through proxy", enabled = true)
+    public void testEnableETag() throws Exception {
+
+        HttpResponse response = httpClient.doPost(epr, headers, payload, "text/xml");
+
+        eTagHeader = response.getFirstHeader("ETag");
+        Assert.assertNotNull(eTagHeader, "ETag header is not present in the response");
+
+        int statusCode = response.getStatusLine().getStatusCode();
+        Assert.assertEquals(statusCode, 200, "Incorrect status code. Expected: 200 Found: " + statusCode);
+        Assert.assertNotNull(httpClient.getResponsePayload(response), "Payload should not empty");
+    }
+
+    @Test(groups = "wso2.esb", description = "If-None-Match header test for cache hit", enabled = false)
+    public void testIfNoneMatchHeaderCacheHit() throws Exception {
+        headers.put("If-None-Match", "\"" + eTagHeader.getValue() + "\"");
+
+        HttpResponse response = httpClient.doPost(epr, headers, payload, "text/xml");
+
+        int statusCode = response.getStatusLine().getStatusCode();
+        Assert.assertEquals(statusCode, 304, "Incorrect status code. Expected: 304 Found: " + statusCode);
+        Assert.assertNotNull(httpClient.getResponsePayload(response), "Payload should not empty");
+    }
+
+    @Test(groups = "wso2.esb", description = "If-None-Match header test for cache miss", enabled = false)
+    public void testIfNoneNoneMatchHeaderCacheMiss() throws Exception {
+
+        payload = "<soapenv:Envelope xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\">" +
+                  "<soapenv:Body>" +
+                  "<p:echoInt xmlns:p=\"http://echo.services.core.carbon.wso2.org\">" +
+                  "<in>2</in>" +
+                  "</p:echoInt>" +
+                  "</soapenv:Body>" +
+                  "</soapenv:Envelope>";
+
+        HttpResponse response = httpClient.doPost(epr, headers, payload, "text/xml");
+
+        int statusCode = response.getStatusLine().getStatusCode();
+        Assert.assertEquals(statusCode, 200, "Incorrect status code. Expected: 200 Found: " + statusCode);
+        Assert.assertNotNull(httpClient.getResponsePayload(response), "Payload should not empty");
+
+        Assert.assertTrue(!response.getFirstHeader("ETag").getValue().equals(headers.get("If-None-Match")),
+                          "New ETag should be different from the old ETag value");
+
+    }
+
+    @Test(groups = "wso2.esb", description = "If-None-Match header with more than one value test case", enabled = false)
+    public void testIfNoneMatchHeaderMoreThanOneValue() throws Exception {
+
+        payload = "<soapenv:Envelope xmlns:soapenv=\"http://www.w3.org/2003/05/soap-envelope\">" +
+                  "<soapenv:Body>" +
+                  "<p:echoInt xmlns:p=\"http://echo.services.core.carbon.wso2.org\">" +
+                  "<in>1</in>" +
+                  "</p:echoInt>" +
+                  "</soapenv:Body>" +
+                  "</soapenv:Envelope>";
+
+        headers.remove("If-None-Match");
+        headers.put("If-None-Match",
+                    "\"-27-97-102-122-100-29-106112-103-39117-127-648049-356\",\"" +
+                    "-16-97-102-122-100-29-106112-103-39117-127-648049-104\",\"" +
+                    "263-97-102-122-100-29-106112-103-39117-127-648049-773\"");
+
+        HttpResponse response = httpClient.doPost(epr, headers, payload, "text/xml");
+
+        int statusCode = response.getStatusLine().getStatusCode();
+        Assert.assertEquals(statusCode, 304, "Incorrect status code. Expected: 304 Found: " + statusCode);
+        Assert.assertNotNull(httpClient.getResponsePayload(response), "Payload should not empty");
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void clean() throws Exception {
+        super.cleanup();
+    }
+}

--- a/integration/mediation-tests/tests-transport/src/test/resources/artifacts/ESB/server/repository/deployment/server/synapse-configs/default/proxy-services/ETagTestProxy.xml
+++ b/integration/mediation-tests/tests-transport/src/test/resources/artifacts/ESB/server/repository/deployment/server/synapse-configs/default/proxy-services/ETagTestProxy.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied. See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  ~
+  -->
+<proxy name="ETagTestProxy"
+       transports="https http"
+       startOnLoad="true"
+       trace="disable" xmlns="http://ws.apache.org/ns/synapse">
+    <description/>
+    <target>
+        <endpoint>
+            <address uri="http://localhost:8480/services/EchoProxy"/>
+        </endpoint>
+        <outSequence>
+            <property name="HTTP_ETAG" value="true" scope="axis2" type="BOOLEAN"/>
+            <send/>
+        </outSequence>
+    </target>
+</proxy>

--- a/integration/mediation-tests/tests-transport/src/test/resources/artifacts/ESB/server/repository/deployment/server/synapse-configs/default/proxy-services/EchoProxy.xml
+++ b/integration/mediation-tests/tests-transport/src/test/resources/artifacts/ESB/server/repository/deployment/server/synapse-configs/default/proxy-services/EchoProxy.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied. See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  ~
+  -->
+<proxy name="EchoProxy"
+       transports="https http"
+       startOnLoad="true"
+       trace="disable" xmlns="http://ws.apache.org/ns/synapse">
+    <description/>
+    <target>
+        <inSequence>
+            <log level="full"/>
+            <respond/>
+        </inSequence>
+    </target>
+</proxy>

--- a/integration/mediation-tests/tests-transport/src/test/resources/testng.xml
+++ b/integration/mediation-tests/tests-transport/src/test/resources/testng.xml
@@ -38,6 +38,7 @@
             <class name="org.wso2.carbon.esb.passthru.transport.test.HTTPDeleteTestCases"/>
             <class name="org.wso2.carbon.esb.passthru.transport.test.MTOMMIMEBoundaryWhenContentTypePreservedTestCase"/>
             <class name="org.wso2.carbon.esb.passthru.transport.test.CookieHeaderExpiresHavingCommaTestCase"/>
+            <class name="org.wso2.carbon.esb.passthru.transport.test.ETagSupportTestCase"/>
         </classes>
     </test>
 


### PR DESCRIPTION
## Purpose
Migrate product-esb test case for Http eTag to product-ei.

## Goals
A test case added to http eTag functionality. 

## Approach
Moved product-esb PR https://github.com/wso2/product-esb/pull/36/ 
into product-ei

## User stories
N/A

## Release note
N/A

## Documentation
N/A

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
This is an integration test.

## Security checks
Yes

## Samples
N/A

## Related PRs
https://github.com/wso2/product-esb/pull/36/

## Migrations (if applicable)
N/A

## Test environment
N/A
 
## Learning
N/A