### PR TITLE
Add SecureProxyUsingPolicyFileInLocalEntryTestCase

### DIFF
--- a/integration/mediation-tests/tests-service/src/test/java/org/wso2/carbon/esb/proxyservice/test/secureProxy/SecureProxyUsingPolicyFileInLocalEntryTestCase.java
+++ b/integration/mediation-tests/tests-service/src/test/java/org/wso2/carbon/esb/proxyservice/test/secureProxy/SecureProxyUsingPolicyFileInLocalEntryTestCase.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.esb.proxyservice.test.secureProxy;
+
+import org.apache.commons.io.output.ByteArrayOutputStream;
+import org.apache.http.HttpResponse;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import org.wso2.carbon.automation.extensions.servers.httpserver.SimpleHttpClient;
+import org.wso2.esb.integration.common.utils.ESBIntegrationTest;
+
+import java.io.IOException;
+
+/**
+ * Verifies whether a Proxy service can be secured using a policy file stored as a local entry.
+ */
+public final class SecureProxyUsingPolicyFileInLocalEntryTestCase extends ESBIntegrationTest {
+
+    @BeforeClass
+    protected void init() throws Exception {
+        super.init();
+    }
+
+    @Test(groups = "wso2.esb", description = "Verifies whether a Proxy service can be secured using a policy file "
+                                             + "stored as a local entry.")
+    public void testPolicyReferenceInWSDLBindings() throws IOException, InterruptedException {
+        String epr = contextUrls.getServiceUrl() + "/SecureProxyWithPolicyInLocalEntryTestProxy?wsdl";
+        final SimpleHttpClient httpClient = new SimpleHttpClient();
+        HttpResponse response = httpClient.doGet(epr, null);
+        ByteArrayOutputStream bos = new ByteArrayOutputStream();
+        response.getEntity().writeTo(bos);
+        String wsdlResponse = new String(bos.toByteArray());
+        CharSequence expectedTag = "Policy";
+        Assert.assertTrue(wsdlResponse.contains(expectedTag),
+                "Expected response not received. Receive response: " + wsdlResponse);
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void destroy() throws Exception {
+        super.cleanup();
+    }
+
+}

--- a/integration/mediation-tests/tests-service/src/test/resources/artifacts/ESB/server/repository/deployment/server/synapse-configs/default/local-entries/SecurityPolicyLE.xml
+++ b/integration/mediation-tests/tests-service/src/test/resources/artifacts/ESB/server/repository/deployment/server/synapse-configs/default/local-entries/SecurityPolicyLE.xml
@@ -1,0 +1,56 @@
+<!--
+  ~ Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied. See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<localEntry xmlns="http://ws.apache.org/ns/synapse" key="server-policy">
+    <wsp:Policy xmlns:wsp="http://schemas.xmlsoap.org/ws/2004/09/policy"
+                xmlns:wsu="http://docs.oasis-open.org/wss/2004/01/oasis-200401-wss-wssecurity-utility-1.0.xsd"
+                wsu:Id="UTOverTransport">
+        <wsp:ExactlyOne>
+            <wsp:All>
+                <sp:TransportBinding xmlns:sp="http://schemas.xmlsoap.org/ws/2005/07/securitypolicy">
+                    <wsp:Policy>
+                        <sp:TransportToken>
+                            <wsp:Policy>
+                                <sp:HttpsToken RequireClientCertificate="true"/>
+                            </wsp:Policy>
+                        </sp:TransportToken>
+                        <sp:AlgorithmSuite>
+                            <wsp:Policy>
+                                <sp:Basic256/>
+                            </wsp:Policy>
+                        </sp:AlgorithmSuite>
+                        <sp:Layout>
+                            <wsp:Policy>
+                                <sp:Lax/>
+                            </wsp:Policy>
+                        </sp:Layout>
+                    </wsp:Policy>
+                </sp:TransportBinding>
+                <rampart:RampartConfig xmlns:rampart="http://ws.apache.org/rampart/policy">
+                    <rampart:encryptionUser>useReqSigCert</rampart:encryptionUser>
+                    <rampart:timestampPrecisionInMilliseconds>true</rampart:timestampPrecisionInMilliseconds>
+                    <rampart:timestampTTL>300</rampart:timestampTTL>
+                    <rampart:timestampMaxSkew>300</rampart:timestampMaxSkew>
+                    <rampart:tokenStoreClass>org.wso2.carbon.security.util.SecurityTokenStore</rampart:tokenStoreClass>
+                    <rampart:nonceLifeTime>300</rampart:nonceLifeTime>
+                </rampart:RampartConfig>
+            </wsp:All>
+        </wsp:ExactlyOne>
+    </wsp:Policy>
+    <description/>
+</localEntry>

--- a/integration/mediation-tests/tests-service/src/test/resources/artifacts/ESB/server/repository/deployment/server/synapse-configs/default/proxy-services/SecureProxyWithPolicyInLocalEntryTestProxy.xml
+++ b/integration/mediation-tests/tests-service/src/test/resources/artifacts/ESB/server/repository/deployment/server/synapse-configs/default/proxy-services/SecureProxyWithPolicyInLocalEntryTestProxy.xml
@@ -1,0 +1,34 @@
+<!--
+  ~ Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied. See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<proxy xmlns="http://ws.apache.org/ns/synapse" name="SecureProxyWithPolicyInLocalEntryTestProxy" transports="https"
+       startOnLoad="true"
+       trace="disable">
+    <description/>
+    <target>
+        <endpoint>
+            <address uri="http://localhost:9000/services/SimpleStockQuoteService"/>
+        </endpoint>
+        <outSequence>
+            <send/>
+        </outSequence>
+    </target>
+    <policy key="server-policy"/>
+    <parameter name="ScenarioID">scenario1</parameter>
+    <enableSec/>
+</proxy>

--- a/integration/mediation-tests/tests-service/src/test/resources/testng.xml
+++ b/integration/mediation-tests/tests-service/src/test/resources/testng.xml
@@ -94,4 +94,10 @@
             <package name="org.wso2.carbon.esb.tenant.test.*"/>
         </packages>
     </test>
+
+    <test name="Secure-Proxy-Test" preserve-order="true" verbose="2" parallel="false">
+        <classes>
+            <class name="org.wso2.carbon.esb.proxyservice.test.secureProxy.SecureProxyUsingPolicyFileInLocalEntryTestCase"/>
+        </classes>
+    </test>
 </suite>


### PR DESCRIPTION
Adds SecureProxyUsingPolicyFileInLocalEntryTestCase to test if the proxy service is successfully deployed when the police is stored as a local entry.

Moves ESB PR: https://github.com/wso2/product-esb/pull/397

Addresses the issue: https://github.com/wso2/product-ei/issues/1307
