### PR TITLE
Add missing 'in' directory of file connector sample

### DIFF
--- a/distribution/src/assembly/bin.xml
+++ b/distribution/src/assembly/bin.xml
@@ -80,6 +80,7 @@
             <fileMode>644</fileMode>
             <excludes>
                 <exclude>**/*.png</exclude>
+                <exclude>**/*.ignore</exclude>
             </excludes>
         </fileSet>
         <!--copy ballerina connectors-->

--- a/samples/file-connector/resources/in/test.ignore
+++ b/samples/file-connector/resources/in/test.ignore
@@ -1,0 +1,1 @@
+dummy file created to add 'in' directory into git


### PR DESCRIPTION
## Purpose
Add missing 'in' directory of file connector sample

## Goals


## Approach


## User stories
N/A

## Release note
N/A

## Documentation
N/A

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
N/A

## Security checks

## Samples

## Related PRs
https://github.com/wso2/product-ei/pull/1433

## Migrations (if applicable)
N/A

## Test environment
JDK 1.8
 
## Learning
