### PR TITLE
Remove CSRF protection for message store.

### DIFF
--- a/distribution/src/conf/Owasp.CsrfGuard.Carbon.properties
+++ b/distribution/src/conf/Owasp.CsrfGuard.Carbon.properties
@@ -440,6 +440,7 @@ org.owasp.csrfguard.configOverlay.secondsBetweenUpdateChecks = 60
 # please remove the below entry to enable protection for services.
 org.owasp.csrfguard.unprotected.Services=%servletContext%/services/*
 org.owasp.csrfguard.unprotected.Sequences=%servletContext%/carbon/sequences/*
+org.owasp.csrfguard.unprotected.MessageStore=%servletContext%/carbon/message_store/*
 org.owasp.csrfguard.unprotected.Configadmin=%servletContext%/carbon/configadmin/*
 org.owasp.csrfguard.unprotected.Localentries=%servletContext%/carbon/localentries/*
 org.owasp.csrfguard.unprotected.Api=%servletContext%/carbon/api/*


### PR DESCRIPTION
## Purpose
> When opening the name space editor it shows a 403 forbidden error message due to a CSRF error. Purpose is to make the name space editor work.

## Goals
> Remove CSRF protection for message store as it is blocking the name space editor. 

