### PR TITLE
[EI-1448] Fix SwitchIntegrationSubsequenceMatchingTestCase failure

### DIFF
--- a/integration/mediation-tests/tests-mediator-2/src/test/java/org/wso2/carbon/esb/mediator/test/switchMediator/SwitchIntegrationSubsequenceMatchingTestCase.java
+++ b/integration/mediation-tests/tests-mediator-2/src/test/java/org/wso2/carbon/esb/mediator/test/switchMediator/SwitchIntegrationSubsequenceMatchingTestCase.java
@@ -68,7 +68,7 @@ public class SwitchIntegrationSubsequenceMatchingTestCase extends ESBIntegration
     @Test(groups = {"wso2.esb"}, description = "Using switch mediator matching the part of the input at regex")
     public void testMatchSubSequenceAtRegexSwitchMediator3() throws Exception {
         try {
-            axis2Client.sendSimpleStockQuoteRequest(getMainSequenceURL(), null, "MSFT");
+            axis2Client.sendSimpleStockQuoteRequest(getProxyServiceURLHttp("switchMediatorSubsequenceMatchingTestProxy"), null, "MSFT");
             fail("Request must throw a Axis fault");
         } catch (AxisFault expected) {
             Assert.assertEquals(expected.getReason(), ESBTestConstant.INCOMING_MESSAGE_IS_NULL, "Error Message Mismatched");

--- a/integration/mediation-tests/tests-mediator-2/src/test/resources/testng.xml
+++ b/integration/mediation-tests/tests-mediator-2/src/test/resources/testng.xml
@@ -33,18 +33,18 @@
         </packages>
     </test>
 
-    <!--<test name="Switch-mediator-Test" preserve-order="true" verbose="2">-->
-        <!--<packages>-->
-            <!--<package name="org.wso2.carbon.esb.mediator.test.switchMediator"/>-->
-        <!--</packages>-->
-        <!--<classes>-->
-            <!--<class name="org.wso2.carbon.esb.mediator.test.switchMediator.InvokeOnErrorSequenceFromSwitchIntegrationTestCase">-->
-                <!--<methods>-->
-                    <!--<exclude name=".*"/>-->
-                <!--</methods>-->
-            <!--</class>-->
-        <!--</classes>-->
-    <!--</test>-->
+    <test name="Switch-mediator-Test" preserve-order="true" verbose="2">
+        <packages>
+            <package name="org.wso2.carbon.esb.mediator.test.switchMediator"/>
+        </packages>
+        <classes>
+            <class name="org.wso2.carbon.esb.mediator.test.switchMediator.InvokeOnErrorSequenceFromSwitchIntegrationTestCase">
+                <methods>
+                    <exclude name=".*"/>
+                </methods>
+            </class>
+        </classes>
+    </test>
 
     <test name="Validate-mediator-Test" preserve-order="true" verbose="2">
         <packages>


### PR DESCRIPTION
## Purpose
Fix SwitchIntegrationSubsequenceMatchingTestCase related failure which was commented temporarily in https://github.com/wso2/product-ei/pull/1448.

## Approach
Since artifacts are deployed at the start, we need to update the method where proxy service url is taken to refer the related proxy service name. This was added in testMatchSubSequenceAtRegexSwitchMediator2() however missed in testMatchSubSequenceAtRegexSwitchMediator3() which caused a 404.

