### PR TITLE
Fix test failure in RestPostFixUrlTest

### DIFF
--- a/integration/mediation-tests/tests-service/src/test/java/org/wso2/carbon/esb/rest/test/api/RestPostFixUrlTest.java
+++ b/integration/mediation-tests/tests-service/src/test/java/org/wso2/carbon/esb/rest/test/api/RestPostFixUrlTest.java
@@ -11,6 +11,7 @@ import org.wso2.carbon.automation.test.utils.http.client.HttpRequestUtil;
 import org.wso2.carbon.automation.test.utils.http.client.HttpResponse;
 import org.wso2.esb.integration.common.utils.ESBIntegrationTest;
 import org.wso2.carbon.logging.view.stub.types.carbon.LogEvent;
+import org.wso2.esb.integration.common.utils.Utils;
 
 /**
  * Related to Patch Automation https://wso2.org/jira/browse/ESBJAVA-3260 This
@@ -35,33 +36,15 @@ public class RestPostFixUrlTest extends ESBIntegrationTest {
 	@Test(groups = { "wso2.esb" }, description = "Sending a Message Via REST with additional resource")
 	public void testRESTURITemplateWithContextURL() throws Exception {
 
-		/** To check whether the Context URL part "anotherParam" available **/
-		boolean responseInLog = false;
-		/*
-		 * sending request from Client API with additional resource
+		/** To check whether the Context URL part "anotherParam" available.
+		 *  sending request from Client API with additional resource
 		 * "anotherParam" services/client/anotherParam
 		 */
 
-		HttpResponse response = HttpRequestUtil.sendGetRequest(
+		HttpRequestUtil.sendGetRequest(
 				getApiInvocationURL("services/client/anotherParam"), null);
-		
-		LogEvent[] logs = logViewerClient.getAllRemoteSystemLogs();
 
-		for (LogEvent logEvent : logs) {
-			String message = logEvent.getMessage();
-
-			/**
-			 * If "To : /services/test/anotherParam" will be printed in the Log,
-			 * the Target URL is appending the Context URL
-			 **/
-			if (message.contains("anotherParam")) {
-				responseInLog = true;
-				break;
-			}
-
-		}
-
-		Assert.assertFalse(responseInLog,
+		Assert.assertFalse(Utils.checkForLog(logViewerClient, "anotherParam", 10),
 				" Target URL is wrong. It appends the context URL part also.");
 
 	}
@@ -69,32 +52,16 @@ public class RestPostFixUrlTest extends ESBIntegrationTest {
 	@Test(groups = { "wso2.esb" }, description = "Sending a Message Via REST with additional resource")
 	public void testRESTURITemplateWithAdditionalParam() throws Exception {
 
-		/** To check whether the Context URL part "anotherParam" available **/
-		boolean responseInLog = false;
-		/*
-		 * sending request from Client API with additional resource - "anotherParam" 
-		 * & prameter - "foo"
+		/** To check whether the Context URL part "anotherParam" available
+		 *  sending request from Client API with additional resource - "anotherParam"
+		 *  & prameter - "foo"
 		 *  services/client/anotherParam/foo
 		 */
 
-		HttpResponse response = HttpRequestUtil.sendGetRequest(
+		HttpRequestUtil.sendGetRequest(
 				getApiInvocationURL("services/client/anotherParam/foo"), null);
-		
-		LogEvent[] logs = logViewerClient.getAllRemoteSystemLogs();
-
-		for (LogEvent logEvent : logs) {
-			String message = logEvent.getMessage();
-			/**
-			 * "To : /services/test/foo" should be printed in the Log,
-			 **/
-			if (message.contains("/services/test/foo")) {
-				responseInLog = true;
-				break;
-			}
-		}
-
-		Assert.assertTrue(responseInLog,
-				" Target URL is wrong. expected /services/test/foo ");
+		Assert.assertTrue(Utils.checkForLog(logViewerClient, "/services/testAPI/foo", 10),
+				" Target URL is wrong. expected /services/testAPI/foo ");
 
 	}
 

--- a/integration/mediation-tests/tests-service/src/test/resources/artifacts/ESB/synapseconfig/rest/RestPostFixUrl.xml
+++ b/integration/mediation-tests/tests-service/src/test/resources/artifacts/ESB/synapseconfig/rest/RestPostFixUrl.xml
@@ -30,7 +30,7 @@
             <inSequence>
                 <send>
                     <endpoint>
-                        <address statistics="disable" trace="disable" uri="http://localhost:8480/services/test">
+                        <address statistics="disable" trace="disable" uri="http://localhost:8480/services/testAPI">
                             <timeout>
                                 <duration>0</duration>
                                 <responseAction>discard</responseAction>
@@ -53,7 +53,7 @@
             </outSequence>
         </resource>
     </api>
-    <api context="/services/test" name="ServerApi">
+    <api context="/services/testAPI" name="ServerApi">
         <resource methods="GET">
             <inSequence>
                 <log category="INFO" level="full" separator=",">


### PR DESCRIPTION
## Purpose
java.net.SocketTimeoutException: Read timed out exception was thrown when invoke an API. This can be happened the same API was exposed via another test which has run parallely. (This is an intermittent issue.).

## Approach
Therefore, as a solution the API url was renamed to be unique.
Further, in order to avoid intermittent issues related to reading logs, the Utils.checkForLog() method is used.
