### PR TITLE
Fix an intermittent test failure in RestPostFixUrl

### DIFF
--- a/integration/mediation-tests/tests-service/src/test/resources/artifacts/ESB/synapseconfig/rest/RestPostFixUrl.xml
+++ b/integration/mediation-tests/tests-service/src/test/resources/artifacts/ESB/synapseconfig/rest/RestPostFixUrl.xml
@@ -59,6 +59,7 @@
                 <log category="INFO" level="full" separator=",">
                     <property expression="$axis2:REST_URL_POSTFIX" name="To"/>
                 </log>
+                <respond/>
             </inSequence>
             <outSequence>
                 <send/>


### PR DESCRIPTION
## Purpose
This is to fix an intermittent test failure which gives read timeout error when calling an API
The fix is to add a respond mediator

