### PR TITLE
Update readme files to use integrator.sh instead of wso2server.sh

### DIFF
--- a/distribution/src/assembly/bin.xml
+++ b/distribution/src/assembly/bin.xml
@@ -842,6 +842,7 @@
                 <exclude>**/*.bat</exclude>
                 <exclude>**/wrapper.conf</exclude>
                 <exclude>build.xml</exclude>
+                <exclude>README.txt</exclude>
             </excludes>
         </fileSet>
 
@@ -2739,8 +2740,9 @@
 	    <filtered>true</filtered>
         </file>
         <file>
-            <source>target/wso2carbon-core-${carbon.kernel.version}/bin/README.txt</source>
+            <source>src/resources/ei-bin-readme.txt</source>
             <outputDirectory>wso2ei-${pom.version}/bin/</outputDirectory>
+            <destName>README.txt</destName>
             <filtered>true</filtered>
             <fileMode>644</fileMode>
         </file>

--- a/distribution/src/resources/ei-bin-readme.txt
+++ b/distribution/src/resources/ei-bin-readme.txt
@@ -1,0 +1,179 @@
+${product.name} v${product.version}
+
+
+This file explains the usages of all the scripts contained within
+this directory.
+
+1. chpasswd.sh & chpasswd.bat
+    - Utility for changing the passwords of users registered in the CARBON user
+      database
+
+	This script is designed to be used with any databases. Tested with H2, MSSQL and Derby. H2 database is embedded with CARBON.
+	Open a console/shell and run the script from "$CARBON_HOME/bin" directory.
+
+	Usage:
+	# chpasswd.bat/sh --db-url jdbc:h2:/$CARBON_HOME/repository/database/WSO2CARBON_DB
+
+	If the administrator wants to use other databases, he should configure the datasource in the "master-datasources.xml", which is in 
+	"$CARBON_HOME/repository/conf/datasources" directory. This datasource is looked up in "registry.xml" and "user-mgt.xml" as a JNDI resource.
+  	He also needs to keep the drivers of the database inside the "$CARBON_HOME/repository/components/lib" directory.
+
+	For eg,
+	If you need to use MSSQL as your DB,
+	a. Put the MSSQL driver inside the "$CARBON_HOME/repository/components/lib" directory.
+	b. Edit the datasource in master-datasources.xml file with your database's url, username, password and drivername details. 
+
+	eg:
+	<datasource>
+            <name>WSO2_CARBON_DB</name>
+            <description>The datasource used for registry and user manager</description>
+            <jndiConfig>
+                <name>jdbc/WSO2CarbonDB</name>
+            </jndiConfig>
+            <definition type="RDBMS">
+                <configuration>
+                    <url>jdbc:jtds:sqlserver://10.100.1.68:1433/USERDB</url>
+                    <username>USER</username>
+                    <password>USER</password>
+                    <driverClassName>net.sourceforge.jtds.jdbc.Driver</driverClassName>
+                    <maxActive>50</maxActive>
+                    <maxWait>60000</maxWait>
+                    <testOnBorrow>true</testOnBorrow>
+                    <validationQuery>SELECT 1</validationQuery>
+                    <validationInterval>30000</validationInterval>
+                </configuration>
+            </definition>
+        </datasource>
+
+	c. The above datasource is looked up using JNDI in "registry.xml" and "usr-mgt.xml" as below.
+	
+	In registry.xml;
+	
+	eg:
+	<dbConfig name="wso2registry">
+        	<dataSource>jdbc/WSO2CarbonDB</dataSource>
+    	</dbConfig>
+
+	In usr-mgt.xml;
+
+	eg:
+	<Configuration>
+                <AdminRole>admin</AdminRole>
+                <AdminUser>
+                     <UserName>admin</UserName>
+                     <Password>admin</Password>
+                </AdminUser>
+            <EveryOneRoleName>everyone</EveryOneRoleName>
+            <Property name="dataSource">jdbc/WSO2CarbonDB</Property>
+            <Property name="MultiTenantRealmConfigBuilder">org.wso2.carbon.user.core.config.multitenancy.SimpleRealmConfigBuilder</Property>
+        </Configuration>
+
+	d. Open a console/shell and run the script from "$CARBON_HOME/bin" directory. Stop the server before running this script.
+	
+	Usage 01:
+	# chpasswd.bat/sh --db-url jdbc:jtds:sqlserver://10.100.1.68:1433/USERDB --db-driver net.sourceforge.jtds.jdbc.Driver --db-username wso2carbon --db-password wso2carbon --username admin --new-password admin123
+
+	Usage 02: MySQL DB
+    sh chpasswd.sh --db-url jdbc:mysql://mysql.carbon-test.org:3306/userstore  --db-driver com.mysql.jdbc.Driver  --db-username root --db-password root123 --username admin --new-password admin123
+
+	e. Now you can access the admin console with your new password.
+
+2. README.txt
+    - This file
+
+3. version.txt
+    - A simple text file used for storing the product version
+
+4. integrator.sh & integrator.bat
+    - The main script file used for running the server.
+
+    Usage: integrator.sh [commands] [system-properties]
+
+            commands:
+                --start		Start Carbon using nohup
+                --stop		Stop the Carbon server process
+                --restart	Restart the Carbon server process
+                --cleanRegistry Clean registry space.
+                                [CAUTION] All Registry data will be lost..
+                --debug <port>  Start the server in remote debugging mode.
+                                port: The remote debugging port.
+                --help      List all the available commands and system properties
+                --version   The version of the product you are running.
+
+            system-properties:
+
+                -DosgiConsole=[port]
+                                Start Carbon with Equinox OSGi console.
+                                If the optional 'port' parameter is provided, a
+                                telnet port will be opened.
+
+                -DosgiDebugOptions
+                                Start Carbon with OSGi debugging enabled.
+                                Debug options are loaded from the file
+                                repository/conf/etc/osgi-debug.options
+
+                -Dsetup         Clean the Registry and other configuration,
+                                recreate DB, re-populate the configuration,
+                                and start Carbon.
+
+                -DportOffset=<offset>
+                                The number by which all ports defined in the runtime ports will be offset
+
+                -DserverRoles<roles>
+                                A comma separated list of roles. Used in deploying cApps
+
+                -DworkerNode
+                                Set this system property when starting as a worker node.
+		
+                -Dprofile=<profileName>
+				Starts the server as the specified profile. e.g. worker profile.
+
+                -Dtenant.idle.time=<timeInMinutes>
+                                If a tenant is idle for the specified time, tenant will be unloaded. Default tenant idle time is 30mins.
+
+5. wsdl2java.sh & wsdl2java.bat - Tool for generating Java code from WSDLs
+
+6. java2wsdl.sh & java2wsdl.bat - Tool for generating WSDL from Java code
+
+7. build.xml - Build configuration for the ant command.
+      Default task - Running the ant command in this directory, will copy the libraries that are require to run remote registry clients in to the repository/lib directory.
+      createWorker task - removes the front end components from the server runtime.
+      localize task - Generates language bundles in the $CARBON_HOME/repository/components/dropins to be picked at a locale change.
+
+
+	RUNNING INSTRUCTIONS FOR LOCALIZE TASK
+	--------------------------------------
+	(i) Create a directory as resources in your $CARBON_HOME.
+	(ii) Add the relevant resources files of your desired languages in to that directory  by following the proper naming conventions of the ui jars.
+
+		For an example in your resources directory, you can add the resource files as follows.
+
+		<resources directory/folder>
+			|
+			|-----org.wso2.carbon.identity.oauth.ui_4.0.7
+			|            |---------resources_fr.properties
+			|            |---------resources_fr_BE.properties
+			|	     |---------what ever your required language files
+ 			|
+			|------org.wso2.carbon.feature.mgt.ui_4.0.6
+                        |            |-------resources_fr.properties
+                        |            |-------resources_fr_BE.properties
+			|            |-------what ever your required language files
+			|
+			|------create directories/folders for each and every ui bundle
+
+
+	(iii) Navigate to the $CARBON_HOME/bin and run the following command in command prompt. 
+		ant localize
+
+      	This will create the language bundles in the $CARBON_HOME/repository/components/dropins directory.
+
+      	If you want to change the default locations of the resources directory and dropins directory, run the following command.
+		ant localize -Dresources.directory=<your path to the resource directory> -Ddropins.directory=<path to the directory where you want to store generated language bundles>
+
+8. yajsw - contains the wrapper.conf file to run a Carbon server as a windows service using YAJSW (Yet Another Java Service Wrapper)
+
+9. wso2carbon-version.txt
+    - A simple text file used for storing the Carbon kernel version
+
+10. carbondump.sh & carbondump.bat - Carbondump is a tool for collecting all the necessary data from a running Carbon instance at the time of an error. The carbondump generates a zip archive with the collected data, which can be used to analyze your system and determine the problem which caused the error.

--- a/docs/xdoc/admin_guide.xml
+++ b/docs/xdoc/admin_guide.xml
@@ -144,7 +144,7 @@ variable to point to the directory in which Java is installed.
 <h3 id="Standalone">Running WSO2 EI in Standalone Mode</h3>
 <p>
 Now you are all set to start WSO2 EI in the standalone mode. Go to EI_HOME/bin directory and if you are
-on Unix/Linux execute the wso2server.sh shell script or if you are on Windows execute the wso2server.bat
+on Unix/Linux execute the integrator.sh shell script or if you are on Windows execute the integrator.bat
 batch file. This will start the EI and you can see the progress of the startup procedure on the console.
 Please note that server startup may take some time depending on the hardware configuration of your system.
 The very first startup of the EI can take up a few additional seconds since some first time configuration
@@ -273,15 +273,15 @@ EI_HOME/bin/wso2EI-sample.sh (for Unix/Linux) or EI_HOME/bin/wso2EI-sample.bat (
 These launcher scripts take a mandatory argument -sn. Use this argument to specify the sample number.
 </p>
 <p>
-eg: ./wso2EI-sample.sh -sn 250 (This will launch the EI using the Sample 250 configuration)
+eg: ./wso2ei-sample.sh -sn 250 (This will launch the EI using the Sample 250 configuration)
 </p>
 <p>
 The sample configuration files can be found in the EI_HOME/samples/service-bus directory.
 </p>
 <p>
-When launching the EI using the wso2EI-sample.sh/wso2EI-sample.bat scripts a new registry context root
+When launching the EI using the wso2ei-sample.sh/wso2ei-sample.bat scripts a new registry context root
 will be created for storing data and configurations related to that sample. Also note that these launcher
-scripts accept the same set of arguments accepted by the wso2server.sh and wso2server.bat.
+scripts accept the same set of arguments accepted by the integrator.sh and integrator.bat.
 </p>
 
 <h2 id="DirHierarchy">WSO2 EI Directory Hierarchy</h2>
@@ -298,10 +298,10 @@ bin -<br/>
   <br/>
   <ul>
     <li>
-      wso2server.sh/wso2server.bat - Launches WSO2 EI
+      integrator.sh/integrator.bat - Launches WSO2 EI
     </li>
     <li>
-      wso2EI-samples.sh/wso2EI-samples.bat - Launches WSO2 EI using one of the sample configurations
+      wso2ei-samples.sh/wso2ei-samples.bat - Launches WSO2 EI using one of the sample configurations
     </li>
     <li>
       wsdl2java.sh/wsdl2java.bat - Launches the Java stub generation tool for Web Services

--- a/docs/xdoc/configuration_language.xml
+++ b/docs/xdoc/configuration_language.xml
@@ -794,7 +794,7 @@ The Synapse server name is picked up either from the system property
 failing which the hostname of the machine would be used or
 default to 'localhost'. You can give a name to a Synapse server instance by
 specifiying -DSynapseServerName=&lt;ServerName&gt; property when you execute
-the startup script, i.e. wso2server.bat or wso2server.sh. You can also edit the
+the startup script, i.e. integrator.bat or integrator.sh. You can also edit the
 wrapper.conf to do this where Synapse is started as a service. </p>
 
 <p>Each service could define the target for received messages as a named

--- a/docs/xdoc/deployment_guide.xml
+++ b/docs/xdoc/deployment_guide.xml
@@ -395,9 +395,9 @@
 
 	<h4> Running the setup</h4>
 	
-    <p>After successful configurations, run the wso2server.sh or wso2server.bat of master node based on your platform with '-Dsetup' option for the first time start up
+    <p>After successful configurations, run the integrator.sh or integrator.bat of master node based on your platform with '-Dsetup' option for the first time start up
 	to create the database tables, and after creating database tables, do not use '-Dsetup' option when run the server.</p>
-    <pre xml:space="preserve">sh CARBON_HOME/bin/wso2server.sh -Dsetup</pre>
+    <pre xml:space="preserve">sh CARBON_HOME/bin/integrator.sh -Dsetup</pre>
 	
     <p>You don't need to specify the -Dsetup option for EI slave node because we have created DB schema in the previous step.</p>
       <p><strong>  Note: </strong> -Dsetup doesn't work with EI slave node because we share a same database for user manager and  -Dsetup option will try to

--- a/docs/xdoc/faq.xml
+++ b/docs/xdoc/faq.xml
@@ -1040,7 +1040,7 @@
                     How can I change the memory allocation for the WSO2 EI?
                 </h3>
                 <p>
-                    The memory allocation setting are in the wso2server.sh. The user can change the memory allocation
+                    The memory allocation setting are in the integrator.sh. The user can change the memory allocation
                     settings by changing the following configuration.
                 </p>
                 <p>

--- a/docs/xdoc/installation_guide.xml
+++ b/docs/xdoc/installation_guide.xml
@@ -239,8 +239,8 @@
             </li>
             <li>
                 Execute the WSO2 EI start script or the daemon script from the bin
-                directory. e.g. ./wso2server.sh OR ./daemon.sh start OR
-                ./wso2server.sh --console
+                directory. e.g. ./integrator.sh OR ./daemon.sh start OR
+                ./integrator.sh --console
             </li>
             <li>
                 Check your WSO2 EI instance using the URL https://localhost:9443/carbon

--- a/docs/xdoc/quickstart_guide.xml
+++ b/docs/xdoc/quickstart_guide.xml
@@ -180,8 +180,8 @@
       these logs later using the Management Console. Then go to the &lt;EI-home&gt;/bin
       folder and execute the following command.
     </p>
-<pre xml:space="preserve">Linux: ./wso2server.sh
-Windows: wso2server.bat</pre>
+<pre xml:space="preserve">Linux: ./integrator.sh
+Windows: integrator.bat</pre>
     <p>
       You will see the following message on the console to indicate that the
       EI started successfully.

--- a/docs/xdoc/samples_setup_guide.xml
+++ b/docs/xdoc/samples_setup_guide.xml
@@ -340,15 +340,15 @@ oneWayUploadUsingMTOM saves the request message to the disk. </p>
 <h2 id="config">Starting Sample EI Configurations </h2>
 
 <p>To start the WSO2 EI with the sample default configuration, execute the
-wso2server.bat or wso2server.sh script found in the /bin directory. This starts
+integrator.bat or integrator.sh script found in the /bin directory. This starts
 up an instance of the EI using the Synapse and Axis2 configuration files
 located in the conf directory. The samples/service-bus directory contains
 the sample configurations available as synapse_sample_&lt;n&gt;.xml files. To
-start a specific sample configuration of the EI, use the wso2EI-samples.sh or
+start a specific sample configuration of the EI, use the wso2ei-samples.sh or
 wso2EI-samples.bat as follows: </p>
 
-<pre xml:space="preserve">wso2EI-samples.bat -sn &lt;n&gt;
- ./wso2EI-samples.sh -sn &lt;n&gt;</pre>
+<pre xml:space="preserve">wso2ei-samples.bat -sn &lt;n&gt;
+ ./wso2ei-samples.sh -sn &lt;n&gt;</pre>
 
 <h2 id="Setting">Setting up the JMS Listener </h2>
 


### PR DESCRIPTION
## Purpose
Some resource files in product distribution still refer to wso2server.sh/wso2server.bat to run the integrator profile. 
It has to be replaced with integrator.sh/integrator.bat

Resolves ESBJAVA-5282

## Goals
Readme files and other resource files were updated.

## Approach
README.txt in bin directory is getting packed from the carbon-kernel distribution. 
To change the content of it, I have created a new REAME file and placed it inside the resources directory.

## User stories
N/A

## Release note

## Documentation


## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs

## Migrations (if applicable)
N/A

## Test environment
 

## Learning
N/A