### PR TITLE
Fix intermittent test failures in file inbound

### DIFF
--- a/integration/mediation-tests/tests-transport/src/test/java/org/wso2/carbon/esb/file/inbound/transport/test/FileInboundWithDynamicSequenceTestCase.java
+++ b/integration/mediation-tests/tests-transport/src/test/java/org/wso2/carbon/esb/file/inbound/transport/test/FileInboundWithDynamicSequenceTestCase.java
@@ -49,9 +49,8 @@ public class FileInboundWithDynamicSequenceTestCase extends ESBIntegrationTest {
 
     @BeforeClass(alwaysRun = true)
     public void setEnvironment() throws Exception {
-        pathToDir = getClass().getResource(File.separator + "artifacts" + File.separator + "ESB"
-                                           + File.separator + "file" + File.separator + "inbound" + File.separator
-                                           + "transport").getPath();
+        pathToDir = getESBResourceLocation() + File.separator + "file" + File.separator + "inbound" + File.separator
+                                           + "transport";
 
         InboundFileFolder = new File(pathToDir + File.separator + "InboundInFileFolder");
 

--- a/integration/mediation-tests/tests-transport/src/test/java/org/wso2/carbon/esb/file/inbound/transport/test/FtpInboundTransportTest.java
+++ b/integration/mediation-tests/tests-transport/src/test/java/org/wso2/carbon/esb/file/inbound/transport/test/FtpInboundTransportTest.java
@@ -55,10 +55,8 @@ public class FtpInboundTransportTest extends ESBIntegrationTest {
 		String outputFolderName = "ftpout";
 		int FTPPort = 9653;
 
-		pathToFtpDir = getClass().getResource(
-				File.separator + "artifacts" + File.separator + "ESB"
-						+ File.separator + "synapseconfig" + File.separator
-						+ "vfsTransport" + File.separator).getPath();
+		pathToFtpDir = getESBResourceLocation()	+ File.separator + "synapseconfig" + File.separator
+						+ "vfsTransport" + File.separator;
 
 		// Local folder of the FTP server root
 		FTPFolder = new File(pathToFtpDir + "FTP_Location" + File.separator);
@@ -122,7 +120,6 @@ public class FtpInboundTransportTest extends ESBIntegrationTest {
 	@Test(groups = "wso2.esb", description = "Inbound endpoint Reading file in FTP Test Case")
 	public void testInboundEnpointReadFileinFTP() throws Exception {
 
-		addInboundEndpoint(addEndpoint1());
 
 		File sourceFile = new File(pathToFtpDir + File.separator + "test.xml");
 		File targetFolder = new File(FTPFolder + File.separator + "ftpin");
@@ -130,7 +127,8 @@ public class FtpInboundTransportTest extends ESBIntegrationTest {
 
 		try {
 			FileUtils.copyFile(sourceFile, targetFile);
-			boolean isFileRead = Utils.checkForLog(logViewerClient, "<m0:symbol>WSO2</m0:symbol>", 2);
+			addInboundEndpoint(addEndpoint1());
+			boolean isFileRead = Utils.checkForLog(logViewerClient, "<m0:symbol>WSO2</m0:symbol>", 10);
 			Assert.assertTrue(isFileRead, "The XML file is not getting read");
 		} finally {
 			deleteFile(targetFile);
@@ -168,8 +166,6 @@ public class FtpInboundTransportTest extends ESBIntegrationTest {
 	@Test(groups = "wso2.esb", description = "Inbound endpoint invalid FTP username Test Case")
 	public void testInboundInvalidFtpUsername() throws Exception {
 
-		addInboundEndpoint(addEndpoint3());
-
 		File sourceFile = new File(pathToFtpDir + File.separator + "test.xml");
 		File targetFile = new File(FTPFolder + File.separator + "ftpin"
 				+ File.separator + "test.xml");
@@ -178,6 +174,7 @@ public class FtpInboundTransportTest extends ESBIntegrationTest {
 
 		try {
 			FileUtils.copyFile(sourceFile, targetFile);
+			addInboundEndpoint(addEndpoint3());
 			Thread.sleep(2000);
 			Assert.assertTrue(!outFile.exists());
 

--- a/integration/mediation-tests/tests-transport/src/test/java/org/wso2/carbon/esb/file/inbound/transport/test/InboundEndpointContentTypePlainTest.java
+++ b/integration/mediation-tests/tests-transport/src/test/java/org/wso2/carbon/esb/file/inbound/transport/test/InboundEndpointContentTypePlainTest.java
@@ -44,8 +44,7 @@ public class InboundEndpointContentTypePlainTest extends ESBIntegrationTest {
     @BeforeClass(alwaysRun = true)
     public void setEnvironment() throws Exception {
 
-	    pathToFtpDir = FrameworkPathUtil.getSystemResourceLocation() + File.separator + "artifacts" + File.separator
-	                   + "ESB" + File.separator + "synapseconfig" + File.separator + "vfsTransport";
+	    pathToFtpDir = getESBResourceLocation() + File.separator + "synapseconfig" + File.separator + "vfsTransport";
 
         InboundFileFolder = new File(pathToFtpDir + File.separator + "InboundFileFolder");
 
@@ -80,7 +79,7 @@ public class InboundEndpointContentTypePlainTest extends ESBIntegrationTest {
         try {
             FileUtils.copyFile(sourceFile, targetFile);
             addInboundEndpoint(addEndpoint());
-            boolean isFileRead = Utils.checkForLog(logViewerClient, "WSO2 Lanka Pvt Ltd", 2);
+            boolean isFileRead = Utils.checkForLog(logViewerClient, "WSO2 Lanka Pvt Ltd", 10);
             Assert.assertTrue(isFileRead, "The Text file is not getting read");
         } finally {
             deleteFile(targetFile);

--- a/integration/mediation-tests/tests-transport/src/test/java/org/wso2/carbon/esb/file/inbound/transport/test/InboundTransportTest.java
+++ b/integration/mediation-tests/tests-transport/src/test/java/org/wso2/carbon/esb/file/inbound/transport/test/InboundTransportTest.java
@@ -42,9 +42,8 @@ public class InboundTransportTest extends ESBIntegrationTest {
 
     @BeforeClass(alwaysRun = true)
     public void setEnvironment() throws Exception {
-        pathToFtpDir = getClass().getResource(
-                File.separator + "artifacts" + File.separator + "ESB" + File.separator + "synapseconfig"
-                        + File.separator + "vfsTransport" + File.separator).getPath();
+        pathToFtpDir = getESBResourceLocation() + File.separator + "synapseconfig"
+                        + File.separator + "vfsTransport" + File.separator;
 
         inboundFileListeningFolder = new File(pathToFtpDir + File.separator + "inboundFileListeningFolder");
 
@@ -73,9 +72,9 @@ public class InboundTransportTest extends ESBIntegrationTest {
         File sourceFile = new File(pathToFtpDir + File.separator + "test.xml");
         File targetFolder = new File(inboundFileListeningFolder + File.separator + "ContentType");
         File targetFile = new File(targetFolder + File.separator + "test.xml");
-        addInboundEndpoint(addEndpoint1(targetFolder.getAbsolutePath()));
 
         FileUtils.copyFile(sourceFile, targetFile);
+        addInboundEndpoint(addEndpoint1(targetFolder.getAbsolutePath()));
 
         boolean isFileRead = Utils.checkForLog(logViewerClient, "<m0:symbol>WSO2</m0:symbol>", 10);
         Assert.assertTrue(isFileRead, "The XML file is not getting read");
@@ -110,13 +109,13 @@ public class InboundTransportTest extends ESBIntegrationTest {
           description = "Inbound Endpoint invalid File URI Test case")
     public void testInboundEndpointInvalidFileUri() throws Exception {
 
-        addInboundEndpoint(addEndpoint4());
 
         File sourceFile = new File(pathToFtpDir + File.separator + "test.xml");
         File targetFolder = new File(inboundFileListeningFolder + File.separator + "uri");
         File targetFile = new File(targetFolder + File.separator + "test.xml");
         try {
             FileUtils.copyFile(sourceFile, targetFile);
+            addInboundEndpoint(addEndpoint4());
             Thread.sleep(2000);
 
             Assert.assertTrue(targetFile.exists(), "Invalid file processed");
@@ -132,7 +131,6 @@ public class InboundTransportTest extends ESBIntegrationTest {
           description = "Inbound Endpoint File name with special chars URI Test case")
     public void testInboundEndpointFileName_SpecialChars() throws Exception {
 
-        addInboundEndpoint(addEndpoint5());
         boolean fileProcessed = false;
 
         File sourceFile = new File(pathToFtpDir + File.separator + "test.xml");
@@ -140,6 +138,7 @@ public class InboundTransportTest extends ESBIntegrationTest {
         File targetFile = new File(targetFolder + File.separator + "test123@wso2_xml.xml");
         try {
             FileUtils.copyFile(sourceFile, targetFile);
+            addInboundEndpoint(addEndpoint5());
             for (int i = 0; i < 10; i++) {
                 if (!targetFile.exists()) {
                     fileProcessed = true;
@@ -161,13 +160,13 @@ public class InboundTransportTest extends ESBIntegrationTest {
           description = "Inbound Endpoint Content type invalid Test case")
     public void testInboundEndpointContentTypeInvalid() throws Exception {
         logViewerClient.clearLogs();
-        addInboundEndpoint(addEndpoint6());
 
         File sourceFile = new File(pathToFtpDir + File.separator + "test.xml");
         File targetFolder = new File(inboundFileListeningFolder + File.separator + "in");
         File targetFile = new File(targetFolder + File.separator + "invalidContentType.xml");
         try {
             FileUtils.copyFile(sourceFile, targetFile);
+            addInboundEndpoint(addEndpoint6());
             boolean isFileRead = Utils.checkForLog(logViewerClient, "<m0:symbol>WSO2</m0:symbol>", 10);
             Assert.assertTrue(isFileRead, "The XML file is not getting read");
 
@@ -183,13 +182,13 @@ public class InboundTransportTest extends ESBIntegrationTest {
           description = "Inbound Endpoint Content type not specified Test case")
     public void testInboundEndpointContentTypeNotSpecified() throws Exception {
 
-        addInboundEndpoint(addEndpoint7());
         boolean fileProcessed = false;
         File sourceFile = new File(pathToFtpDir + File.separator + "test.xml");
         File targetFolder = new File(inboundFileListeningFolder + File.separator + "in");
         File targetFile = new File(targetFolder + File.separator + "in.xml");
         try {
             FileUtils.copyFile(sourceFile, targetFile);
+            addInboundEndpoint(addEndpoint7());
             for (int i = 0; i < 10; i++) {
                 if (!targetFile.exists()) {
                     fileProcessed = true;
@@ -210,7 +209,6 @@ public class InboundTransportTest extends ESBIntegrationTest {
           description = "Inbound Endpoint move after process Test case")
     public void testInboundEndpointMoveAfterProcess() throws Exception {
 
-        addInboundEndpoint(addEndpoint8());
         boolean fileProcessed = false;
         File sourceFile = new File(pathToFtpDir + File.separator + "test.xml");
         File targetFolder = new File(inboundFileListeningFolder + File.separator + "move");
@@ -226,6 +224,7 @@ public class InboundTransportTest extends ESBIntegrationTest {
 
         try {
             FileUtils.copyFile(sourceFile, targetFile);
+            addInboundEndpoint(addEndpoint8());
             for (int i = 0; i < 10; i++) {
                 if (!targetFile.exists()) {
                     fileProcessed = true;

--- a/integration/mediation-tests/tests-transport/src/test/resources/testng.xml
+++ b/integration/mediation-tests/tests-transport/src/test/resources/testng.xml
@@ -109,11 +109,11 @@
             </packages>
         </test>-->
 
-    <!--<test name="inbound-File Transport-Test" preserve-order="true" verbose="2">-->
-        <!--<packages>-->
-            <!--<package name="org.wso2.carbon.esb.file.inbound.transport.test"/>-->
-        <!--</packages>-->
-    <!--</test>-->
+    <test name="inbound-File Transport-Test" preserve-order="true" verbose="2">
+        <packages>
+            <package name="org.wso2.carbon.esb.file.inbound.transport.test"/>
+        </packages>
+    </test>
 
     <test name="inbound-Generic Transport-Test" preserve-order="true" verbose="2">
         <packages>


### PR DESCRIPTION
## Purpose
> Some tests in file inbound transport are intermittently failing. Purpose is to avoid intermittent failures due to timeouts.

## Goals
> Increased the time outs which are not static timeouts. Changed the place where the inboundEndpoint is added. Added it after copyFile is executed.

Related issue https://github.com/wso2/product-ei/issues/1445
