### PR TITLE
Update integrator executable scripts

### DIFF
--- a/distribution/src/scripts/integrator.bat
+++ b/distribution/src/scripts/integrator.bat
@@ -1,4 +1,4 @@
-@echo off
+﻿@echo off
 
 REM ---------------------------------------------------------------------------
 REM   Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
@@ -25,4 +25,106 @@ rem
 rem   JAVA_OPTS       (Optional) Java runtime options used when the commands
 rem                   is executed.
 rem ---------------------------------------------------------------------------
-..\wso2\ballerina\bin\ballerina.bat run %1
+
+rem ----- if JAVA_HOME is not set we're not happy ------------------------------
+
+:checkJava
+
+if "%JAVA_HOME%" == "" goto noJavaHome
+if not exist "%JAVA_HOME%\bin\java.exe" goto noJavaHome
+goto checkServer
+
+:noJavaHome
+echo "You must set the JAVA_HOME variable before running Ballerina."
+goto end
+
+rem ----- set BALLERINA_HOME ----------------------------
+:checkServer
+rem %~sdp0 is expanded pathname of the current script under NT with spaces in the path removed
+rem set BALLERINA_HOME=%~sdp0..
+set BALLERINA_HOME=%~sdp0..\wso2\ballerina
+SET curDrive=%cd:~0,1%
+SET ballerinaDrive=%BALLERINA_HOME:~0,1%
+if not "%curDrive%" == "%ballerinaDrive%" %ballerinaDrive%:
+
+goto updateClasspath
+
+:noServerHome
+echo BALLERINA_HOME is set incorrectly or BALLERINA could not be located. Please set BALLERINA_HOME.
+goto end
+
+rem ----- update classpath -----------------------------------------------------
+:updateClasspath
+
+setlocal EnableDelayedExpansion
+set BALLERINA_CLASSPATH=
+FOR %%C in ("%BALLERINA_HOME%\bre\lib\bootstrap\*.jar") DO set BALLERINA_CLASSPATH=!BALLERINA_CLASSPATH!;"%BALLERINA_HOME%\bre\lib\bootstrap\%%~nC%%~xC"
+
+set BALLERINA_CLASSPATH="%JAVA_HOME%\lib\tools.jar";%BALLERINA_CLASSPATH%;
+
+FOR %%D in ("%BALLERINA_HOME%\bre\lib\*.jar") DO set BALLERINA_CLASSPATH=!BALLERINA_CLASSPATH!;"%BALLERINA_HOME%\bre\lib\%%~nD%%~xD"
+
+rem ----- Process the input command -------------------------------------------
+
+rem Slurp the command line arguments. This loop allows for an unlimited number
+rem of arguments (up to the command line limit, anyway).
+
+:setupArgs
+if ""%1""==""debug""    goto commandDebug
+if ""%1""==""-debug""   goto commandDebug
+if ""%1""==""--debug""  goto commandDebug
+if not ""%1""=="""" goto doneStart
+goto noBalFile
+
+
+rem TODO: Add build command once it is available in ballerina
+
+rem ----- commandDebug ---------------------------------------------------------
+:commandDebug
+shift
+set DEBUG_PORT=%1
+if "%DEBUG_PORT%"=="" goto noDebugPort
+if not "%JAVA_OPTS%"=="" echo Warning !!!. User specified JAVA_OPTS will be ignored, once you give the --debug option.
+set JAVA_OPTS=-Xdebug -Xnoagent -Djava.compiler=NONE -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=%DEBUG_PORT%
+shift
+set BAL_LOCATION=%1
+if "%BAL_LOCATION%"=="" goto noBalFile
+set COMMANDLINE=run %BAL_LOCATION%
+
+echo Please start the remote debugging client to continue...
+goto runServer
+
+:noDebugPort
+echo Please specify the debug port after the --debug option
+goto end
+
+:doneStart
+set COMMANDLINE=run %1
+if "%OS%"=="Windows_NT" @setlocal
+if "%OS%"=="WINNT" @setlocal
+goto runServer
+
+:noBalFile
+echo Please specify the directory which contains program files or the location of compiled ballerina program
+goto end
+
+rem ----------------- Execute The Requested Command ----------------------------
+
+:runServer
+
+set CMD=%*
+
+rem ---------- Add jars to classpath ----------------
+
+set BALLERINA_CLASSPATH=.\bre\lib\bootstrap;%BALLERINA_CLASSPATH%
+
+set JAVA_ENDORSED=".\bre\lib\bootstrap\endorsed";"%JAVA_HOME%\jre\lib\endorsed";"%JAVA_HOME%\lib\endorsed"
+
+set CMD_LINE_ARGS=-Xbootclasspath/a:%BALLERINA_XBOOTCLASSPATH% -Xms256m -Xmx1024m -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath="%BALLERINA_HOME%\heap-dump.hprof"  -Dcom.sun.management.jmxremote -classpath %BALLERINA_CLASSPATH% %JAVA_OPTS% -Djava.endorsed.dirs=%JAVA_ENDORSED%  -Dballerina.home="%BALLERINA_HOME%"  -Djava.command="%JAVA_HOME%\bin\java" -Djava.opts="%JAVA_OPTS%" -Djava.io.tmpdir="%BALLERINA_HOME%\tmp" -Denable.nonblocking=false -Dtransports.netty.conf="%BALLERINA_HOME%\bre\conf\netty-transports.yml" -Dfile.encoding=UTF8 -Dballerina.version=0.95.1 -Djava.util.logging.config.file="%BALLERINA_HOME%\bre\conf\logging.properties" -Djava.util.logging.manager="org.ballerinalang.logging.BLogManager"
+
+
+:runJava
+"%JAVA_HOME%\bin\java" %CMD_LINE_ARGS% org.ballerinalang.launcher.Main %COMMANDLINE%
+
+:end
+

--- a/distribution/src/scripts/integrator.sh
+++ b/distribution/src/scripts/integrator.sh
@@ -24,5 +24,207 @@
 #   JAVA_OPTS           (Optional) Java runtime options used when the commands
 #                       is executed.
 #
+# NOTE: Borrowed generously from Apache Tomcat startup scripts.
 # -----------------------------------------------------------------------------
-sh ./../wso2/ballerina/bin/ballerina run $1
+
+# OS specific support.  $var _must_ be set to either true or false.
+#ulimit -n 100000
+BASE_DIR=$PWD
+cygwin=false;
+darwin=false;
+os400=false;
+mingw=false;
+case "`uname`" in
+CYGWIN*) cygwin=true;;
+MINGW*) mingw=true;;
+OS400*) os400=true;;
+Darwin*) darwin=true
+        if [ -z "$JAVA_HOME" ] ; then
+		   if [ -z "$JAVA_VERSION" ] ; then
+			 JAVA_HOME=$(/usr/libexec/java_home)
+           else
+             echo "Using Java version: $JAVA_VERSION"
+			 JAVA_HOME=$(/usr/libexec/java_home -v $JAVA_VERSION)
+		   fi
+	    fi
+        ;;
+esac
+
+# resolve links - $0 may be a softlink
+PRG="$0"
+
+while [ -h "$PRG" ]; do
+  ls=`ls -ld "$PRG"`
+  link=`expr "$ls" : '.*-> \(.*\)$'`
+  if expr "$link" : '.*/.*' > /dev/null; then
+    PRG="$link"
+  else
+    PRG=`dirname "$PRG"`/"$link"
+  fi
+done
+
+# Get standard environment variables
+PRGDIR=`dirname "$PRG"`
+
+
+echo "$PRGDIR"
+
+# set BALLERINA_HOME
+BALLERINA_HOME=`cd "$PRGDIR/../wso2/ballerina" ; pwd`
+
+echo "$BALLERINA_HOME"
+
+# For Cygwin, ensure paths are in UNIX format before anything is touched
+if $cygwin; then
+  [ -n "$JAVA_HOME" ] && JAVA_HOME=`cygpath --unix "$JAVA_HOME"`
+  [ -n "$BALLERINA_HOME" ] && BALLERINA_HOME=`cygpath --unix "$BALLERINA_HOME"`
+fi
+
+# For OS400
+if $os400; then
+  # Set job priority to standard for interactive (interactive - 6) by using
+  # the interactive priority - 6, the helper threads that respond to requests
+  # will be running at the same priority as interactive jobs.
+  COMMAND='chgjob job('$JOBNAME') runpty(6)'
+  system $COMMAND
+
+  # Enable multi threading
+  QIBM_MULTI_THREADED=Y
+  export QIBM_MULTI_THREADED
+fi
+
+# For Migwn, ensure paths are in UNIX format before anything is touched
+if $mingw ; then
+  [ -n "$BALLERINA_HOME" ] &&
+    BALLERINA_HOME="`(cd "$BALLERINA_HOME"; pwd)`"
+  [ -n "$JAVA_HOME" ] &&
+    JAVA_HOME="`(cd "$JAVA_HOME"; pwd)`"
+fi
+
+if [ -z "$JAVACMD" ] ; then
+  if [ -n "$JAVA_HOME"  ] ; then
+    if [ -x "$JAVA_HOME/jre/sh/java" ] ; then
+      # IBM's JDK on AIX uses strange locations for the executables
+      JAVACMD="$JAVA_HOME/jre/sh/java"
+    else
+      JAVACMD="$JAVA_HOME/bin/java"
+    fi
+  else
+    JAVACMD=java
+  fi
+fi
+
+if [ ! -x "$JAVACMD" ] ; then
+  echo "Error: JAVA_HOME is not defined correctly."
+  exit 1
+fi
+
+# if JAVA_HOME is not set we're not happy
+if [ -z "$JAVA_HOME" ]; then
+  echo "You must set the JAVA_HOME variable before running Ballerina."
+  exit 1
+fi
+
+# ----- Process the input command ----------------------------------------------
+
+for c in "$@"
+do
+    if [ "$c" = "--debug" ] || [ "$c" = "-debug" ] || [ "$c" = "debug" ]; then
+          CMD="--debug"
+    elif [ "$CMD" = "--debug" ] && [ -z "$PORT" ]; then
+          PORT=$c
+    elif [ "$c" = "--build" ] || [ "$c" = "-build" ] || [ "$c" = "build" ]; then
+         CMD="--build"
+    elif [ "$CMD" = "--build" ] && [ -z "$LOCATION" ]; then
+          LOCATION=$c
+    else
+          LOCATION=$c
+    fi
+done
+
+if [ -z "$LOCATION" ]; then
+    echo "Please specify the directory which contains program files or the location of compiled ballerina program"
+    exit 1
+fi
+
+if [ "$CMD" = "--debug" ]; then
+  if [ "$PORT" = "" ]; then
+    echo "Please specify the debug port after the --debug option"
+    exit 1
+  fi
+  if [ -n "$JAVA_OPTS" ]; then
+    echo "Warning !!!. User specified JAVA_OPTS will be ignored, once you give the --debug option."
+  fi
+  JAVA_OPTS="-Xdebug -Xnoagent -Djava.compiler=NONE -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=$PORT"
+  echo "Please start the remote debugging client to continue..."
+  COMMANDLINE = "$LOCATION"
+elif [ "$CMD" = "--build" ]; then
+  # TODO: Modify after feature it is available in ballerina
+  echo "Building the source is currently not available, will be available when it is available in ballerina distribution"
+  exit 1
+  if [ "$LOCATION" = "" ]; then
+    echo "Please specify the directory which contains source program files after --build option"
+    exit 1
+  fi
+  COMMANDLINE = "build $LOCATION"
+  echo "Building source files located at $LOCATION"
+else
+  COMMANDLINE="run $LOCATION"
+fi
+
+BALLERINA_XBOOTCLASSPATH=""
+for f in "$BALLERINA_HOME"/bre/lib/bootstrap/xboot/*.jar
+do
+    if [ "$f" != "$BALLERINA_HOME/bre/lib/bootstrap/xboot/*.jar" ];then
+        BALLERINA_XBOOTCLASSPATH="$BALLERINA_XBOOTCLASSPATH":$f
+    fi
+done
+
+JAVA_ENDORSED_DIRS="$BALLERINA_HOME/bin/bootstrap/endorsed":"$JAVA_HOME/jre/lib/endorsed":"$JAVA_HOME/lib/endorsed"
+
+BALLERINA_CLASSPATH=""
+if [ -e "$BALLERINA_HOME/bre/lib/bootstrap/tools.jar" ]; then
+    BALLERINA_CLASSPATH="$JAVA_HOME/lib/tools.jar"
+fi
+
+for f in "$BALLERINA_HOME"/bre/lib/bootstrap/*.jar
+do
+    if [ "$f" != "$BALLERINA_HOME/bre/lib/bootstrap/*.jar" ];then
+        BALLERINA_CLASSPATH="$BALLERINA_CLASSPATH":$f
+    fi
+done
+
+for j in "$BALLERINA_HOME"/bre/lib/*.jar
+do
+    BALLERINA_CLASSPATH="$BALLERINA_CLASSPATH":$j
+done
+
+# For Cygwin, switch paths to Windows format before running java
+if $cygwin; then
+  JAVA_HOME=`cygpath --absolute --windows "$JAVA_HOME"`
+  BALLERINA_HOME=`cygpath --absolute --windows "$BALLERINA_HOME"`
+  CLASSPATH=`cygpath --path --windows "$CLASSPATH"`
+  JAVA_ENDORSED_DIRS=`cygpath --path --windows "$JAVA_ENDORSED_DIRS"`
+  BALLERINA_CLASSPATH=`cygpath --path --windows "$BALLERINA_CLASSPATH"`
+  BALLERINA_XBOOTCLASSPATH=`cygpath --path --windows "$BALLERINA_XBOOTCLASSPATH"`
+fi
+
+# ----- Execute The Requested Command -----------------------------------------
+$JAVACMD \
+	-Xbootclasspath/a:"$BALLERINA_XBOOTCLASSPATH" \
+	-Xms256m -Xmx1024m \
+	-XX:+HeapDumpOnOutOfMemoryError \
+	-XX:HeapDumpPath="$BALLERINA_HOME/heap-dump.hprof" \
+	$JAVA_OPTS \
+	-classpath "$BALLERINA_CLASSPATH" \
+	-Djava.endorsed.dirs="$JAVA_ENDORSED_DIRS" \
+	-Dballerina.home=$BALLERINA_HOME \
+	-Dballerina.version=0.95.1 \
+	-Djava.util.logging.config.file="$BALLERINA_HOME/bre/conf/logging.properties" \
+	-Djava.util.logging.manager="org.ballerinalang.logging.BLogManager" \
+	-Dtransports.netty.conf="$BALLERINA_HOME/bre/conf/netty-transports.yml" \
+	-Djava.io.tmpdir="$BALLERINA_HOME/tmp" \
+	-Denable.nonblocking=false \
+	-Djava.security.egd=file:/dev/./urandom \
+	-Dfile.encoding=UTF8 \
+	org.ballerinalang.launcher.Main $COMMANDLINE


### PR DESCRIPTION
## Purpose
Improve integrator.sh and integrator.bat to handle unhappy paths (ex: no .balx file given).
Pointing to ballerina scripts is not working when try to run from outside of the bin directory.
Related to #1544

## Goals
Scripts were modified in a way that it can be executed from anywhere.

## Approach
integrator.sh and integrator.bat is re-written by extracting content from ballerina execution scripts. 

## User stories

## Release note

## Documentation
N/A

## Training

## Certification
N/A

## Marketing
N/A

## Automation tests
## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples

## Related PRs

## Migrations (if applicable)

## Test environment
MacOSX, Windows 7, JDK 1.8
 
## Learning
