### PR TITLE
Fix intermittent test failures

### DIFF
--- a/integration/dataservice-hosting-tests/tests-integration/tests/src/test/java/org/wso2/ei/dataservice/integration/test/DSSIntegrationTest.java
+++ b/integration/dataservice-hosting-tests/tests-integration/tests/src/test/java/org/wso2/ei/dataservice/integration/test/DSSIntegrationTest.java
@@ -21,6 +21,7 @@ import org.apache.axiom.attachments.ByteArrayDataSource;
 import org.apache.axiom.om.OMElement;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
+import org.wso2.carbon.authenticator.stub.LoginAuthenticationExceptionException;
 import org.wso2.carbon.automation.engine.context.AutomationContext;
 import org.wso2.carbon.automation.engine.context.TestUserMode;
 import org.wso2.carbon.automation.engine.context.beans.Tenant;
@@ -28,12 +29,18 @@ import org.wso2.carbon.automation.engine.context.beans.User;
 import org.wso2.carbon.automation.extensions.XPathConstants;
 import org.wso2.carbon.automation.test.utils.common.TestConfigurationProvider;
 import org.wso2.carbon.integration.common.utils.LoginLogoutClient;
+import org.wso2.carbon.integration.common.utils.exceptions.AutomationUtilException;
 import org.wso2.ei.dataservice.integration.common.utils.DSSTestCaseUtils;
 import org.wso2.ei.dataservice.integration.common.utils.SqlDataSourceUtil;
+import org.wso2.esb.integration.common.utils.ESBTestConstant;
+import org.xml.sax.SAXException;
 
 import javax.activation.DataHandler;
+import javax.xml.stream.XMLStreamException;
 import javax.xml.xpath.XPathExpressionException;
 import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
 import java.util.List;
 
 public abstract class DSSIntegrationTest {
@@ -169,5 +176,17 @@ public abstract class DSSIntegrationTest {
                 new Object[]{TestUserMode.SUPER_TENANT_ADMIN},
 //                new Object[]{TestUserMode.TENANT_ADMIN},
         };
+    }
+
+    protected void reloadSessionCookie(TestUserMode userType) throws Exception {
+        dssContext = new AutomationContext(PRODUCT_NAME, userType);
+        sessionCookie = login(dssContext);
+    }
+
+    protected String login(AutomationContext dssContext)
+            throws IOException, XPathExpressionException, URISyntaxException, SAXException, XMLStreamException,
+            LoginAuthenticationExceptionException, AutomationUtilException {
+        LoginLogoutClient loginLogoutClient = new LoginLogoutClient(dssContext);
+        return loginLogoutClient.login();
     }
 }

--- a/integration/dataservice-hosting-tests/tests-integration/tests/src/test/java/org/wso2/ei/dataservice/integration/test/jira/issues/CARBON15262JsonGsonFormatterTenantModeTest.java
+++ b/integration/dataservice-hosting-tests/tests-integration/tests/src/test/java/org/wso2/ei/dataservice/integration/test/jira/issues/CARBON15262JsonGsonFormatterTenantModeTest.java
@@ -65,6 +65,7 @@ public class CARBON15262JsonGsonFormatterTenantModeTest extends DSSIntegrationTe
 	}
 
 	@AfterClass(alwaysRun = true) public void destroy() throws Exception {
+		super.reloadSessionCookie(TestUserMode.TENANT_ADMIN);
 		deleteService(serviceName);
 		cleanup();
 	}

--- a/integration/mediation-tests/tests-transport/src/test/java/org/wso2/carbon/esb/ssl/test/DynamicSSLProfilesPTTListenerTestCase.java
+++ b/integration/mediation-tests/tests-transport/src/test/java/org/wso2/carbon/esb/ssl/test/DynamicSSLProfilesPTTListenerTestCase.java
@@ -16,6 +16,7 @@
 
 package org.wso2.carbon.esb.ssl.test;
 
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterTest;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -132,8 +133,9 @@ public class DynamicSSLProfilesPTTListenerTestCase extends ESBIntegrationTest {
     }
 
     @SetEnvironment(executionEnvironments = { ExecutionEnvironment.STANDALONE })
-    @AfterTest(alwaysRun = true)
+    @AfterClass(alwaysRun = true)
     public void destroy() throws Exception {
+        super.reloadSessionCookie();
         deleteProxyService(proxyService);
         super.cleanup();
         if (serverManager != null) {


### PR DESCRIPTION
## Purpose
> Fix intermittent test failures happening in jenkins.
Failed tests : CARBON15262JsonGsonFormatterTenantModeTest and DynamicSSLProfilesPTTListenerTestCase

Here we are updating the sessionCookie variable before deleting the service as it throws an unauthorized error when trying to delete the service.

