### PR TITLE
Disable testcases which fail when killing processes

### DIFF
--- a/integration/mediation-tests/tests-transport/src/test/resources/testng.xml
+++ b/integration/mediation-tests/tests-transport/src/test/resources/testng.xml
@@ -113,6 +113,13 @@
         <packages>
             <package name="org.wso2.carbon.esb.file.inbound.transport.test"/>
         </packages>
+        <classes>
+            <class name="org.wso2.carbon.esb.file.inbound.transport.test.FtpInboundTransportTest">
+                <methods>
+                    <exclude name=".*"/>
+                </methods>
+            </class>
+        </classes>
     </test>
 
     <test name="inbound-Generic Transport-Test" preserve-order="true" verbose="2">


### PR DESCRIPTION
## Purpose
The following tests are failing when it tries to kill processes running on a given port in Jenkins.

org.wso2.carbon.esb.file.inbound.transport.test.FtpInboundTransportTest.runFTPServerForInboundTest
org.wso2.carbon.esb.file.inbound.transport.test.FtpInboundTransportTest.stopFTPServerForInboundTest

Therefore, for the moment the tests are disabled.

This issue is tracked in [1]

[1] https://github.com/wso2/product-ei/issues/1468

