### PR TITLE
Add broker execution script for windows

### DIFF
--- a/distribution/src/assembly/bin.xml
+++ b/distribution/src/assembly/bin.xml
@@ -128,6 +128,12 @@
             <filtered>true</filtered>
         </file>
         <file>
+            <source>src/scripts/broker.bat</source>
+            <outputDirectory>bin/</outputDirectory>
+            <fileMode>755</fileMode>
+            <filtered>true</filtered>
+        </file>
+        <file>
             <source>src/conf/broker/deployment.yaml</source>
             <outputDirectory>conf/broker/</outputDirectory>
             <fileMode>644</fileMode>

--- a/distribution/src/scripts/broker.bat
+++ b/distribution/src/scripts/broker.bat
@@ -1,29 +1,74 @@
 @echo off
+
 REM ---------------------------------------------------------------------------
-REM        Copyright 2005-2009 WSO2, Inc. http://www.wso2.org
+REM  Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
 REM
-REM  Licensed under the Apache License, Version 2.0 (the "License");
-REM  you may not use this file except in compliance with the License.
+REM  WSO2 Inc. licenses this file to you under the Apache License,
+REM  Version 2.0 (the "License"); you may not use this file except
+REM  in compliance with the License.
 REM  You may obtain a copy of the License at
 REM
 REM      http://www.apache.org/licenses/LICENSE-2.0
 REM
-REM  Unless required by applicable law or agreed to in writing, software
-REM  distributed under the License is distributed on an "AS IS" BASIS,
-REM  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-REM  See the License for the specific language governing permissions and
-REM  limitations under the License.
+REM  Unless required by applicable law or agreed to in writing,
+REM  software distributed under the License is distributed on an
+REM  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+REM  KIND, either express or implied. See the License for the
+REM  specific language governing permissions and limitations
+REM  under the License.
+REM
+REM ---------------------------------------------------------------------------
 
-rem ---------------------------------------------------------------------------
-rem Main Script for WSO2 Message Broker
-rem
-rem Environment Variable Prequisites
-rem
-rem
-rem   JAVA_HOME       Must point at your Java Development Kit installation.
-rem
-rem   JAVA_OPTS       (Optional) Java runtime options used when the commands
-rem                   is executed.
-rem ---------------------------------------------------------------------------
+rem ----- if JAVA_HOME is not set we're not happy ------------------------------
+:checkJava
+if "%JAVA_HOME%" == "" goto noJavaHome
+if not exist "%JAVA_HOME%\bin\java.exe" goto noJavaHome
+goto checkServer
 
-rem --------- NOTE: This needs to be implemented
+:noJavaHome
+echo "You must set the JAVA_HOME variable before running the Broker"
+goto end
+
+rem ----- set MESSAGE_BROKER_HOME ----------------------------
+:checkServer
+rem %~sdp0 is expanded pathname of the current script under NT with spaces in the path removed
+set MESSAGE_BROKER_HOME=%~sdp0..\wso2\broker
+SET curDrive=%cd:~0,1%
+SET brokerDrive=%MESSAGE_BROKER_HOME:~0,1%
+if not "%curDrive%" == "%brokerDrive%" %brokerDrive%:
+
+goto updateClasspath
+
+:noServerHome
+echo MESSAGE_BROKER_HOME is set incorrectly or MESSAGE_BROKER could not be located. Please set MESSAGE_BROKER_HOME.
+goto end
+
+rem ----- update classpath -----------------------------------------------------
+:updateClasspath
+setlocal EnableDelayedExpansion
+set MESSAGE_BROKER_CLASSPATH=
+FOR %%C in ("%MESSAGE_BROKER_HOME%\lib\*.jar") DO set MESSAGE_BROKER_CLASSPATH=!MESSAGE_BROKER_CLASSPATH!;"%MESSAGE_BROKER_HOME%\lib\%%~nC%%~xC"
+
+rem ----- Process the input command -------------------------------------------
+:setupArgs
+if ""%1""=="""" goto doneStart
+
+:doneStart
+if "%OS%"=="Windows_NT" @setlocal
+if "%OS%"=="WINNT" @setlocal
+goto runServer
+
+rem ----------------- Execute The Requested Command ----------------------------
+
+:runServer
+set CMD=%*
+
+rem ---------- Add jars to classpath ----------------
+set MESSAGE_BROKER_CLASSPATH=.\lib;%MESSAGE_BROKER_CLASSPATH%
+
+set CMD_LINE_ARGS=-Xbootclasspath/a:%MESSAGE_BROKER_XBOOTCLASSPATH% -Xms256m -Xmx1024m -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath="%MESSAGE_BROKER_HOME%\heap-dump.hprof" -classpath %MESSAGE_BROKER_CLASSPATH% %JAVA_OPTS% -Dmessage.broker.home="%MESSAGE_BROKER_HOME%" -Djava.command="%JAVA_HOME%\bin\java" -Djava.opts="%JAVA_OPTS%" -Dlog4j.configuration="file:%MESSAGE_BROKER_HOME%\conf\log4j.properties" -Dbroker.config="%MESSAGE_BROKER_HOME%\conf\broker.yaml" -Dbroker.classpath=%MESSAGE_BROKER_CLASSPATH% -Dfile.encoding=UTF8
+
+:runJava
+"%JAVA_HOME%\bin\java" %CMD_LINE_ARGS% org.wso2.broker.Main %CMD%
+
+:end

--- a/distribution/src/scripts/integrator.bat
+++ b/distribution/src/scripts/integrator.bat
@@ -1,4 +1,4 @@
-﻿@echo off
+@echo off
 
 REM ---------------------------------------------------------------------------
 REM   Copyright (c) 2017, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.


### PR DESCRIPTION
## Purpose
Add broker.bat into EI7 distribution.
Resolves #1534 

## Goals
Add missing broker.bat file.

## Approach
Took broker.bat file from following and modified the BROKER_HOME pointing to correct location for broker in EI7 pack.

https://github.com/MaryamZi/message-broker/blob/93b14fa5d8e56da2bbcb3766285386eee1e2f806/modules/launcher/src/main/resources/broker.bat 

## User stories

## Release note

## Documentation
To start the broker profile in windows use the following command
```
> broker.bat
```
## Training

## Certification

## Marketing

## Automation tests

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples

## Related PRs

## Migrations (if applicable)

## Test environment
Windows 7
 
## Learning
