### PR TITLE
Add documentation links to readme.txt file of distribution

### DIFF
--- a/distribution/README.txt
+++ b/distribution/README.txt
@@ -64,6 +64,19 @@ Contains configuration files specific to EI.
  Contains ballerina runtime related files/folders.
 
 
+Documentation
+=============
+
+For Enterprise Integrator 7 documentation, please refer to:
+https://github.com/wso2/product-ei/blob/7.0.x/README.md
+
+For more information about Message Broker, please visit:
+https://github.com/wso2/message-broker/blob/master/README.md
+
+More information on Ballerina can be found from:
+https://ballerinalang.org/docs/
+
+
 Known issues of WSO2 EI @product.version@
 ==================================
 


### PR DESCRIPTION
## Purpose
Add documentation links to readme.txt file of distribution
Resolves #1538 

## Goals
Add documentation links of message broker, integrator, and ballerina into EI7 distribution readme.txt.

## Approach
Documentation links were added to the readme.txt file

## User stories

## Release note

## Documentation
N/A
## Training


## Certification

## Marketing

## Automation tests
## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples

## Related PRs

## Migrations (if applicable)
## Test environment
 
## Learning