### PR TITLE
Remove Axis2-Transport-RabbitMq-amqp_2.0.0_ from Instrumentation

### DIFF
--- a/integration/mediation-tests/coverage-report/instrumentation.txt
+++ b/integration/mediation-tests/coverage-report/instrumentation.txt
@@ -53,4 +53,3 @@ synapse-tasks_
 synapse-vfs-transport_
 org.wso2.carbon.mediator.transform_
 org.apache.axis2.transport.rabbitmq_
-axis2-transport-rabbitmq-amqp_2.0.0_


### PR DESCRIPTION
## Purpose
Removed duplicated instrumentation Axis2-Transport-RabbitMq-amqp_2.0.0_ to prevent below error

Caused by: java.lang.IllegalStateException: Can't add different class with same name: org/apache/axis2/transport/rabbitmq/RabbitMQConnectionFactory
	at org.jacoco.core.analysis.CoverageBuilder.visitCoverage(CoverageBuilder.java:106)
	at org.jacoco.core.analysis.Analyzer$1.visitEnd(Analyzer.java:92)
	at org.objectweb.asm.ClassVisitor.visitEnd(ClassVisitor.java:317)
	at org.jacoco.core.internal.flow.ClassProbesAdapter.visitEnd(ClassProbesAdapter.java:133)
	at org.objectweb.asm.ClassReader.accept(ClassReader.java:697)
	at org.objectweb.asm.ClassReader.accept(ClassReader.java:506)
	at org.jacoco.core.analysis.Analyzer.analyzeClass(Analyzer.java:107)
	at org.jacoco.core.analysis.Analyzer.analyzeClass(Analyzer.java:142)
	... 28 more
