### PR TITLE
Fix test instrumentation.txt file

### DIFF
--- a/integration/mediation-tests/coverage-report/instrumentation.txt
+++ b/integration/mediation-tests/coverage-report/instrumentation.txt
@@ -53,3 +53,4 @@ synapse-tasks_
 synapse-vfs-transport_
 org.wso2.carbon.mediator.transform_
 org.apache.axis2.transport.rabbitmq_
+axis2-transport-rabbitmq-amqp_2.0.0_

--- a/pom.xml
+++ b/pom.xml
@@ -1301,7 +1301,7 @@
         <axis2.osgi.version.range>[1.6.1, 1.7.0)</axis2.osgi.version.range>
 
         <!--MB-->
-        <carbon.messaging.version>3.2.21</carbon.messaging.version>
+        <carbon.messaging.version>3.2.22</carbon.messaging.version>
         <carbon.metrics.version>1.2.3</carbon.metrics.version>
         <product.mb.version>3.1.0</product.mb.version>
         <jline.version>1.0</jline.version>


### PR DESCRIPTION
JCoco coverage generation failed due to the duplicate dependencies in EI distribution as carbon-business-messaging used an older version of axis2 transport release. this will fix the coverage generation issue. Git Issue: https://github.com/wso2/product-ei/issues/1658

## Purpose
Fix JCoco Coverage generation issue.