### PR TITLE
Fix validate mediator test failure

### DIFF
--- a/integration/mediation-tests/tests-mediator-2/src/test/java/org/wso2/carbon/esb/mediator/test/validate/ValidateIntegrationNegativeTestCase.java
+++ b/integration/mediation-tests/tests-mediator-2/src/test/java/org/wso2/carbon/esb/mediator/test/validate/ValidateIntegrationNegativeTestCase.java
@@ -22,9 +22,9 @@ import org.apache.axis2.AxisFault;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
+import org.wso2.carbon.registry.resource.stub.ResourceAdminServiceExceptionException;
 import org.wso2.esb.integration.common.clients.registry.ResourceAdminServiceClient;
 import org.wso2.esb.integration.common.utils.ESBIntegrationTest;
-import org.wso2.esb.integration.common.utils.ESBTestConstant;import org.wso2.carbon.registry.resource.stub.ResourceAdminServiceExceptionException;
 
 import javax.activation.DataHandler;
 import javax.xml.xpath.XPathExpressionException;
@@ -60,12 +60,12 @@ public class ValidateIntegrationNegativeTestCase extends ESBIntegrationTest {
                                                "XPath expression using \"source\" attribute " +
                                                "Check how mediator operates on the elements of SOAP body")
     public void TestWithInvalidXpath() throws Exception {
-
+        final String expectedErrorMsg = "Error occurred while accessing source element: //m0:requestElement/m0:getQuote";
         try {
             axis2Client.sendSimpleStockQuoteRequest(
                     getProxyServiceURLHttp("validateMediatorInvalidXPathTestProxy"), null, "WSO2");
         } catch (AxisFault expected) {
-            assertEquals(expected.getMessage(), ESBTestConstant.INCOMING_MESSAGE_IS_NULL, "Error Message mismatched");
+            assertEquals(expected.getMessage(), expectedErrorMsg, "Error Message mismatched");
         }
     }
 

--- a/integration/mediation-tests/tests-mediator-2/src/test/resources/artifacts/ESB/server/repository/deployment/server/synapse-configs/default/proxy-services/validateMediatorInvalidXPathTestProxy.xml
+++ b/integration/mediation-tests/tests-mediator-2/src/test/resources/artifacts/ESB/server/repository/deployment/server/synapse-configs/default/proxy-services/validateMediatorInvalidXPathTestProxy.xml
@@ -11,8 +11,9 @@
                     <makefault response="true">
                         <code xmlns:tns="http://www.w3.org/2003/05/soap-envelope"
                               value="tns:Receiver" targetNamespace="http://services.samples"/>
-                        <reason value="Invalid custom quote request"/>
+                        <reason expression="$ctx:ERROR_MESSAGE"/>
                     </makefault>
+                    <respond/>
                 </on-fail>
             </validate>
             <send>


### PR DESCRIPTION
Previously, when the source element is given and if it is not accessible from the request body, logic was written to throw a synapse exception and handle it inside the validate mediator by forwarding to fault sequence of the validate mediator. Now this fix catches that synapse exception and invokes the on-fail sequence since it is a validation error. Test case has to be altered to follow the progressions Git Issue: https://github.com/wso2/product-ei/issues/1753