### PR TITLE
Fix mediator properties not display issue

### DIFF
--- a/features/org.wso2.ei.analytics.feature/src/main/capp/dashboard/GadgetMediatorProperties_1.0.0/EIAnalytics-Gadget-Mediator_Properties/js/merge.js
+++ b/features/org.wso2.ei.analytics.feature/src/main/capp/dashboard/GadgetMediatorProperties_1.0.0/EIAnalytics-Gadget-Mediator_Properties/js/merge.js
@@ -3,7 +3,7 @@
 
 // declare global: diff_match_patch, DIFF_INSERT, DIFF_DELETE, DIFF_EQUAL
 
-(function(mod) {
+; (function(mod) {
   if (typeof exports == "object" && typeof module == "object") // CommonJS
     mod(require("codemirror")); // Note non-packaged dependency diff_match_patch
   else if (typeof define == "function" && define.amd) // AMD


### PR DESCRIPTION
## Purpose
Mediator properties not display after configure the hostname.
Resolves wso2/product-ei#1746.

## Goals
In message tracing it should display the mediator properties for each message.

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## User stories
> Summary of user stories addressed by this change>

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.

## Marketing
>