### PR TITLE
Test faultSequence execution for malformed response

### DIFF
--- a/integration/mediation-tests/tests-common/integration-test-utils/src/main/java/org/wso2/esb/integration/common/utils/servers/SimpleHTTPServer.java
+++ b/integration/mediation-tests/tests-common/integration-test-utils/src/main/java/org/wso2/esb/integration/common/utils/servers/SimpleHTTPServer.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.esb.integration.common.utils.servers;
+
+import com.sun.net.httpserver.Headers;
+import com.sun.net.httpserver.HttpContext;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.nio.charset.Charset;
+import java.util.Map;
+
+/**
+ * Simple HTTP server
+ * This simple server wraps {@link HttpServer}
+ */
+public class SimpleHTTPServer {
+
+    private static Log log = LogFactory.getLog(SimpleHTTPServer.class);
+    private HttpServer httpServer;
+
+    public SimpleHTTPServer(int port) throws IOException {
+        this.httpServer = HttpServer.create(new InetSocketAddress(port), 0);
+    }
+
+    /**
+     * Creates a HttpContext. A HttpContext represents a mapping from a URI path to a exchange handler on wrapped
+     * {@link HttpServer}. This will create handler that respond with provided HTTP headers and HTTP payload
+     *
+     * @param context context path
+     * @param httpHeaders HTTP response headers
+     * @param responsePayload HTTP response payload
+     * @return creted {@link HttpContext}
+     */
+    public HttpContext createContext(String context, Map<String, String> httpHeaders, String responsePayload) {
+        return httpServer.createContext(context, new DefaultResponseHandler(httpHeaders, responsePayload));
+    }
+
+    /**
+     * Creates a HttpContext. A HttpContext represents a mapping from a URI path to a exchange handler on wrapped
+     * HttpServer. Once created, all requests received by the server for the path will be handled by calling the given
+     * handler object.
+     *
+     * @param context context path
+     * @param handler {@link HttpHandler} implementation
+     * @return created {@link HttpContext}
+     */
+    public HttpContext createContext(String context, HttpHandler handler) {
+        return httpServer.createContext(context, handler);
+    }
+
+    /**
+     * Start the HTTP Server
+     */
+    public void start() {
+        httpServer.setExecutor(null); // creates a default executor
+        httpServer.start();
+        log.info("SimpleHTTPServer started at " + httpServer.getAddress().getHostName() + ":" + httpServer.getAddress()
+                .getPort());
+    }
+
+    /**
+     * Stop the HTTP Server
+     */
+    public void stop() {
+        httpServer.stop(0);
+        log.info("SimpleHTTPServer stopped");
+    }
+
+    /**
+     * Unwrap underlying HttpServer instance
+     * @return HttpServer instance
+     */
+    public HttpServer unwrap() {
+        return httpServer;
+    }
+
+    /**
+     * HttpHandler implementation to handle request
+     */
+    private static class DefaultResponseHandler implements HttpHandler {
+
+        Map<String, String> responseHeaders;
+        String responsePayload;
+
+        DefaultResponseHandler(Map<String, String> responseHeaders, String responsePayload) {
+            this.responseHeaders = responseHeaders;
+            this.responsePayload = responsePayload;
+        }
+
+        @Override
+        public void handle(HttpExchange httpExchange) throws IOException {
+
+            //Add headers to response message
+            if (responseHeaders != null) {
+                Headers headers = httpExchange.getResponseHeaders();
+                for (Map.Entry<String, String> entry : responseHeaders.entrySet()) {
+                    headers.add(entry.getKey(), entry.getValue());
+                }
+            }
+            httpExchange.sendResponseHeaders(200, responsePayload.length());
+
+            //Add response payload
+            OutputStream responseStream = httpExchange.getResponseBody();
+            try {
+                responseStream.write(responsePayload.getBytes(Charset.defaultCharset()));
+            } finally {
+                responseStream.close();
+            }
+        }
+    }
+}

--- a/integration/mediation-tests/tests-other/src/test/java/org/wso2/carbon/esb/sequence/fault/TestFaultSequenceExecutionForMalformedResponse.java
+++ b/integration/mediation-tests/tests-other/src/test/java/org/wso2/carbon/esb/sequence/fault/TestFaultSequenceExecutionForMalformedResponse.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.esb.sequence.fault;
+
+import com.sun.net.httpserver.Headers;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import org.apache.http.HttpResponse;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import org.wso2.esb.integration.common.utils.ESBIntegrationTest;
+import org.wso2.esb.integration.common.utils.clients.SimpleHttpClient;
+import org.wso2.esb.integration.common.utils.servers.SimpleHTTPServer;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.Charset;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Test case to verify Fault Sequence execution when malformed payload received as response from the BE
+ */
+public class TestFaultSequenceExecutionForMalformedResponse extends ESBIntegrationTest {
+
+    private static final String targetApiName = "simpleApiToTestResponsePayload";
+    private  SimpleHTTPServer simpleHTTPServer;
+
+    @BeforeClass(alwaysRun = true)
+    public void setEnvironment() throws Exception {
+        super.init();
+        verifyAPIExistence(targetApiName);
+
+        //Prepare and start mock back end server
+        int port = 8089;
+        simpleHTTPServer = new SimpleHTTPServer(port);
+        simpleHTTPServer.createContext("/testBE", new malformedResponseBEHandler());
+        simpleHTTPServer.start();//start server
+    }
+
+    @Test(groups = "wso2.esb",
+          description = "Testcase to test whether the the fault sequence get executed when malformed payload received from BE")
+    public void testFaultSeqExecutionForMalformedPayload() throws IOException {
+        //Send request to ESB
+        String contentType = "text/xml";
+        String payload = "<Request><Message>This is request message</Message></Request>";
+        String url = getApiInvocationURL(targetApiName);
+
+        Map<String, String> headers = new HashMap<String, String>(1);
+        headers.put("Content-Type", contentType);
+
+        SimpleHttpClient httpClient = new SimpleHttpClient();
+        HttpResponse response = httpClient.doPost(url, headers, payload, contentType);
+        String responsePayload = httpClient.getResponsePayload(response);
+
+        Assert.assertNotNull(responsePayload, "Error occurred while retrieving response payload: entity null");
+        Assert.assertTrue(responsePayload.contains("Response from fault sequence"),
+                "Fault sequence did not execute due to malformed response");
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void destroy() throws Exception {
+        simpleHTTPServer.stop();//shutdown mock BE server
+        super.cleanup();
+    }
+
+    /**
+     * HttpHandler implementation to handle request
+     */
+    private static class malformedResponseBEHandler implements HttpHandler {
+
+        @Override
+        public void handle(HttpExchange httpExchange) throws IOException {
+            Headers headers = httpExchange.getResponseHeaders();
+            headers.add("Content-Type", "text/xml");
+
+            //response payload
+            String response = "<a></b>";
+
+            httpExchange.sendResponseHeaders(200, response.length());
+            OutputStream responseStream = httpExchange.getResponseBody();
+            try {
+                responseStream.write(response.getBytes(Charset.defaultCharset()));
+            } finally {
+                responseStream.close();
+            }
+        }
+    }
+}

--- a/integration/mediation-tests/tests-other/src/test/resources/artifacts/ESB/server/repository/deployment/server/synapse-configs/default/api/simpleApiToTestResponsePayload.xml
+++ b/integration/mediation-tests/tests-other/src/test/resources/artifacts/ESB/server/repository/deployment/server/synapse-configs/default/api/simpleApiToTestResponsePayload.xml
@@ -1,0 +1,68 @@
+<!--
+  ~     Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~     WSO2 Inc. licenses this file to you under the Apache License,
+  ~     Version 2.0 (the "License"); you may not use this file except
+  ~     in compliance with the License.
+  ~     You may obtain a copy of the License at
+  ~
+  ~       http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~    Unless required by applicable law or agreed to in writing,
+  ~    software distributed under the License is distributed on an
+  ~    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~    KIND, either express or implied.  See the License for the
+  ~    specific language governing permissions and limitations
+  ~    under the License.
+  -->
+<!--
+    This test resource used for: org.wso2.carbon.esb.sequence.fault.TestFaultSequenceExecutionForMalformedResponse
+ -->
+<api xmlns="http://ws.apache.org/ns/synapse"
+     name="simpleApiToTestResponsePayload"
+     context="/simpleApiToTestResponsePayload">
+    <resource methods="POST PUT GET">
+        <inSequence>
+            <log level="full"/>
+            <log>
+                <property name="MESSAGE" value="Sending request"/>
+            </log>
+            <call>
+                <endpoint>
+                    <address uri="http://localhost:8089/testBE"/>
+                </endpoint>
+            </call>
+            <log>
+                <property name="MESSAGE" value="response received"/>
+            </log>
+            <log level="full"/>
+            <respond/>
+        </inSequence>
+        <faultSequence>
+            <log>
+                <property name="MESSAGE" value="Executing Fault Sequence"/>
+                <property
+                        name="ERROR_CODE"
+                        expression="get-property('ERROR_CODE')"/>
+                <property
+                        name="ERROR_MESSAGE"
+                        expression="get-property('ERROR_MESSAGE')"/>
+            </log>
+            <payloadFactory media-type="xml">
+                <format>
+                    <Response xmlns="">
+                        <FaultMessage>$1</FaultMessage>
+                        <FaultCode>$2</FaultCode>
+                        <ResponseOrigin>Response from fault sequence</ResponseOrigin>
+                    </Response>
+                </format>
+                <args>
+                    <arg evaluator="xml" expression="get-property('ERROR_MESSAGE')"/>
+                    <arg evaluator="xml" expression="get-property('ERROR_CODE')"/>
+                </args>
+            </payloadFactory>
+            <send/>
+        </faultSequence>
+    </resource>
+</api>
+

--- a/integration/mediation-tests/tests-other/src/test/resources/testng.xml
+++ b/integration/mediation-tests/tests-other/src/test/resources/testng.xml
@@ -141,6 +141,12 @@
         </classes>
     </test>
 
+    <test name="FaultSequence tests" preserve-order="true" verbose="2">
+        <packages>
+            <package name="org.wso2.carbon.esb.sequence.fault"/>
+        </packages>
+    </test>
+
 </suite>
 
 


### PR DESCRIPTION
## Purpose
> Test case to verify execution of the fault sequence execution when back-end respond with malformed payload
> This also introduce SimpleHTTPServer wrapping HttpServer to create mock backends 

## Goals
> Testcase for Issue: https://github.com/wso2/product-ei/issues/1662

## Approach
> client -> API -> BE -> API (will build the message) -> faultSequence -> Create response payload -> client (with response) -> assert the response message