### PR TITLE
Fix property mediator test failures

### DIFF
--- a/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/property/PropertyIntegrationNO_ENTITY_BODY_PropertyTest.java
+++ b/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/property/PropertyIntegrationNO_ENTITY_BODY_PropertyTest.java
@@ -28,6 +28,8 @@ import org.wso2.carbon.automation.engine.annotations.SetEnvironment;
 import org.wso2.carbon.automation.test.utils.http.client.HttpClientUtil;
 import org.wso2.esb.integration.common.utils.ESBIntegrationTest;
 
+import javax.ws.rs.core.MediaType;
+
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 
@@ -37,7 +39,7 @@ import static org.testng.Assert.assertNotNull;
 
 public class PropertyIntegrationNO_ENTITY_BODY_PropertyTest extends ESBIntegrationTest {
 
-    private OMElement response1;
+    private OMElement response;
     private HttpClientUtil client;
 
     @BeforeClass(alwaysRun = true)
@@ -52,16 +54,17 @@ public class PropertyIntegrationNO_ENTITY_BODY_PropertyTest extends ESBIntegrati
     @SetEnvironment(executionEnvironments = {ExecutionEnvironment.STANDALONE})
     @Test(groups = "wso2.esb", description = "Test-Without No_ENTITY_BODY Property")
     public void testWithoutNoEntityBodyPropertTest() throws Exception {
-        response1 = client.get(getProxyServiceURLHttp("Axis2ProxyService1") + "/echoString?in=IBM");
-        assertNotNull(response1, "Response is null");
-        assertEquals(response1.getFirstElement().getText(), "IBM", "Text does not match");
+        response = client.getWithContentType(getProxyServiceURLHttp("Axis2ProxyService1") + "/echoString?in=IBM",
+                "", MediaType.APPLICATION_FORM_URLENCODED);
+        assertNotNull(response, "Response is null");
+        assertEquals(response.getFirstElement().getText(), "IBM", "Text does not match");
     }
 
     @SetEnvironment(executionEnvironments = {ExecutionEnvironment.STANDALONE})
-    @Test(groups = "wso2.esb", expectedExceptions = OMException.class,
-          description = "Test-With NO_ENTITY_BODY")
+    @Test(groups = "wso2.esb", expectedExceptions = OMException.class, description = "Test-With NO_ENTITY_BODY")
     public void testWithNoEntityBodyPropertTest() throws Exception {
-        client.get(getProxyServiceURLHttp("Axis2ProxyService2") + "/echoString?in=IBM");
+        client.getWithContentType(getProxyServiceURLHttp("Axis2ProxyService2") + "/echoString",
+                "in=IBM", MediaType.APPLICATION_FORM_URLENCODED);
     }
 
     @AfterClass(alwaysRun = true)

--- a/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/property/PropertyIntegrationRESTURLPostFixTestCase.java
+++ b/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/property/PropertyIntegrationRESTURLPostFixTestCase.java
@@ -27,6 +27,8 @@ import org.wso2.carbon.automation.engine.annotations.SetEnvironment;
 import org.wso2.carbon.automation.test.utils.http.client.HttpClientUtil;
 import org.wso2.esb.integration.common.utils.ESBIntegrationTest;
 
+import javax.ws.rs.core.MediaType;
+
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 
@@ -51,7 +53,8 @@ public class PropertyIntegrationRESTURLPostFixTestCase extends ESBIntegrationTes
     @SetEnvironment(executionEnvironments = {ExecutionEnvironment.STANDALONE})
     @Test(groups = "wso2.esb", description = "Test-REST URL Postfix")
     public void testRESTUrlPostFix() throws Exception {
-        response = client.get(getProxyServiceURLHttp("REST_URL_POSTFIX_TestProxy")+"/echoString?in=wso2");
+        response = client.getWithContentType(getProxyServiceURLHttp("REST_URL_POSTFIX_TestProxy") + "/echoString",
+                "in=WSO2", MediaType.APPLICATION_FORM_URLENCODED);
         assertNotNull(response,"Response is null");
         assertEquals(response.getQName().getLocalPart(),"echoStringResponse","Tag does not match");
         assertEquals(response.getFirstElement().getLocalName(),"return","Tag does not match");


### PR DESCRIPTION
With the improvement made in https://wso2.org/jira/browse/ESBJAVA-2183, some of property mediator tests were failed due to incompatibilities in the test suite. This PR is to fix those test failures