### PR TITLE
Fix issues in ESBJAVA4279_MPRetryUponResponseSC_500 test case

### DIFF
--- a/integration/mediation-tests/tests-patches/src/test/java/org/wso2/carbon/esb/message/processor/test/ESBJAVA4279_MPRetryUponResponseSC_500_withNonRetryStatusCodes_200_and_202_TestCase.java
+++ b/integration/mediation-tests/tests-patches/src/test/java/org/wso2/carbon/esb/message/processor/test/ESBJAVA4279_MPRetryUponResponseSC_500_withNonRetryStatusCodes_200_and_202_TestCase.java
@@ -42,8 +42,7 @@ public class ESBJAVA4279_MPRetryUponResponseSC_500_withNonRetryStatusCodes_200_a
                                                                                                extends
                                                                                                ESBIntegrationTest {
     private static final String PROXY_SERVICE_NAME = "NonRetrySCProxy";
-    private static final String EXPECTED_ERROR_MESSAGE =
-                                                         "BlockingMessageSender of message processor [Processor1] failed to send message to the endpoint";
+    private static final String EXPECTED_ERROR_MESSAGE = "Message forwarding failed";
     private static final String EXPECTED_MP_DEACTIVATION_MSG =
                                                                "Successfully deactivated the message processor [Processor1]";
     private static final int RETRY_COUNT = 4;
@@ -53,9 +52,9 @@ public class ESBJAVA4279_MPRetryUponResponseSC_500_withNonRetryStatusCodes_200_a
     @BeforeClass(alwaysRun = true)
     public void deployeService() throws Exception {
         super.init();
+        activeMQServer.startJMSBroker();
         loadESBConfigurationFromClasspath("/artifacts/ESB/messageProcessorConfig/MessageProcessorRetryUpon_500_ResponseWith_200And_202As_Non_retry_SC.xml");
         isProxyDeployed(PROXY_SERVICE_NAME);
-        activeMQServer.startJMSBroker();
     }
 
     @Test(groups = { "wso2.esb" }, description = "Test whether a Message Processor retries sending the message to the EP when the response status code is 500 and MP is configured with 200,202 as non-retry status codes.")

--- a/integration/mediation-tests/tests-patches/src/test/resources/artifacts/ESB/messageProcessorConfig/MessageProcessorRetryUpon_500_ResponseWith_200And_202As_Non_retry_SC.xml
+++ b/integration/mediation-tests/tests-patches/src/test/resources/artifacts/ESB/messageProcessorConfig/MessageProcessorRetryUpon_500_ResponseWith_200And_202As_Non_retry_SC.xml
@@ -14,7 +14,7 @@
                       value="true"
                       scope="axis2"
                       type="STRING"/>
-            <property name="OUT_ONLY" value="true" scope="default" type="STRING"/>
+            <!--property name="OUT_ONLY" value="true" scope="default" type="STRING"/-->
             <store messageStore="JMSMS"/>
          </inSequence>
       </target>
@@ -54,6 +54,8 @@
                      targetEndpoint="EP"
                      messageStore="JMSMS">
       <parameter name="client.retry.interval">2000</parameter>
+      <parameter name="max.store.connection.attempts">-1</parameter>
+      <parameter name="store.connection.retry.interval">1000</parameter>
       <parameter name="max.delivery.attempts">4</parameter>
       <parameter name="interval">4000</parameter>
       <parameter name="non.retry.status.codes">200,202</parameter>


### PR DESCRIPTION
There were two reasons which cause this test failure.
1. Due to unavailability of the broker at the time of proxy initialization, message processor gets deactivated. Hence it was unable to send the message to the endpoint.
2. A response was expected from the request in the test case even though "OUT-ONLY" property is defined in the proxy configuration.

PS: This is occurred due to new modifications introduced in [1] and the test case is modified to compatible with the new changes

[1] https://github.com/wso2/wso2-synapse/pull/1009