### PR TITLE
Add config path parameter to forgetme.bat scripts

### DIFF
--- a/distribution/src/scripts/forgetme.bat
+++ b/distribution/src/scripts/forgetme.bat
@@ -33,4 +33,4 @@ SET curDrive=%cd:~0,1%
 SET wsasDrive=%CARBON_HOME:~0,1%
 if not "%curDrive%" == "%wsasDrive%" %wsasDrive%:
 cd %CARBON_HOME%
-call %CARBON_HOME%\wso2\tools\identity-anonymization-tool\bin\forgetme.bat
+call %CARBON_HOME%\wso2\tools\identity-anonymization-tool\bin\forgetme.bat -d %CARBON_HOME%\wso2\tools\identity-anonymization-tool\conf %*

--- a/distribution/src/scripts/profiles/forgetme.bat
+++ b/distribution/src/scripts/profiles/forgetme.bat
@@ -33,4 +33,4 @@ SET curDrive=%cd:~0,1%
 SET wsasDrive=%CARBON_HOME:~0,1%
 if not "%curDrive%" == "%wsasDrive%" %wsasDrive%:
 cd %CARBON_HOME%
-call %CARBON_HOME%\..\tools\identity-anonymization-tool\bin\forgetme.bat
+call %CARBON_HOME%\..\tools\identity-anonymization-tool\bin\forgetme.bat -d %CARBON_HOME%\..\tools\identity-anonymization-tool\conf %*

--- a/pom.xml
+++ b/pom.xml
@@ -1498,7 +1498,7 @@
         <greenmail.version>1.3</greenmail.version>
 
         <!-- Forget-me tool -->
-        <forgetme.tool.version>1.1.7</forgetme.tool.version>
+        <forgetme.tool.version>1.1.9</forgetme.tool.version>
     </properties>
 
     <repositories>


### PR DESCRIPTION
## Purpose
> "U" parameter seems not recognized when executing the forget-me.sh script in windows environment. and the fix resolves wso2/product-ei#1927

## Goals
> Resolves wso2/product-ei#1927

## Approach
> Added a runtime argument to the script and updated forget me tool version to 1.1.9