### PR TITLE
Add thread name and refactor carbon logfile appender pattern layout

### DIFF
--- a/distribution/src/conf/log4j.properties
+++ b/distribution/src/conf/log4j.properties
@@ -124,7 +124,7 @@ log4j.appender.CARBON_LOGFILE.File=${carbon.home}/repository/logs/${instance.log
 log4j.appender.CARBON_LOGFILE.Append=true
 log4j.appender.CARBON_LOGFILE.layout=org.wso2.carbon.utils.logging.TenantAwarePatternLayout
 # ConversionPattern will be overridden by the configuration setting in the DB
-log4j.appender.CARBON_LOGFILE.layout.ConversionPattern=TID: [%T] [%S] [%d] %P%5p {%c} - %x %m {%c}%n
+log4j.appender.CARBON_LOGFILE.layout.ConversionPattern=[%d] [%T] [%S] [%t] %P%5p {%c} - %x %m%n
 log4j.appender.CARBON_LOGFILE.layout.TenantPattern=%U%@%D [%T] [%S]
 log4j.appender.CARBON_LOGFILE.threshold=DEBUG
 


### PR DESCRIPTION
## Purpose
> Including thread name in the pattern layout configuration of the CARBON_LOGFILE appender. Also removing 'TID' and the repeated package name from the logs, and moving the timestamp to the beginning of the log.

