### PR TITLE
Avoid multiple activations AppDeployerServiceComponent

### DIFF
--- a/components/org.wso2.carbon.micro.integrator.core/src/main/java/org/wso2/carbon/micro/integrator/core/deployment/synapse/deployer/SynapseAppDeployer.java
+++ b/components/org.wso2.carbon.micro.integrator.core/src/main/java/org/wso2/carbon/micro/integrator/core/deployment/synapse/deployer/SynapseAppDeployer.java
@@ -1048,6 +1048,12 @@ public class SynapseAppDeployer implements AppDeploymentHandler {
                     } catch (DeploymentException e) {
                         artifact.setDeploymentStatus(AppDeployerConstants.DEPLOYMENT_STATUS_FAILED);
                         throw e;
+                    } catch (Throwable throwable) {
+                        artifact.setDeploymentStatus(AppDeployerConstants.DEPLOYMENT_STATUS_FAILED);
+                        // Since there can be different deployers, they can throw any error.
+                        // So need to handle unhandled exception has occurred during deployement. Hence catch all and
+                        // wrap it with DeployementException and throw it
+                        throw new DeploymentException(throwable);
                     } finally {
                         //clear the log appender once deployment is finished to avoid appending the
                         //same log to other classes.


### PR DESCRIPTION
## Purpose
Supporting fix for
https://github.com/wso2/product-ei/issues/2272
https://github.com/wso2/product-ei/issues/2275

Catch unhandled error thrown by deployers and handle them avoiding them reaching OSGI level to avoid multiple Activations of AppDeployerServiceComponent