### PR TITLE
Remove Unnecessary Logs

### DIFF
--- a/distribution/src/broker/conf/log4j.properties
+++ b/distribution/src/broker/conf/log4j.properties
@@ -76,7 +76,33 @@ log4j.logger.ExecMapper=WARN
 log4j.logger.ExecReducer=WARN
 log4j.logger.net.sf.ehcache.config.ConfigurationFactory=ERROR
 
-log4j.logger.trace.messages=TRACE,CARBON_TRACE_LOGFILE
+#andes specific
+log4j.logger.org.wso2.andes.server.handler.ConnectionStartOkMethodHandler=WARN
+log4j.logger.org.wso2.andes.server.handler.ChannelOpenHandler=WARN
+log4j.logger.org.wso2.andes.server.handler.ChannelCloseHandler=WARN
+log4j.logger.org.wso2.andes.server.AMQChannel=WARN
+log4j.logger.org.wso2.andes.server.handler.ConnectionCloseMethodHandler=WARN
+log4j.logger.org.wso2.andes.server.handler.QueueDeclareHandler=WARN
+log4j.logger.org.wso2.andes.server.handler.QueueBindHandler=WARN
+log4j.logger.org.wso2.andes.server.virtualhost.VirtualHostConfigRecoveryHandler=WARN
+log4j.logger.org.wso2.andes.amqp.QpidAndesBridge=WARN
+log4j.logger.MessageExpirationTask=WARN
+
+# Set to level TRACE to enable MessageTracer for the broker profile
+log4j.logger.org.wso2.andes.tools.utils.MessageTracer=INFO,CARBON_TRACE_LOGFILE
+
+#Andes logs for troubleshooting
+#kernel - outbound
+log4j.logger.org.wso2.andes.kernel.slot.MessageDeliveryTask=INFO
+log4j.logger.org.wso2.andes.kernel.slot.SlotDeliveryWorkerManager=INFO
+log4j.logger.org.wso2.andes.kernel.slot.SlotManagerClusterMode=INFO
+log4j.logger.org.wso2.andes.kernel.subscription.AndesSubscription=INFO
+log4j.logger.org.wso2.andes.kernel.MessageHandler=INFO
+
+#Kernel - inbound
+log4j.logger.org.wso2.andes.kernel.distruptor.inbound.MessageWriter=INFO
+log4j.logger.org.wso2.andes.kernel.distruptor.inbound.AckHandler=INFO
+log4j.logger.org.wso2.andes.kernel.distruptor.inbound.StateEventHandler=INFO
 
 log4j.additivity.org.apache.axis2.clustering=false
 log4j.additivity.com.atomikos=false


### PR DESCRIPTION
## Purpose
This PR removes the following logs printed that are unnecessary and confusing.
[2018-06-12 15:00:11,950] [EI-Broker]  INFO {org.wso2.andes.server.handler.ConnectionStartOkMethodHandler} -  SASL Mechanism selected: PLAIN
[2018-06-12 15:00:11,950] [EI-Broker]  INFO {org.wso2.andes.server.handler.ConnectionStartOkMethodHandler} -  Locale selected: en_US
[2018-06-12 15:00:11,952] [EI-Broker]  INFO {org.wso2.andes.server.handler.ConnectionStartOkMethodHandler} -  Connected as: admin
[2018-06-12 15:00:11,953] [EI-Broker]  INFO {org.wso2.andes.server.handler.ConnectionStartOkMethodHandler} -  Framesize set to 65535
[2018-06-12 15:00:11,965] [EI-Broker]  INFO {org.wso2.andes.server.handler.ChannelOpenHandler} -  Connecting to: carbon
[2018-06-12 15:00:11,965] [EI-Broker]  INFO {org.wso2.andes.kernel.AndesChannel} -  Channel created (ID: 127.0.0.1:59720)
[2018-06-12 15:00:11,967] [EI-Broker]  INFO {org.wso2.andes.server.handler.QueueDeclareHandler} -  Queue testqueue1 declared successfully
[2018-06-12 15:00:11,968] [EI-Broker]  INFO {org.wso2.andes.server.handler.QueueBindHandler} -  Binding queue testqueue1 to exchange DirectExchange[amq.direct] with routing key testqueue1
[2018-06-12 15:00:11,970] [EI-Broker]  INFO {org.wso2.andes.server.handler.ChannelCloseHandler} -  Received channel close for id 1 citing class 0 and method 0
[2018-06-12 15:00:11,970] [EI-Broker]  INFO {org.wso2.andes.server.AMQChannel} -  No consumers to unsubscribe on channel [/127.0.0.1:59720(admin):1]
[2018-06-12 15:00:11,970] [EI-Broker]  INFO {org.wso2.andes.kernel.FlowControlManager} -  Channel removed (ID: 127.0.0.1:59720)
[2018-06-12 15:00:11,971] [EI-Broker]  INFO {org.wso2.andes.server.handler.ConnectionCloseMethodHandler} -  ConnectionClose rece
