### PR TITLE
Modify database name and jdbcUrl by fixing issue

### DIFF
--- a/integration/dataservice-hosting-tests/tests-common/integration-test-utils/src/main/java/org/wso2/ei/dataservice/integration/common/utils/SqlDataSourceUtil.java
+++ b/integration/dataservice-hosting-tests/tests-common/integration-test-utils/src/main/java/org/wso2/ei/dataservice/integration/common/utils/SqlDataSourceUtil.java
@@ -167,8 +167,8 @@ public class SqlDataSourceUtil {
 
         if (jdbcUrl.contains("h2") && jdbcDriver.contains("h2")) {
             //Random number appends to a database name to create new database for H2*//*
-            databaseName = System.getProperty("basedir")+ File.separator + "target" + File.separator+ databaseName + new Random().nextInt();
-            jdbcUrl = jdbcUrl + databaseName;
+            databaseName = databaseName + new Random().nextInt();
+            jdbcUrl = jdbcUrl + System.getProperty("basedir")+ File.separator + "target" + File.separator + databaseName;
             //create database on in-memory
             H2DataBaseManager h2 = null;
             try {
@@ -199,8 +199,8 @@ public class SqlDataSourceUtil {
 
         if (jdbcUrl.contains("h2") && jdbcDriver.contains("h2")) {
             //Random number appends to a database name to create new database for H2*//*
-            databaseName = System.getProperty("basedir")+ File.separator + "target" + File.separator+ databaseName + new Random().nextInt();
-            jdbcUrl = jdbcUrl + databaseName;
+            databaseName = databaseName + new Random().nextInt();
+            jdbcUrl = jdbcUrl + System.getProperty("basedir")+ File.separator + "target" + File.separator + databaseName;
             //create database on in-memory
             H2DataBaseManager h2 = null;
             try {


### PR DESCRIPTION
## Purpose
> To fix the NDataSourceException in createDataSource in Windows instance

## Goals
> Modify variable assignment of databaseName and jdbcUrl.

## Approach
> Assign db name for databaseName variable rather than giving the path to db file and append path to dbs file to jdcbUrl.

## User stories
> 

## Release note
> B

## Documentation
> 

## Training
> 

## Certification
> 

## Marketing
> 

## Automation tests
 - Integration tests
   >

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> 

## Related PRs
> 

## Migrations (if applicable)
>

## Test environment
> Windows 2016, Oracle JDK 8
 
## Learning
> 