### PR TITLE
testgrid bug fix for Mediation-tests module

### DIFF
--- a/integration/automation-extensions/src/main/java/org/wso2/esb/integration/common/extensions/carbonserver/CarbonServerManager.java
+++ b/integration/automation-extensions/src/main/java/org/wso2/esb/integration/common/extensions/carbonserver/CarbonServerManager.java
@@ -435,7 +435,7 @@ public class CarbonServerManager {
                 Paths.get(carbonHome, "wso2", "tmp", scriptName + ".bat").toFile(), "-Dcatalina.base",
                 "-javaagent:" + jacocoAgentFile + "=destfile=" + coverageDumpFilePath + "" + ",append=true,includes="
                         + CodeCoverageUtils.getInclusionJarsPattern(":") + ",excludes=" + CodeCoverageUtils
-                        .getExclusionJarsPattern(":") + " \\");
+                        .getExclusionJarsPattern(":"));
     }
 
 


### PR DESCRIPTION
## Purpose
> Testgrid execution failed to execute mediation test for Window 2016 OS on Testgrid. Test executor append jacco report argument to the java execution command with additional backslash to the integration.bat file. This additional backslash cause to not allow to start EI server and it show error saying "Could not find or load main class ...".