### PR TITLE
Close FileInputStream and FileOutputStream resources after usage

### DIFF
--- a/integration/mediation-tests/tests-common/integration-test-utils/src/main/java/org/wso2/esb/integration/common/utils/common/ServerConfigurationManager.java
+++ b/integration/mediation-tests/tests-common/integration-test-utils/src/main/java/org/wso2/esb/integration/common/utils/common/ServerConfigurationManager.java
@@ -36,6 +36,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.OutputStreamWriter;
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.channels.FileChannel;
@@ -98,14 +99,15 @@ public class ServerConfigurationManager {
      * backup the current server configuration file
      *
      * @param fileName file name
+     * @throws IOException
      */
     private void backupConfiguration(String fileName) throws IOException {
         //restore backup configuration
         String carbonHome = System.getProperty(ServerConstants.CARBON_HOME);
-        String confDir = Paths.get(carbonHome ,"conf").toString();
+        String confDir = Paths.get(carbonHome,"conf").toString();
         String AXIS2_XML = "axis2";
         if (fileName.contains(AXIS2_XML)) {
-            confDir = Paths.get(confDir , "axis2" ).toString();
+            confDir = Paths.get(confDir, "axis2").toString();
         }
         originalConfig = Paths.get(confDir,fileName).toFile();
         backUpConfig = Paths.get(confDir , fileName + ".backup").toFile();
@@ -113,7 +115,8 @@ public class ServerConfigurationManager {
         Files.move(originalConfig.toPath(), backUpConfig.toPath(), StandardCopyOption.REPLACE_EXISTING);
 
         if (originalConfig.exists()) {
-            throw new IOException("Failed to rename file from " + originalConfig.getName() + "to" + backUpConfig.getName());
+            throw new IOException("Failed to rename file from " + originalConfig.getName() + "to" +
+                    backUpConfig.getName());
         }
 
         configDatas.add(new ConfigData(backUpConfig, originalConfig));
@@ -123,6 +126,7 @@ public class ServerConfigurationManager {
      * Backup a file residing in a cabron server.
      *
      * @param file file residing in server to backup.
+     * @throws IOException
      */
     private void backupConfiguration(File file) throws IOException {
         //restore backup configuration
@@ -132,7 +136,8 @@ public class ServerConfigurationManager {
         Files.move(originalConfig.toPath(), backUpConfig.toPath(), StandardCopyOption.REPLACE_EXISTING);
 
         if (originalConfig.exists()) {
-            throw new IOException("Failed to rename file from " + originalConfig.getName() + "to" + backUpConfig.getName());
+            throw new IOException("Failed to rename file from " + originalConfig.getName() + "to" +
+                    backUpConfig.getName());
         }
 
         configDatas.add(new ConfigData(backUpConfig, originalConfig));
@@ -501,7 +506,7 @@ public class ServerConfigurationManager {
      */
     public void copyToComponentDropins(File jar) throws IOException, URISyntaxException {
         String carbonHome = System.getProperty(ServerConstants.CARBON_HOME);
-        String lib = Paths.get(carbonHome , "dropins").toString();
+        String lib = Paths.get(carbonHome, "dropins").toString();
         FileManager.copyJarFile(jar, lib);
     }
 
@@ -512,7 +517,8 @@ public class ServerConfigurationManager {
      */
     public void removeFromComponentDropins(String fileName) throws IOException, URISyntaxException {
         String carbonHome = System.getProperty(ServerConstants.CARBON_HOME);
-        File file = Paths.get(carbonHome , "dropins" ,fileName).toFile();
+        URI filePath = Paths.get(carbonHome, "dropins", fileName).toUri();
+        File file = Paths.get(filePath).toFile();
 
         if (file.exists()) {
             FileManager.deleteFile(file.getAbsolutePath());

--- a/integration/mediation-tests/tests-other/src/test/java/org/wso2/carbon/esb/handler/HandlerTest.java
+++ b/integration/mediation-tests/tests-other/src/test/java/org/wso2/carbon/esb/handler/HandlerTest.java
@@ -53,8 +53,8 @@ public class HandlerTest extends ESBIntegrationTest {
         super.init();
         serverConfigurationManager = new ServerConfigurationManager(context);
         serverConfigurationManager
-                .copyToComponentDropins(new File(getClass().getResource(LOCATION + File.separator + JAR_NAME).toURI()));
-        copyToComponentConf(getClass().getResource(LOCATION + File.separator + CONF_NAME).getPath(), CONF_NAME);
+                .copyToComponentDropins(new File(getClass().getResource(LOCATION + "/" + JAR_NAME).toURI()));
+        copyToComponentConf(getClass().getResource(LOCATION + "/" + CONF_NAME).getPath(), CONF_NAME);
         serverConfigurationManager.restartForcefully();
         super.init();
         logViewerClient = new LogViewerClient(contextUrls.getBackEndUrl(), getSessionCookie());
@@ -118,9 +118,8 @@ public class HandlerTest extends ESBIntegrationTest {
     @AfterClass(alwaysRun = true)
     public void destroy() throws Exception {
         serverConfigurationManager
-                .removeFromComponentDropins(getClass().getResource(LOCATION + File.separator + JAR_NAME).getPath());
-        removeFromComponentConf(getClass().getResource(LOCATION + File.separator + CONF_NAME).getPath());
+                .removeFromComponentDropins(getClass().getResource(LOCATION + "/" + JAR_NAME).getPath());
+        removeFromComponentConf(getClass().getResource(LOCATION + "/" + CONF_NAME).getPath());
         super.cleanup();
     }
-
 }

--- a/integration/mediation-tests/tests-patches/src/test/java/org/wso2/carbon/esb/passthru/transport/test/ESBJAVA3336HostHeaderValuePortCheckTestCase.java
+++ b/integration/mediation-tests/tests-patches/src/test/java/org/wso2/carbon/esb/passthru/transport/test/ESBJAVA3336HostHeaderValuePortCheckTestCase.java
@@ -18,7 +18,7 @@
 
 package org.wso2.carbon.esb.passthru.transport.test;
 
-import junit.framework.Assert;
+import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -31,10 +31,8 @@ import org.wso2.esb.integration.common.utils.common.ServerConfigurationManager;
 import org.wso2.carbon.logging.view.stub.types.carbon.LogEvent;
 import org.wso2.carbon.utils.ServerConstants;
 import org.wso2.esb.integration.common.utils.ESBIntegrationTest;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
+
+import java.io.*;
 import java.util.Properties;
 
 import static org.testng.Assert.assertFalse;
@@ -106,7 +104,7 @@ public class ESBJAVA3336HostHeaderValuePortCheckTestCase extends ESBIntegrationT
             properties.store(fos, null);
             serverConfigurationManager.applyConfigurationWithoutRestart(destinationFile);
         } catch (Exception e) {
-            log.error(" File Cannot Find " + e.getMessage());
+            Assert.assertTrue(false, "Exception occured with the message: " + e.getMessage());
         } finally {
             if (fis != null) {
                 fis.close();

--- a/integration/mediation-tests/tests-patches/src/test/java/org/wso2/carbon/esb/passthru/transport/test/ESBJAVA3336HostHeaderValuePortCheckTestCase.java
+++ b/integration/mediation-tests/tests-patches/src/test/java/org/wso2/carbon/esb/passthru/transport/test/ESBJAVA3336HostHeaderValuePortCheckTestCase.java
@@ -91,7 +91,7 @@ public class ESBJAVA3336HostHeaderValuePortCheckTestCase extends ESBIntegrationT
      * @param srcFile
      * @param key
      * @param value
-     * @throws Exception
+     * @throws IOException
      */
     private void applyProperty(File srcFile, String key, String value) throws IOException {
         FileInputStream fis = null;

--- a/integration/mediation-tests/tests-patches/src/test/java/org/wso2/carbon/esb/passthru/transport/test/ESBJAVA3336HostHeaderValuePortCheckTestCase.java
+++ b/integration/mediation-tests/tests-patches/src/test/java/org/wso2/carbon/esb/passthru/transport/test/ESBJAVA3336HostHeaderValuePortCheckTestCase.java
@@ -93,9 +93,13 @@ public class ESBJAVA3336HostHeaderValuePortCheckTestCase extends ESBIntegrationT
     private void applyProperty(File srcFile, String key, String value) throws Exception {
         File destinationFile = new File(srcFile.getName());
         Properties properties = new Properties();
-        properties.load(new FileInputStream(srcFile));
+        FileInputStream fis = new FileInputStream(srcFile);
+        properties.load(fis);
         properties.setProperty(key, value);
-        properties.store(new FileOutputStream(destinationFile), null);
+        fis.close();
+        FileOutputStream fos = new FileOutputStream(destinationFile);
+        properties.store(fos, null);
         serverConfigurationManager.applyConfigurationWithoutRestart(destinationFile);
+        fos.close();
     }
 }

--- a/integration/mediation-tests/tests-patches/src/test/java/org/wso2/carbon/esb/passthru/transport/test/ESBJAVA3336HostHeaderValuePortCheckTestCase.java
+++ b/integration/mediation-tests/tests-patches/src/test/java/org/wso2/carbon/esb/passthru/transport/test/ESBJAVA3336HostHeaderValuePortCheckTestCase.java
@@ -18,6 +18,7 @@
 
 package org.wso2.carbon.esb.passthru.transport.test;
 
+import junit.framework.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -32,6 +33,7 @@ import org.wso2.carbon.utils.ServerConstants;
 import org.wso2.esb.integration.common.utils.ESBIntegrationTest;
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.util.Properties;
 
@@ -91,15 +93,27 @@ public class ESBJAVA3336HostHeaderValuePortCheckTestCase extends ESBIntegrationT
      * @throws Exception
      */
     private void applyProperty(File srcFile, String key, String value) throws Exception {
-        File destinationFile = new File(srcFile.getName());
-        Properties properties = new Properties();
-        FileInputStream fis = new FileInputStream(srcFile);
-        properties.load(fis);
-        properties.setProperty(key, value);
-        fis.close();
-        FileOutputStream fos = new FileOutputStream(destinationFile);
-        properties.store(fos, null);
-        serverConfigurationManager.applyConfigurationWithoutRestart(destinationFile);
-        fos.close();
+        FileInputStream fis = null;
+        FileOutputStream fos = null;
+        String outFileName = srcFile.getName();
+        try {
+            File destinationFile = new File(outFileName);
+            fis = new FileInputStream(srcFile);
+            fos = new FileOutputStream(destinationFile);
+            Properties properties = new Properties();
+            properties.load(fis);
+            properties.setProperty(key, value);
+            properties.store(fos, null);
+            serverConfigurationManager.applyConfigurationWithoutRestart(destinationFile);
+        } catch (Exception e) {
+            log.error(" File Cannot Find " + e.getMessage());
+        } finally {
+            if (fis != null) {
+                fis.close();
+            }
+            if (fos != null) {
+                fos.close();
+            }
+        }
     }
 }

--- a/integration/mediation-tests/tests-patches/src/test/java/org/wso2/carbon/esb/passthru/transport/test/ESBJAVA3336HostHeaderValuePortCheckTestCase.java
+++ b/integration/mediation-tests/tests-patches/src/test/java/org/wso2/carbon/esb/passthru/transport/test/ESBJAVA3336HostHeaderValuePortCheckTestCase.java
@@ -32,7 +32,10 @@ import org.wso2.carbon.logging.view.stub.types.carbon.LogEvent;
 import org.wso2.carbon.utils.ServerConstants;
 import org.wso2.esb.integration.common.utils.ESBIntegrationTest;
 
-import java.io.*;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.IOException;
 import java.util.Properties;
 
 import static org.testng.Assert.assertFalse;
@@ -90,7 +93,7 @@ public class ESBJAVA3336HostHeaderValuePortCheckTestCase extends ESBIntegrationT
      * @param value
      * @throws Exception
      */
-    private void applyProperty(File srcFile, String key, String value) throws Exception {
+    private void applyProperty(File srcFile, String key, String value) throws IOException {
         FileInputStream fis = null;
         FileOutputStream fos = null;
         String outFileName = srcFile.getName();

--- a/integration/mediation-tests/tests-patches/src/test/java/org/wso2/carbon/esb/passthru/transport/test/HttpAccessLogTestCase.java
+++ b/integration/mediation-tests/tests-patches/src/test/java/org/wso2/carbon/esb/passthru/transport/test/HttpAccessLogTestCase.java
@@ -30,7 +30,12 @@ import org.wso2.carbon.utils.ServerConstants;
 import org.wso2.esb.integration.common.utils.ESBIntegrationTest;
 import org.wso2.esb.integration.common.utils.ESBTestConstant;
 
-import java.io.*;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.FileReader;
 import java.util.Properties;
 
 import static java.io.File.separator;
@@ -120,7 +125,7 @@ public class HttpAccessLogTestCase extends ESBIntegrationTest {
      * @param value
      * @throws Exception
      */
-    private void applyProperty(File srcFile, String key, String value) throws Exception {
+    private void applyProperty(File srcFile, String key, String value) throws IOException {
         FileInputStream fis = null;
         FileOutputStream fos = null;
         String outFileName = srcFile.getName();

--- a/integration/mediation-tests/tests-patches/src/test/java/org/wso2/carbon/esb/passthru/transport/test/HttpAccessLogTestCase.java
+++ b/integration/mediation-tests/tests-patches/src/test/java/org/wso2/carbon/esb/passthru/transport/test/HttpAccessLogTestCase.java
@@ -126,16 +126,28 @@ public class HttpAccessLogTestCase extends ESBIntegrationTest {
      * @throws Exception
      */
     private void applyProperty(File srcFile, String key, String value) throws Exception {
-        File destinationFile = new File(srcFile.getName());
-        Properties properties = new Properties();
-        FileInputStream fis = new FileInputStream(srcFile);
-        properties.load(fis);
-        properties.setProperty(key, value);
-        fis.close();
-        FileOutputStream fos = new FileOutputStream(destinationFile);
-        properties.store(fos, null);
-        serverConfigurationManager.applyConfigurationWithoutRestart(destinationFile);
-        fos.close();
+        FileInputStream fis = null;
+        FileOutputStream fos = null;
+        String outFileName = srcFile.getName();
+        try {
+            File destinationFile = new File(outFileName);
+            fis = new FileInputStream(srcFile);
+            fos = new FileOutputStream(destinationFile);
+            Properties properties = new Properties();
+            properties.load(fis);
+            properties.setProperty(key, value);
+            properties.store(fos, null);
+            serverConfigurationManager.applyConfigurationWithoutRestart(destinationFile);
+        } catch (Exception e) {
+            log.error(" File Cannot Find " + e.getMessage());
+        } finally {
+            if (fis != null) {
+                fis.close();
+            }
+            if (fos != null) {
+                fos.close();
+            }
+        }
     }
 
     /**

--- a/integration/mediation-tests/tests-patches/src/test/java/org/wso2/carbon/esb/passthru/transport/test/HttpAccessLogTestCase.java
+++ b/integration/mediation-tests/tests-patches/src/test/java/org/wso2/carbon/esb/passthru/transport/test/HttpAccessLogTestCase.java
@@ -123,7 +123,7 @@ public class HttpAccessLogTestCase extends ESBIntegrationTest {
      * @param srcFile
      * @param key
      * @param value
-     * @throws Exception
+     * @throws IOException
      */
     private void applyProperty(File srcFile, String key, String value) throws IOException {
         FileInputStream fis = null;

--- a/integration/mediation-tests/tests-patches/src/test/java/org/wso2/carbon/esb/passthru/transport/test/HttpAccessLogTestCase.java
+++ b/integration/mediation-tests/tests-patches/src/test/java/org/wso2/carbon/esb/passthru/transport/test/HttpAccessLogTestCase.java
@@ -128,10 +128,14 @@ public class HttpAccessLogTestCase extends ESBIntegrationTest {
     private void applyProperty(File srcFile, String key, String value) throws Exception {
         File destinationFile = new File(srcFile.getName());
         Properties properties = new Properties();
-        properties.load(new FileInputStream(srcFile));
+        FileInputStream fis = new FileInputStream(srcFile);
+        properties.load(fis);
         properties.setProperty(key, value);
-        properties.store(new FileOutputStream(destinationFile), null);
+        fis.close();
+        FileOutputStream fos = new FileOutputStream(destinationFile);
+        properties.store(fos, null);
         serverConfigurationManager.applyConfigurationWithoutRestart(destinationFile);
+        fos.close();
     }
 
     /**

--- a/integration/mediation-tests/tests-patches/src/test/java/org/wso2/carbon/esb/passthru/transport/test/HttpAccessLogTestCase.java
+++ b/integration/mediation-tests/tests-patches/src/test/java/org/wso2/carbon/esb/passthru/transport/test/HttpAccessLogTestCase.java
@@ -30,12 +30,7 @@ import org.wso2.carbon.utils.ServerConstants;
 import org.wso2.esb.integration.common.utils.ESBIntegrationTest;
 import org.wso2.esb.integration.common.utils.ESBTestConstant;
 
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.FileOutputStream;
-import java.io.FileReader;
-import java.io.IOException;
+import java.io.*;
 import java.util.Properties;
 
 import static java.io.File.separator;
@@ -139,7 +134,7 @@ public class HttpAccessLogTestCase extends ESBIntegrationTest {
             properties.store(fos, null);
             serverConfigurationManager.applyConfigurationWithoutRestart(destinationFile);
         } catch (Exception e) {
-            log.error(" File Cannot Find " + e.getMessage());
+            Assert.assertTrue(false, "Exception occured with the message: " + e.getMessage());
         } finally {
             if (fis != null) {
                 fis.close();


### PR DESCRIPTION
## Purpose
> To fix the file accessing issue which is getting due to resource leakage.

## Goals
> Close the resources in method exit.

## Approach
>  Close the FileInputStream and FileOutputStream in after its usage.

## User stories
> 

## Release note
> 

## Documentation
> 

## Training
> 

## Certification
> 

## Marketing
> 

## Automation tests
 - Integration tests

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> 

## Related PRs
> 

## Migrations (if applicable)
> 

## Test environment
> Windows, Oracle JDK 8
 
## Learning
> 