### PR TITLE
bug fix for tests-pach windows

### DIFF
--- a/integration/mediation-tests/tests-patches/src/test/java/org/wso2/carbon/esb/datamapper/ESBJAVA5045XsiNilElementSupport.java
+++ b/integration/mediation-tests/tests-patches/src/test/java/org/wso2/carbon/esb/datamapper/ESBJAVA5045XsiNilElementSupport.java
@@ -30,17 +30,16 @@ import java.io.File;
  */
 public class ESBJAVA5045XsiNilElementSupport extends DataMapperIntegrationTest {
 
-    private final String DM_ARTIFACT_ROOT_PATH = File.separator + "artifacts" + File.separator + "ESB" + File.separator + "mediatorconfig" + File.separator +
-                                                 "datamapper" + File.separator + "multiplePrefix" + File.separator;
-    private final String DM_REGISTRY_ROOT_PATH = "datamapper" + File.separator;
+    private final String DM_ARTIFACT_ROOT_PATH = "/artifacts/ESB/mediatorconfig/datamapper/multiplePrefix/";
+    private final String DM_REGISTRY_ROOT_PATH = "datamapper/";
 
     @Test(groups = {"wso2.esb"}, description = "Datamapper : test support for xsi:nil attribute in elements")
     public void testxsiNilAttributeInElement() throws Exception {
         verifyAPIExistence("ESBJAVA5045convertMenuApi");
-        uploadResourcesToGovernanceRegistry(DM_REGISTRY_ROOT_PATH + "multiplePrefix" + File.separator, DM_ARTIFACT_ROOT_PATH,
-                                            "FoodMapping.dmc",
-                                            "FoodMapping_inputSchema.json",
-                                            "FoodMapping_outputSchema.json");
+        uploadResourcesToGovernanceRegistry(DM_REGISTRY_ROOT_PATH + "multiplePrefix/", DM_ARTIFACT_ROOT_PATH,
+                "FoodMapping.dmc",
+                "FoodMapping_inputSchema.json",
+                "FoodMapping_outputSchema.json");
 
         String requestMsg = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n"
                             + "<breakfast_menu>\n"

--- a/integration/mediation-tests/tests-patches/src/test/java/org/wso2/carbon/esb/vfs/transport/test/ESBJAVA4679VFSPasswordSecurityTestCase.java
+++ b/integration/mediation-tests/tests-patches/src/test/java/org/wso2/carbon/esb/vfs/transport/test/ESBJAVA4679VFSPasswordSecurityTestCase.java
@@ -86,9 +86,7 @@ public class ESBJAVA4679VFSPasswordSecurityTestCase extends ESBIntegrationTest {
         FTPPassword = "pass";
 
         pathToFtpDir = getClass().getResource(
-                File.separator + "artifacts" + File.separator + "ESB"
-                + File.separator + "synapseconfig" + File.separator
-                + "vfsTransport" + File.separator).getPath();
+                "/artifacts/ESB/synapseconfig/vfsTransport/").getPath();
 
         // Local folder of the FTP server root
         FTPFolder = new File(pathToFtpDir + "securePasswordFTP");
@@ -101,7 +99,7 @@ public class ESBJAVA4679VFSPasswordSecurityTestCase extends ESBIntegrationTest {
         Assert.assertTrue(FTPFolder.mkdir(), "FTP root file folder not created");
 
         // create a directory under FTP server root
-        inputFolder = new File(FTPFolder.getAbsolutePath() + File.separator
+        inputFolder = new File(FTPFolder.getAbsolutePath() + "/"
                                + inputFolderName);
 
         if (inputFolder.exists()) {
@@ -122,11 +120,7 @@ public class ESBJAVA4679VFSPasswordSecurityTestCase extends ESBIntegrationTest {
         // gracefully
         serverConfigurationManager = new ServerConfigurationManager(context);
         serverConfigurationManager.applyConfiguration(new File(getClass()
-                                                                       .getResource(
-                                                                               File.separator + "artifacts" + File.separator + "ESB"
-                                                                               + File.separator + "synapseconfig"
-                                                                               + File.separator + "vfsTransport"
-                                                                               + File.separator + "axis2.xml").getPath()));
+                .getResource("/artifacts/ESB/synapseconfig/vfsTransport/axis2.xml").getPath()));
         super.init();
         logViewerClient = new LogViewerClient(contextUrls.getBackEndUrl(),
                                               getSessionCookie());
@@ -153,8 +147,8 @@ public class ESBJAVA4679VFSPasswordSecurityTestCase extends ESBIntegrationTest {
 
         //copy SOAP message  into the SFTP server
         String sentMessageFile = "test.xml";
-        File sourceMessage = new File(sampleFileFolder + File.separator + sentMessageFile);
-        File destinationMessage = new File(inputFolder + File.separator + sentMessageFile);
+        File sourceMessage = new File(sampleFileFolder + "/" + sentMessageFile);
+        File destinationMessage = new File(inputFolder + "/" + sentMessageFile);
         copyFile(sourceMessage, destinationMessage);
 
         //Below is encrypted value of "user1:pass" using local wso2carbon.jks TODO if security settings change, will need to change below value as well. Otherwise this test will fail


### PR DESCRIPTION
## Purpose
> Windows show error when it trying to access testing resources URI with File.separator constant. Therefore it change to the backslash to fix the bugs in ESBJAVA4679VFSPasswordSecurityTestCase and ESBJAVA5045XsiNilElementSupport classes. 

Issue #2659