### PR TITLE
Add windows compatible fixes

### DIFF
--- a/integration/mediation-tests/tests-common/integration-test-utils/src/main/java/org/wso2/esb/integration/common/utils/ESBIntegrationTest.java
+++ b/integration/mediation-tests/tests-common/integration-test-utils/src/main/java/org/wso2/esb/integration/common/utils/ESBIntegrationTest.java
@@ -67,6 +67,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.regex.Matcher;
 import javax.activation.DataHandler;
+import javax.activation.FileDataSource;
 import javax.xml.namespace.QName;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.xpath.XPathExpressionException;
@@ -421,9 +422,8 @@ public abstract class ESBIntegrationTest {
 	                                                                                RemoteException {
 		List<LibraryFileItem> uploadLibraryInfoList = new ArrayList<LibraryFileItem>();
 		LibraryFileItem uploadedFileItem = new LibraryFileItem();
-		uploadedFileItem.setDataHandler(new DataHandler(new URL("file:" + File.separator +
-		                                                        File.separator + repoLocation +
-		                                                        File.separator + strFileName)));
+		uploadedFileItem.setDataHandler(new DataHandler(new FileDataSource(new File(repoLocation +
+		                                                        File.separator + strFileName))));
 		uploadedFileItem.setFileName(strFileName);
 		uploadedFileItem.setFileType("zip");
 		uploadLibraryInfoList.add(uploadedFileItem);

--- a/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/aggregate/SoapHeaderBlocksTestCase.java
+++ b/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/aggregate/SoapHeaderBlocksTestCase.java
@@ -11,6 +11,7 @@ import org.wso2.carbon.integration.common.admin.client.CarbonAppUploaderClient;
 import org.wso2.esb.integration.common.utils.ESBIntegrationTest;
 
 import javax.activation.DataHandler;
+import javax.activation.FileDataSource;
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLSession;
@@ -39,8 +40,8 @@ public class SoapHeaderBlocksTestCase extends ESBIntegrationTest {
         super.init();
         carbonAppUploaderClient = new CarbonAppUploaderClient(context.getContextUrls().getBackEndUrl(), getSessionCookie());
         carbonAppUploaderClient.uploadCarbonAppArtifact(carFileNameWithExtension
-                , new DataHandler(new URL("file:" + File.separator + File.separator + getESBResourceLocation()
-                + File.separator + "car" + File.separator + carFileNameWithExtension)));
+                , new DataHandler( new FileDataSource( new File(getESBResourceLocation()
+                + File.separator + "car" + File.separator + carFileNameWithExtension))));
         applicationAdminClient = new ApplicationAdminClient(context.getContextUrls().getBackEndUrl(), getSessionCookie());
         Assert.assertTrue(isCarFileDeployed(carFileName), "Car file deployment failed");
         loadESBConfigurationFromClasspath("/artifacts/ESB/synapseconfig/requestWithSoapHeaderBlockConfig/synapse.xml");

--- a/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/payload/factory/PayloadFactoryWithDynamicKeyTestCase.java
+++ b/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/payload/factory/PayloadFactoryWithDynamicKeyTestCase.java
@@ -9,10 +9,12 @@ import org.wso2.esb.integration.common.utils.ESBIntegrationTest;
 import org.wso2.carbon.registry.resource.stub.ResourceAdminServiceExceptionException;
 
 import javax.activation.DataHandler;
+import javax.activation.FileDataSource;
 import javax.xml.namespace.QName;
 import javax.xml.xpath.XPathExpressionException;
 import java.io.File;
 import java.net.URL;
+import java.nio.file.Paths;
 import java.rmi.RemoteException;
 
 import static org.testng.Assert.assertEquals;
@@ -63,10 +65,10 @@ public class PayloadFactoryWithDynamicKeyTestCase extends ESBIntegrationTest {
 
         resourceAdminServiceStub.addResource(
                 "/_system/config/payloadFactory/payload-in.xml", "application/xml", "payload format",
-                new DataHandler(new URL("file://" + getESBResourceLocation() + File.separator +
-                        "mediatorconfig/payload/factory/payload-in.xml")));
-
-
+                new DataHandler(new FileDataSource( new File(getESBResourceLocation() + File.separator +
+                                                            "mediatorconfig" + File.separator + "payload" +
+                                                            File.separator + "factory" + File.separator +
+                                                            "payload-in.xml"))));
     }
 
     private void clearUploadedResource()

--- a/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/message/processor/test/DeactivatedCappMPBehaviourOnRestartTestCase.java
+++ b/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/message/processor/test/DeactivatedCappMPBehaviourOnRestartTestCase.java
@@ -22,6 +22,7 @@ import java.io.File;
 import java.net.URL;
 
 import javax.activation.DataHandler;
+import javax.activation.FileDataSource;
 
 import org.apache.axiom.om.OMAbstractFactory;
 import org.apache.axiom.om.OMElement;
@@ -60,9 +61,8 @@ public class DeactivatedCappMPBehaviourOnRestartTestCase extends ESBIntegrationT
         axis2Server = new SampleAxis2Server("test_axis2_server_9001.xml");
         axis2Server.deployService(SampleAxis2Server.SIMPLE_STOCK_QUOTE_SERVICE);
         axis2Server.start();
-        uploadCapp(carFileName, new DataHandler(
-                new URL("file:" + File.separator + File.separator + getESBResourceLocation() + File.separator + "car"
-                        + File.separator + carFileName)));
+        uploadCapp(carFileName, new DataHandler(new FileDataSource(new File(
+                getESBResourceLocation() + File.separator + "car" + File.separator + carFileName))));
         isProxyDeployed(PROXY_SERVICE_NAME);
     }
 

--- a/integration/mediation-tests/tests-mediator-2/src/test/java/org/wso2/carbon/esb/mediator/test/spring/SpringMediationBeansTestCase.java
+++ b/integration/mediation-tests/tests-mediator-2/src/test/java/org/wso2/carbon/esb/mediator/test/spring/SpringMediationBeansTestCase.java
@@ -34,6 +34,7 @@ import java.io.File;
 import java.net.URL;
 import java.rmi.RemoteException;
 import javax.activation.DataHandler;
+import javax.activation.FileDataSource;
 
 /**
  * Related to https://wso2.org/jira/browse/ESBJAVA-3291
@@ -42,9 +43,7 @@ import javax.activation.DataHandler;
  */
 public class SpringMediationBeansTestCase extends ESBIntegrationTest {
 
-	private final String SPRING_XML_LOCATION = File.separator + "artifacts"
-			+ File.separator + "ESB" + File.separator + "mediatorconfig"
-			+ File.separator + "spring";
+	private final String SPRING_XML_LOCATION =  "/artifacts/ESB/mediatorconfig/spring";
  
 	private LogViewerClient logViewerClient;
 
@@ -54,7 +53,7 @@ public class SpringMediationBeansTestCase extends ESBIntegrationTest {
 		super.init();
 		clearUploadedResource();
 		uploadResourcesToConfigRegistry();
-		loadESBConfigurationFromClasspath(SPRING_XML_LOCATION + File.separator + "spring_mediation_error.xml");
+		loadESBConfigurationFromClasspath(SPRING_XML_LOCATION + "/spring_mediation_error.xml");
 		logViewerClient = new LogViewerClient(contextUrls.getBackEndUrl(), getSessionCookie());
 
 	}
@@ -111,9 +110,8 @@ public class SpringMediationBeansTestCase extends ESBIntegrationTest {
 		
 		resourceAdminServiceStub.addResource(
 				"/_system/config/spring/spring_bean_for_error_client.xml","application/xml", "spring bean config files",
-                new DataHandler(new URL("file:///" + getClass().getResource(
-                				SPRING_XML_LOCATION + File.separator 
-                				+  "utils/spring_bean_for_error_client.xml").getPath())));
+                new DataHandler(new FileDataSource( new File(getClass().getResource(
+                				SPRING_XML_LOCATION +  "/utils/spring_bean_for_error_client.xml").getPath()))));
 	}
 
 	private void clearUploadedResource() throws InterruptedException,

--- a/integration/mediation-tests/tests-other/src/test/java/org/wso2/carbon/esb/hotdeployment/test/SynapseArtifactsHotDeploymentTestCase.java
+++ b/integration/mediation-tests/tests-other/src/test/java/org/wso2/carbon/esb/hotdeployment/test/SynapseArtifactsHotDeploymentTestCase.java
@@ -36,8 +36,6 @@ import java.io.IOException;
 import java.rmi.RemoteException;
 import java.util.concurrent.Callable;
 
-import org.awaitility.Awaitility.*;
-
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 /**

--- a/integration/mediation-tests/tests-patches/src/test/java/org/wso2/carbon/esb/car/deployment/test/CARBON16113DeployArtifactsBeforeTransportStarsTestCase.java
+++ b/integration/mediation-tests/tests-patches/src/test/java/org/wso2/carbon/esb/car/deployment/test/CARBON16113DeployArtifactsBeforeTransportStarsTestCase.java
@@ -32,6 +32,7 @@ import org.wso2.esb.integration.common.utils.common.ServerConfigurationManager;
 import java.io.File;
 import java.net.URL;
 import javax.activation.DataHandler;
+import javax.activation.FileDataSource;
 
 /**
  * Test case to ensure Carbon apps (.car files) are deployed before the transport starts.
@@ -56,8 +57,8 @@ public class CARBON16113DeployArtifactsBeforeTransportStarsTestCase extends ESBI
     public void carReDeploymentTest() throws Exception {
         logViewerClient = new LogViewerClient(contextUrls.getBackEndUrl(), getSessionCookie());
         uploadCapp("car-deployment-before-tranaport-start-test_1.0.0.car", new DataHandler(
-                new URL("file:" + File.separator + File.separator + getESBResourceLocation() + File.separator + "car"
-                        + File.separator + "car-deployment-before-tranaport-start-test_1.0.0.car")));
+                new FileDataSource(new File(getESBResourceLocation() + File.separator + "car"
+                        + File.separator + "car-deployment-before-tranaport-start-test_1.0.0.car"))));
         logViewerClient.clearLogs();
         serverConfigurationManager.restartGracefully();
         super.init();

--- a/integration/mediation-tests/tests-patches/src/test/java/org/wso2/carbon/esb/car/deployment/test/ESBJAVA3611EndpointTestCase.java
+++ b/integration/mediation-tests/tests-patches/src/test/java/org/wso2/carbon/esb/car/deployment/test/ESBJAVA3611EndpointTestCase.java
@@ -26,6 +26,7 @@ import org.wso2.carbon.automation.engine.context.TestUserMode;
 import org.wso2.esb.integration.common.utils.ESBIntegrationTest;
 
 import javax.activation.DataHandler;
+import javax.activation.FileDataSource;
 import java.io.File;
 import java.net.URL;
 import java.util.concurrent.TimeUnit;
@@ -38,8 +39,9 @@ public class ESBJAVA3611EndpointTestCase extends ESBIntegrationTest {
     protected void uploadCarFileTest() throws Exception {
         super.init(TestUserMode.TENANT_ADMIN);
         uploadCapp(carFileName
-                   , new DataHandler(new URL("file:" + File.separator + File.separator + getESBResourceLocation()
-                                             + File.separator + "car" + File.separator + carFileName)));
+                   , new DataHandler(new FileDataSource(new File(getESBResourceLocation() +
+                                                                File.separator + "car" + File.separator +
+                                                                carFileName))));
         TimeUnit.SECONDS.sleep(30);
         log.info(carFileName + " uploaded successfully");
     }

--- a/integration/mediation-tests/tests-patches/src/test/java/org/wso2/carbon/esb/mediators/store/ESBJAVA4470StoreMediatorEmptyOMArraySerializeException.java
+++ b/integration/mediation-tests/tests-patches/src/test/java/org/wso2/carbon/esb/mediators/store/ESBJAVA4470StoreMediatorEmptyOMArraySerializeException.java
@@ -32,6 +32,7 @@ import java.io.File;
 import java.net.URL;
 import java.util.concurrent.TimeUnit;
 import javax.activation.DataHandler;
+import javax.activation.FileDataSource;
 
 import static org.testng.Assert.assertFalse;
 
@@ -46,9 +47,8 @@ public class ESBJAVA4470StoreMediatorEmptyOMArraySerializeException extends ESBI
         super.init();
         logViewerClient = new LogViewerClient(contextUrls.getBackEndUrl(), getSessionCookie());
         uploadCapp(carFileName
-                , new DataHandler(new URL("file:" + File.separator + File.separator +
-                getESBResourceLocation() + File.separator + "car" +
-                File.separator + carFileName)));
+                , new DataHandler(new FileDataSource(new File(getESBResourceLocation() + File.separator + "car" +
+                                                            File.separator + carFileName))));
         TimeUnit.SECONDS.sleep(30);
         log.info(carFileName + " uploaded successfully");
     }

--- a/integration/mediation-tests/tests-service/src/test/java/org/wso2/carbon/esb/car/deployment/test/CAppArtifactIndicationTestCase.java
+++ b/integration/mediation-tests/tests-service/src/test/java/org/wso2/carbon/esb/car/deployment/test/CAppArtifactIndicationTestCase.java
@@ -27,6 +27,7 @@ import org.wso2.esb.integration.common.clients.service.mgt.ServiceAdminClient;
 import org.wso2.esb.integration.common.utils.ESBIntegrationTest;
 
 import javax.activation.DataHandler;
+import javax.activation.FileDataSource;
 import java.io.File;
 import java.net.URL;
 import java.util.concurrent.TimeUnit;
@@ -48,8 +49,9 @@ public class CAppArtifactIndicationTestCase extends ESBIntegrationTest {
         CarbonAppUploaderClient carbonAppUploaderClient =
                 new CarbonAppUploaderClient(context.getContextUrls().getBackEndUrl(), sessionCookie);
         carbonAppUploaderClient.uploadCarbonAppArtifact("esb-artifacts-car_1.0.0.car"
-                , new DataHandler(new URL("file:" + File.separator + File.separator + getESBResourceLocation()
-                                          + File.separator + "car" + File.separator + "esb-artifacts-car_1.0.0.car")));
+                , new DataHandler(new FileDataSource(new File(getESBResourceLocation() +
+                                                                File.separator + "car" + File.separator +
+                                                                "esb-artifacts-car_1.0.0.car"))));
         serviceAdminClient =
                 new ServiceAdminClient(context.getContextUrls().getBackEndUrl(), sessionCookie);
         TimeUnit.SECONDS.sleep(5);

--- a/integration/mediation-tests/tests-service/src/test/java/org/wso2/carbon/esb/car/deployment/test/CAppDeactivateAndRestartTestCase.java
+++ b/integration/mediation-tests/tests-service/src/test/java/org/wso2/carbon/esb/car/deployment/test/CAppDeactivateAndRestartTestCase.java
@@ -35,6 +35,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 import javax.activation.DataHandler;
+import javax.activation.FileDataSource;
 
 /**
  * Testcase to test persisting deactivation of vfs proxy deployed using CAPP after restart of the server
@@ -62,8 +63,8 @@ public class CAppDeactivateAndRestartTestCase extends ESBIntegrationTest {
         CarbonAppUploaderClient carbonAppUploaderClient =
                 new CarbonAppUploaderClient(context.getContextUrls().getBackEndUrl(), sessionCookie);
         carbonAppUploaderClient.uploadCarbonAppArtifact(carFileName,
-                new DataHandler(new URL("file:" + File.separator + File.separator + getESBResourceLocation()
-                        + File.separator + "car" + File.separator + carFileName)));
+                new DataHandler(new FileDataSource(new File(getESBResourceLocation() +
+                                                            File.separator + "car" + File.separator + carFileName))));
         log.info(carFileName + " uploaded successfully");
 
         //deactivate proxy service
@@ -128,8 +129,7 @@ public class CAppDeactivateAndRestartTestCase extends ESBIntegrationTest {
         String FTPPassword = "admin";
         int FTPPort = 8085;
 
-        String pathToFtpDir = getClass().getResource(File.separator + "artifacts" + File.separator + "ESB" +
-                File.separator + "synapseconfig" + File.separator + "vfsTransport" + File.separator).getPath();
+        String pathToFtpDir = getClass().getResource("/artifacts/ESB/synapseconfig/vfsTransport/").getPath();
 
         // Local folder of the FTP server root
         File ftpFolder = new File(pathToFtpDir + "FTP_Location" + File.separator);

--- a/integration/mediation-tests/tests-service/src/test/java/org/wso2/carbon/esb/car/deployment/test/CarbonApplicationDeploymentTestCase.java
+++ b/integration/mediation-tests/tests-service/src/test/java/org/wso2/carbon/esb/car/deployment/test/CarbonApplicationDeploymentTestCase.java
@@ -30,6 +30,7 @@ import org.wso2.carbon.integration.common.admin.client.CarbonAppUploaderClient;
 import org.wso2.esb.integration.common.utils.ESBIntegrationTest;
 
 import javax.activation.DataHandler;
+import javax.activation.FileDataSource;
 import java.io.File;
 import java.net.URL;
 import java.util.Calendar;
@@ -47,8 +48,8 @@ public class CarbonApplicationDeploymentTestCase extends ESBIntegrationTest {
         super.init();
         carbonAppUploaderClient = new CarbonAppUploaderClient(context.getContextUrls().getBackEndUrl(), getSessionCookie());
         carbonAppUploaderClient.uploadCarbonAppArtifact("esb-artifacts-car_1.0.0.car"
-                , new DataHandler(new URL("file:" + File.separator + File.separator + getESBResourceLocation()
-                                          + File.separator + "car" + File.separator + "esb-artifacts-car_1.0.0.car")));
+                , new DataHandler(new FileDataSource(new File(getESBResourceLocation() + File.separator +
+                                                            "car" + File.separator + "esb-artifacts-car_1.0.0.car"))));
         isCarFileUploaded = true;
         applicationAdminClient = new ApplicationAdminClient(context.getContextUrls().getBackEndUrl(), getSessionCookie());
         Assert.assertTrue(isCarFileDeployed(carFileName), "Car file deployment failed");

--- a/integration/mediation-tests/tests-service/src/test/java/org/wso2/carbon/esb/car/deployment/test/ClassMediatorCarTestCase.java
+++ b/integration/mediation-tests/tests-service/src/test/java/org/wso2/carbon/esb/car/deployment/test/ClassMediatorCarTestCase.java
@@ -31,6 +31,7 @@ import org.wso2.carbon.integration.common.admin.client.CarbonAppUploaderClient;
 import org.wso2.esb.integration.common.utils.ESBIntegrationTest;
 
 import javax.activation.DataHandler;
+import javax.activation.FileDataSource;
 import java.io.File;
 import java.net.URL;
 import java.util.Calendar;
@@ -55,13 +56,12 @@ public class ClassMediatorCarTestCase extends ESBIntegrationTest {
         super.init();
         carbonAppUploaderClient =
                 new CarbonAppUploaderClient(context.getContextUrls().getBackEndUrl(), getSessionCookie());
-        carbonAppUploaderClient.
-                uploadCarbonAppArtifact(car1FileName,
-                                        new DataHandler(new URL("file:" + File.separator + File.separator +
-                                                                getESBResourceLocation() +
-                                                                File.separator + "car" +
-                                                                File.separator +
-                                                                car1FileName)));
+        carbonAppUploaderClient.uploadCarbonAppArtifact(car1FileName,
+                                        new DataHandler(new FileDataSource(
+                                                new File(getESBResourceLocation() +
+                                                        File.separator + "car" +
+                                                        File.separator +
+                                                        car1FileName))));
         isCarFile1Uploaded = true;
         applicationAdminClient =
                 new ApplicationAdminClient(context.getContextUrls().getBackEndUrl(), getSessionCookie());
@@ -112,11 +112,11 @@ public class ClassMediatorCarTestCase extends ESBIntegrationTest {
                 new CarbonAppUploaderClient(context.getContextUrls().getBackEndUrl(), getSessionCookie());
         carbonAppUploaderClient.
                 uploadCarbonAppArtifact(car2FileName,
-                                        new DataHandler(new URL("file:" + File.separator + File.separator +
-                                                                getESBResourceLocation() +
-                                                                File.separator + "car" +
-                                                                File.separator +
-                                                                car2FileName)));
+                                        new DataHandler(new FileDataSource(
+                                                new File(getESBResourceLocation() +
+                                                        File.separator + "car" +
+                                                        File.separator +
+                                                        car2FileName))));
         isCarFile2Uploaded = true;
         applicationAdminClient =
                 new ApplicationAdminClient(context.getContextUrls().getBackEndUrl(), getSessionCookie());

--- a/integration/mediation-tests/tests-service/src/test/java/org/wso2/carbon/esb/car/deployment/test/XSLTTransformationCarTestCase.java
+++ b/integration/mediation-tests/tests-service/src/test/java/org/wso2/carbon/esb/car/deployment/test/XSLTTransformationCarTestCase.java
@@ -33,6 +33,7 @@ import org.wso2.esb.integration.common.clients.registry.ResourceAdminServiceClie
 import org.wso2.esb.integration.common.utils.ESBIntegrationTest;
 
 import javax.activation.DataHandler;
+import javax.activation.FileDataSource;
 import java.io.File;
 import java.net.URL;
 import java.rmi.RemoteException;
@@ -53,8 +54,8 @@ public class XSLTTransformationCarTestCase extends ESBIntegrationTest {
         super.init();
         carbonAppUploaderClient = new CarbonAppUploaderClient(context.getContextUrls().getBackEndUrl(), getSessionCookie());
         carbonAppUploaderClient.uploadCarbonAppArtifact("xslt-transformation-car_1.0.0.car"
-                , new DataHandler(new URL("file:" + File.separator + File.separator + getESBResourceLocation()
-                                          + File.separator + "car" + File.separator + "xslt-transformation-car_1.0.0.car")));
+                , new DataHandler(new FileDataSource( new File(getESBResourceLocation()
+                                          + File.separator + "car" + File.separator + "xslt-transformation-car_1.0.0.car"))));
         isCarFileUploaded = true;
         applicationAdminClient = new ApplicationAdminClient(context.getContextUrls().getBackEndUrl(), getSessionCookie());
         Assert.assertTrue(isCarFileDeployed(carFileName), "Car file deployment failed");

--- a/integration/mediation-tests/tests-service/src/test/java/org/wso2/carbon/esb/scheduledtask/test/TaskRedeployWithCappTestCase.java
+++ b/integration/mediation-tests/tests-service/src/test/java/org/wso2/carbon/esb/scheduledtask/test/TaskRedeployWithCappTestCase.java
@@ -12,6 +12,7 @@ import org.wso2.carbon.logging.view.stub.types.carbon.LogEvent;
 import org.wso2.esb.integration.common.utils.ESBIntegrationTest;
 
 import javax.activation.DataHandler;
+import javax.activation.FileDataSource;
 import java.io.File;
 import java.net.URL;
 import java.util.Calendar;
@@ -44,18 +45,18 @@ public class TaskRedeployWithCappTestCase extends ESBIntegrationTest {
     public void taskRedeployWithCappTest() throws Exception {
         int beforeLogSize = logViewer.getAllRemoteSystemLogs().length;
 
-        carbonAppUploaderClient.uploadCarbonAppArtifact(carFileFullName, new DataHandler(
-                new URL("file:" + File.separator + File.separator + getESBResourceLocation() + File.separator +
-                        "scheduledTask" + File.separator + carFileFullName)));
+        carbonAppUploaderClient.uploadCarbonAppArtifact(carFileFullName, new DataHandler( new FileDataSource( new File
+                (getESBResourceLocation() + File.separator +
+                        "scheduledTask" + File.separator + carFileFullName))));
         isCarFileUploaded = true;
         applicationAdminClient =
                 new ApplicationAdminClient(context.getContextUrls().getBackEndUrl(), getSessionCookie());
         Assert.assertTrue(isCarFileDeployed(carFileName), "Car file deployment failed");
         TimeUnit.SECONDS.sleep(50);//wait for some tasks to execute
 
-        carbonAppUploaderClient.uploadCarbonAppArtifact(carFileFullName, new DataHandler(
-                new URL("file:" + File.separator + File.separator + getESBResourceLocation() + File.separator +
-                        "scheduledTask" + File.separator + carFileFullName)));
+        carbonAppUploaderClient.uploadCarbonAppArtifact(carFileFullName, new DataHandler( new FileDataSource( new File
+                (getESBResourceLocation() + File.separator +
+                        "scheduledTask" + File.separator + carFileFullName))));
 
         TimeUnit.SECONDS
                 .sleep(150); //10 seconds proxy sleep time * 5 exeutions * 3 seconds interval  : wait for all tasks


### PR DESCRIPTION
## Purpose

Test cases fixes (to make compatible with windows machine):
TaskRedeployWithCappTestCase.*
XSLTTransformationCarTestCase.*
SpringMediationBeansTestCase.*
PayloadFactoryWithDynamicKeyTestCase.*
SoapHeaderBlocksTestCase.*
MediationLibraryServiceTestCase.*
CAppDeactivateAndRestartTestCase.*
CARBON16113DeployArtifactsBeforeTransportStarsTestCase.*
CAppArtifactIndicationTestCase.*
CarbonApplicationDeploymentTestCase.*
CarbonApplicationReDeploymentTestCase.*
ClassMediatorCarTestCase.*
DeactivatedCappMPBehaviourOnRestartTestCase.*
ESBJAVA3611EndpointTestCase.*
ESBJAVA4470StoreMediatorEmptyOMArraySerializeException.*