### PR TITLE
Add await condition instead of thread sleep in tests for tests-transport

### DIFF
--- a/integration/mediation-tests/tests-common/integration-test-utils/src/main/java/org/wso2/esb/integration/common/utils/ESBIntegrationTest.java
+++ b/integration/mediation-tests/tests-common/integration-test-utils/src/main/java/org/wso2/esb/integration/common/utils/ESBIntegrationTest.java
@@ -292,6 +292,11 @@ public abstract class ESBIntegrationTest {
 		esbUtils.addInboundEndpoint(contextUrls.getBackEndUrl(), sessionCookie, inboundEndpoint);
 	}
 
+	protected boolean isInboundEndpointDeployed(OMElement inboundEndpoint) throws Exception {
+		String inboundName = inboundEndpoint.getAttributeValue(new QName("name"));
+		return esbUtils.isInboundEndpointExist(contextUrls.getBackEndUrl(), sessionCookie, inboundName);
+	}
+
 	protected void isInboundUndeployed(String inboundEndpoint) throws Exception {
 		try {
 			esbUtils.isInboundEndpointUndeployed(contextUrls.getBackEndUrl(), sessionCookie, inboundEndpoint);
@@ -356,12 +361,25 @@ public abstract class ESBIntegrationTest {
 		                                           proxyServiceName), "Proxy Deployment failed or time out");
 	}
 
+	protected boolean isProxyDeployed(OMElement omElement) throws Exception {
+		String proxyName = omElement.getAttributeValue(new QName("name"));
+		return esbUtils.isProxyDeployed(contextUrls.getBackEndUrl(), sessionCookie, proxyName);
+	}
+
+    protected boolean isProxySuccesfullyDeployed(String proxyName) throws Exception {
+        return esbUtils.isProxyDeployed(contextUrls.getBackEndUrl(), sessionCookie, proxyName);
+    }
+
 	protected void isEndpointDeployed(String endpointName) throws Exception {
 		Assert.assertTrue(esbUtils.isEndpointDeployed(contextUrls.getBackEndUrl(), sessionCookie,
 		                                           endpointName), "Endpoint Deployment failed or time out");
 	}
 
+    protected boolean isEndpointDeployed(OMElement omElement) throws Exception {
 
+        String endpointName = omElement.getAttributeValue(new QName("name"));
+        return esbUtils.isEndpointDeployed(contextUrls.getBackEndUrl(), sessionCookie, endpointName);
+    }
 
 	protected void isLocalEntryDeployed(String localEntryName) throws Exception {
 		Assert.assertTrue(esbUtils.isLocalEntryDeployed(contextUrls.getBackEndUrl(), sessionCookie,
@@ -417,6 +435,11 @@ public abstract class ESBIntegrationTest {
 		}
 		sequencesList.add(sequenceName);
 	}
+
+	protected boolean isSequenceDeployed(OMElement sequenceConfig) throws RemoteException, SequenceEditorException {
+        String sequenceName = sequenceConfig.getAttributeValue(new QName("name"));
+        return esbUtils.isSequenceExist(contextUrls.getBackEndUrl(), sessionCookie, sequenceName);
+    }
 
 	protected  void uploadConnector(String repoLocation, String strFileName) throws MalformedURLException,
 	                                                                                RemoteException {

--- a/integration/mediation-tests/tests-transport/src/test/java/org/wso2/carbon/esb/file/inbound/transport/test/FtpInboundTransportTest.java
+++ b/integration/mediation-tests/tests-transport/src/test/java/org/wso2/carbon/esb/file/inbound/transport/test/FtpInboundTransportTest.java
@@ -20,6 +20,7 @@ package org.wso2.carbon.esb.file.inbound.transport.test;
 import org.apache.axiom.om.OMElement;
 import org.apache.axiom.om.util.AXIOMUtil;
 import org.apache.commons.io.FileUtils;
+import org.awaitility.Awaitility;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -34,8 +35,11 @@ import org.wso2.esb.integration.common.utils.Utils;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
 
 public class FtpInboundTransportTest extends ESBIntegrationTest {
+
 	private FTPServerManager ftpServerManager;
 	private String FTPUsername;
 	private String FTPPassword;
@@ -55,8 +59,8 @@ public class FtpInboundTransportTest extends ESBIntegrationTest {
 		String outputFolderName = "ftpout";
 		int FTPPort = 9653;
 
-		pathToFtpDir = getESBResourceLocation()	+ File.separator + "synapseconfig" + File.separator
-						+ "vfsTransport" + File.separator;
+		pathToFtpDir = getESBResourceLocation() + File.separator + "synapseconfig" + File.separator
+				+ "vfsTransport" + File.separator;
 
 		// Local folder of the FTP server root
 		FTPFolder = new File(pathToFtpDir + "FTP_Location" + File.separator);
@@ -67,20 +71,16 @@ public class FtpInboundTransportTest extends ESBIntegrationTest {
 		}
 		Assert.assertTrue(FTPFolder.mkdir(), "FTP root file folder not created");
 
-
 		// create 'in' directory under FTP server root
-		inputFolder = new File(FTPFolder.getAbsolutePath() + File.separator
-				+ inputFolderName);
+		inputFolder = new File(FTPFolder.getAbsolutePath() + File.separator + inputFolderName);
 
 		if (inputFolder.exists()) {
 			FileUtils.deleteDirectory(inputFolder);
 		}
 		Assert.assertTrue(inputFolder.mkdir(), "FTP data /in folder not created");
 
-
 		// create 'out' directory under FTP server root
-		outputFolder = new File(FTPFolder.getAbsolutePath() + File.separator
-				+ outputFolderName);
+		outputFolder = new File(FTPFolder.getAbsolutePath() + File.separator + outputFolderName);
 
 		if (outputFolder.exists()) {
 			FileUtils.deleteDirectory(outputFolder);
@@ -91,20 +91,19 @@ public class FtpInboundTransportTest extends ESBIntegrationTest {
 		Utils.shutdownFailsafe(FTPPort);
 
 		// start-up FTP server
-		ftpServerManager = new FTPServerManager(FTPPort,
-				FTPFolder.getAbsolutePath(), FTPUsername, FTPPassword);
+		ftpServerManager = new FTPServerManager(FTPPort, FTPFolder.getAbsolutePath(), FTPUsername, FTPPassword);
 		ftpServerManager.startFtpServer();
 
 		super.init();
 
-		logViewerClient = new LogViewerClient(contextUrls.getBackEndUrl(),
-				getSessionCookie());
+		logViewerClient = new LogViewerClient(contextUrls.getBackEndUrl(), getSessionCookie());
 		log.info("Before Class test method completed successfully");
 
 	}
 
 	@AfterClass(alwaysRun = true)
 	public void stopFTPServerForInboundTest() throws Exception {
+
 		try {
 			super.cleanup();
 		} finally {
@@ -116,10 +115,9 @@ public class FtpInboundTransportTest extends ESBIntegrationTest {
 
 	}
 
-	@SetEnvironment(executionEnvironments = { ExecutionEnvironment.STANDALONE })
+	@SetEnvironment(executionEnvironments = {ExecutionEnvironment.STANDALONE})
 	@Test(groups = "wso2.esb", description = "Inbound endpoint Reading file in FTP Test Case")
 	public void testInboundEnpointReadFileinFTP() throws Exception {
-
 
 		File sourceFile = new File(pathToFtpDir + File.separator + "test.xml");
 		File targetFolder = new File(FTPFolder + File.separator + "ftpin");
@@ -139,113 +137,116 @@ public class FtpInboundTransportTest extends ESBIntegrationTest {
 	//  This test case works locally, but in the Jenkins build, it fails due to a lack of permission issue
 	//	@SetEnvironment(executionEnvironments = { ExecutionEnvironment.STANDALONE })
 	//	@Test(groups = "wso2.esb", dependsOnMethods = "testInboundInvalidFtpUsername", description = "Inbound endpoint move after process in FTP Test Case")
-	public void testInboundEnpointMoveAfterProcessFTP() throws Exception {
+    public void testInboundEnpointMoveAfterProcessFTP() throws Exception {
 
-		addInboundEndpoint(addEndpoint2());
+        addInboundEndpoint(addEndpoint2());
 
-		File sourceFile = new File(pathToFtpDir + File.separator + "test.xml");
-		File targetFile = new File(FTPFolder + File.separator + "ftpin"
-				+ File.separator + "test.xml");
-		File outFile = new File(FTPFolder + File.separator + "ftpout"
-				+ File.separator + "test.xml");
+        File sourceFile = new File(pathToFtpDir + File.separator + "test.xml");
+        File targetFile = new File(FTPFolder + File.separator + "ftpin" + File.separator + "test.xml");
+        File outFile = new File(FTPFolder + File.separator + "ftpout" + File.separator + "test.xml");
 
-		try {
-			FileUtils.copyFile(sourceFile, targetFile);
-			Thread.sleep(2000);
-			Assert.assertTrue(outFile.exists(),
-					"Input file is not moved after processing the file");
-			Assert.assertFalse(targetFile.exists(),
-					"Input file is exist after processing the input file");
-		} finally {
-			deleteFile(targetFile);
-			deleteFile(outFile);
-		}
+        try {
+            FileUtils.copyFile(sourceFile, targetFile);
+            Awaitility.await()
+                      .pollInterval(50, TimeUnit.MILLISECONDS)
+                      .atMost(60, TimeUnit.SECONDS)
+                      .until(isFileExist(outFile));
+            Assert.assertTrue(outFile.exists(), "Input file is not moved after processing the file");
+            Assert.assertFalse(targetFile.exists(), "Input file is exist after processing the input file");
+        } finally {
+            deleteFile(targetFile);
+            deleteFile(outFile);
+        }
 
-	}
+    }
 
-	@SetEnvironment(executionEnvironments = { ExecutionEnvironment.STANDALONE })
-	@Test(groups = "wso2.esb", description = "Inbound endpoint invalid FTP username Test Case")
-	public void testInboundInvalidFtpUsername() throws Exception {
+    @SetEnvironment(executionEnvironments = {ExecutionEnvironment.STANDALONE})
+    @Test(groups = "wso2.esb", description = "Inbound endpoint invalid FTP username Test Case")
+    public void testInboundInvalidFtpUsername() throws Exception {
 
-		File sourceFile = new File(pathToFtpDir + File.separator + "test.xml");
-		File targetFile = new File(FTPFolder + File.separator + "ftpin"
-				+ File.separator + "test.xml");
-		File outFile = new File(FTPFolder + File.separator + "ftpout"
-				+ File.separator + "test.xml");
+        File sourceFile = new File(pathToFtpDir + File.separator + "test.xml");
+        File targetFile = new File(FTPFolder + File.separator + "ftpin" + File.separator + "test.xml");
+        File outFile = new File(FTPFolder + File.separator + "ftpout" + File.separator + "test.xml");
 
-		try {
-			FileUtils.copyFile(sourceFile, targetFile);
-			addInboundEndpoint(addEndpoint3());
-			Thread.sleep(2000);
-			Assert.assertTrue(!outFile.exists());
+        try {
+            FileUtils.copyFile(sourceFile, targetFile);
+            addInboundEndpoint(addEndpoint3());
+            Awaitility.await()
+                      .pollInterval(50, TimeUnit.MILLISECONDS)
+                      .atMost(60, TimeUnit.SECONDS)
+                      .until(isFileNotExist(outFile));
+            Assert.assertTrue(!outFile.exists());
 
-		} finally {
-			deleteFile(targetFile);
-		}
-	}
+        } finally {
+            deleteFile(targetFile);
+        }
+    }
 
 	private OMElement addEndpoint1() throws Exception {
+
 		OMElement synapseConfig = null;
 		synapseConfig = AXIOMUtil
-				.stringToOM("<inboundEndpoint name=\"testFtpFile1\" onError=\"inFault\" protocol=\"file\"\n"
-						+ " sequence=\"requestHandlerSeq\" suspend=\"false\" xmlns=\"http://ws.apache.org/ns/synapse\">\"\n"
-						+ " <parameters>\n"
-						+ " <parameter name=\"interval\">1000</parameter>\n"
-						+ " <parameter name=\"coordination\">false</parameter>\n"
-						+ " <parameter name=\"transport.vfs.ActionAfterErrors\">NONE</parameter>\n"
-						+ " <parameter name=\"transport.vfs.Locking\">disable</parameter>\n"
-						+ " <parameter name=\"transport.vfs.ContentType\">application/xml</parameter>\n"
-						+ " <parameter name=\"transport.vfs.ActionAfterFailure\">NONE</parameter>\n"
-						+ " <parameter name=\"transport.vfs.ActionAfterProcess\">NONE</parameter>\n"
-						+ " <parameter name=\"transport.vfs.FileURI\">ftp://admin:admin@localhost:9653/ftpin/test.xml"
-						+ "</parameter>\n"
-						+ " </parameters>\n"
-						+ "</inboundEndpoint>\n");
+                .stringToOM("<inboundEndpoint name=\"testFtpFile1\" onError=\"inFault\" protocol=\"file\"\n"
+                            + " sequence=\"requestHandlerSeq\" suspend=\"false\" xmlns=\"http://ws.apache.org/ns/synapse\">\"\n"
+                            + " <parameters>\n"
+                            + " <parameter name=\"interval\">1000</parameter>\n"
+                            + " <parameter name=\"coordination\">false</parameter>\n"
+                            + " <parameter name=\"transport.vfs.ActionAfterErrors\">NONE</parameter>\n"
+                            + " <parameter name=\"transport.vfs.Locking\">disable</parameter>\n"
+                            + " <parameter name=\"transport.vfs.ContentType\">application/xml</parameter>\n"
+                            + " <parameter name=\"transport.vfs.ActionAfterFailure\">NONE</parameter>\n"
+                            + " <parameter name=\"transport.vfs.ActionAfterProcess\">NONE</parameter>\n"
+                            + " <parameter name=\"transport.vfs.FileURI\">ftp://admin:admin@localhost:9653/ftpin/test.xml"
+                            + "</parameter>\n"
+                            + " </parameters>\n"
+                            + "</inboundEndpoint>\n");
 
 		return synapseConfig;
 	}
 
 	private OMElement addEndpoint2() throws Exception {
+
 		OMElement synapseConfig = null;
 		synapseConfig = AXIOMUtil
 				.stringToOM("<inboundEndpoint name=\"testFtpFile2\" onError=\"inFault\" protocol=\"file\"\n"
-						+ " sequence=\"requestHandlerSeq\" suspend=\"false\" xmlns=\"http://ws.apache.org/ns/synapse\">\"\n"
-						+ " <parameters>\n"
-						+ " <parameter name=\"interval\">1000</parameter>\n"
-						+ " <parameter name=\"transport.vfs.ActionAfterErrors\">NONE</parameter>\n"
-						+ " <parameter name=\"transport.vfs.Locking\">enable</parameter>\n"
-						+ " <parameter name=\"transport.vfs.ContentType\">application/xml</parameter>\n"
-						+ " <parameter name=\"transport.vfs.ActionAfterFailure\">NONE</parameter>\n"
-						+ " <parameter name=\"transport.vfs.ActionAfterProcess\">MOVE</parameter>\n"
-						+ "<parameter name=\"transport.vfs.MoveAfterProcess\">ftp://admin:admin@localhost:9653/ftpout"
-						+ "</parameter>"
-						+ " <parameter name=\"transport.vfs.FileURI\">ftp://admin:admin@localhost:9653/ftpin"
-						+ "</parameter>\n"
-						+ " </parameters>\n"
-						+ "</inboundEndpoint>\n");
+                            + " sequence=\"requestHandlerSeq\" suspend=\"false\" xmlns=\"http://ws.apache.org/ns/synapse\">\"\n"
+                            + " <parameters>\n"
+                            + " <parameter name=\"interval\">1000</parameter>\n"
+                            + " <parameter name=\"transport.vfs.ActionAfterErrors\">NONE</parameter>\n"
+                            + " <parameter name=\"transport.vfs.Locking\">enable</parameter>\n"
+                            + " <parameter name=\"transport.vfs.ContentType\">application/xml</parameter>\n"
+                            + " <parameter name=\"transport.vfs.ActionAfterFailure\">NONE</parameter>\n"
+                            + " <parameter name=\"transport.vfs.ActionAfterProcess\">MOVE</parameter>\n"
+                            + "<parameter name=\"transport.vfs.MoveAfterProcess\">ftp://admin:admin@localhost:9653/ftpout"
+                            + "</parameter>"
+                            + " <parameter name=\"transport.vfs.FileURI\">ftp://admin:admin@localhost:9653/ftpin"
+                            + "</parameter>\n"
+                            + " </parameters>\n"
+                            + "</inboundEndpoint>\n");
 
 		return synapseConfig;
 	}
 
 	private OMElement addEndpoint3() throws Exception {
+
 		OMElement synapseConfig = null;
 		synapseConfig = AXIOMUtil
-				.stringToOM("<inboundEndpoint name=\"testFtpFile3\" onError=\"inFault\" protocol=\"file\"\n"
-						+ " sequence=\"requestHandlerSeq\" suspend=\"false\" xmlns=\"http://ws.apache.org/ns/synapse\">\"\n"
-						+ " <parameters>\n"
-						+ " <parameter name=\"interval\">1000</parameter>\n"
-						+ " <parameter name=\"coordination\">false</parameter>\n"
-						+ " <parameter name=\"transport.vfs.ActionAfterErrors\">NONE</parameter>\n"
-						+ " <parameter name=\"transport.vfs.Locking\">enable</parameter>\n"
-						+ " <parameter name=\"transport.vfs.ContentType\">application/xml</parameter>\n"
-						+ " <parameter name=\"transport.vfs.ActionAfterFailure\">NONE</parameter>\n"
-						+ " <parameter name=\"transport.vfs.ActionAfterProcess\">MOVE</parameter>\n"
-						+ "<parameter name=\"transport.vfs.MoveAfterProcess\">ftp://admin:admin@localhost:9653/ftpout/test.xml"
-						+ "</parameter>"
-						+ " <parameter name=\"transport.vfs.FileURI\">ftp://invalid:admin@localhost:9653/ftpin/test.xml"
-						+ "</parameter>\n"
-						+ " </parameters>\n"
-						+ "</inboundEndpoint>\n");
+                .stringToOM("<inboundEndpoint name=\"testFtpFile3\" onError=\"inFault\" protocol=\"file\"\n"
+                            + " sequence=\"requestHandlerSeq\" suspend=\"false\" xmlns=\"http://ws.apache.org/ns/synapse\">\"\n"
+                            + " <parameters>\n"
+                            + " <parameter name=\"interval\">1000</parameter>\n"
+                            + " <parameter name=\"coordination\">false</parameter>\n"
+                            + " <parameter name=\"transport.vfs.ActionAfterErrors\">NONE</parameter>\n"
+                            + " <parameter name=\"transport.vfs.Locking\">enable</parameter>\n"
+                            + " <parameter name=\"transport.vfs.ContentType\">application/xml</parameter>\n"
+                            + " <parameter name=\"transport.vfs.ActionAfterFailure\">NONE</parameter>\n"
+                            + " <parameter name=\"transport.vfs.ActionAfterProcess\">MOVE</parameter>\n"
+                            + "<parameter name=\"transport.vfs.MoveAfterProcess\">ftp://admin:admin@localhost:9653/ftpout/test.xml"
+                            + "</parameter>"
+                            + " <parameter name=\"transport.vfs.FileURI\">ftp://invalid:admin@localhost:9653/ftpin/test.xml"
+                            + "</parameter>\n"
+                            + " </parameters>\n"
+                            + "</inboundEndpoint>\n");
 
 		return synapseConfig;
 	}
@@ -253,4 +254,22 @@ public class FtpInboundTransportTest extends ESBIntegrationTest {
 	private boolean deleteFile(File file) throws IOException {
 		return file.exists() && file.delete();
 	}
+
+    private Callable<Boolean> isFileExist(final File file) {
+        return new Callable<Boolean>() {
+            @Override
+            public Boolean call() throws Exception {
+                return file.exists();
+            }
+        };
+    }
+
+    private Callable<Boolean> isFileNotExist(final File file) {
+        return new Callable<Boolean>() {
+            @Override
+            public Boolean call() throws Exception {
+            	return !file.exists();
+            }
+        };
+    }
 }

--- a/integration/mediation-tests/tests-transport/src/test/java/org/wso2/carbon/esb/https/inbound/transport/test/HttpsInboundTransportTestCase.java
+++ b/integration/mediation-tests/tests-transport/src/test/java/org/wso2/carbon/esb/https/inbound/transport/test/HttpsInboundTransportTestCase.java
@@ -18,16 +18,24 @@ package org.wso2.carbon.esb.https.inbound.transport.test;
 
 
 import org.apache.axiom.om.OMElement;
+import org.apache.commons.lang.ArrayUtils;
+import org.awaitility.Awaitility;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
+import org.wso2.carbon.sequences.stub.types.SequenceEditorException;
 import org.wso2.esb.integration.common.utils.ESBIntegrationTest;
 import org.wso2.esb.integration.common.utils.clients.SecureServiceClient;
 
 import javax.xml.stream.XMLStreamException;
 import java.io.File;
 import java.io.FileNotFoundException;
+import java.rmi.RemoteException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
 
 public class HttpsInboundTransportTestCase extends ESBIntegrationTest {
 
@@ -37,12 +45,24 @@ public class HttpsInboundTransportTestCase extends ESBIntegrationTest {
     public void setEnvironment() throws Exception {
         super.init();
         secureAxisServiceClient = new SecureServiceClient();
-        addSequence(getArtifactConfig("TestIn.xml"));
-        addSequence(getArtifactConfig("reciveSeq.xml"));
-        addSequence(getArtifactConfig("TestOut.xml"));
-        addInboundEndpoint(getArtifactConfig("synapse.xml"));
-        Thread.sleep(30000);
 
+        List<OMElement> sequenceList = new ArrayList<>();
+        sequenceList.add(getArtifactConfig("TestIn.xml"));
+        sequenceList.add(getArtifactConfig("reciveSeq.xml"));
+        sequenceList.add(getArtifactConfig("TestOut.xml"));
+        addSequence(sequenceList.get(0));
+        addSequence(sequenceList.get(1));
+        addSequence(sequenceList.get(2));
+
+        List<OMElement> inboundList = new ArrayList<>();
+        inboundList.add(getArtifactConfig("synapse.xml"));
+
+        addInboundEndpoint(inboundList.get(0));
+
+        Awaitility.await()
+                  .pollInterval(50, TimeUnit.MILLISECONDS)
+                  .atMost(60, TimeUnit.SECONDS)
+                  .until(isServicesDeployed(sequenceList, inboundList));
     }
 
     @Test(groups = "wso2.esb", description = "" )
@@ -75,4 +95,25 @@ public class HttpsInboundTransportTestCase extends ESBIntegrationTest {
         return synapseConfig;
     }
 
+    private Callable<Boolean> isServicesDeployed(final List<OMElement> omSeqList, final List<OMElement> omInboundList) {
+        return new Callable<Boolean>() {
+            @Override
+            public Boolean call() throws Exception {
+                boolean isServicesDeployed;
+                for(OMElement seqElement : omSeqList) {
+                    isServicesDeployed = isSequenceDeployed(seqElement);
+                    if (!isServicesDeployed) {
+                        return false;
+                    }
+                }
+                for(OMElement inElement : omInboundList) {
+                    isServicesDeployed = isInboundEndpointDeployed(inElement);
+                    if (!isServicesDeployed) {
+                        return false;
+                    }
+                }
+                return true;
+            }
+        };
+    }
 }

--- a/integration/mediation-tests/tests-transport/src/test/java/org/wso2/carbon/esb/jms/transport/test/MSMPCronForwarderCase.java
+++ b/integration/mediation-tests/tests-transport/src/test/java/org/wso2/carbon/esb/jms/transport/test/MSMPCronForwarderCase.java
@@ -19,6 +19,7 @@
 package org.wso2.carbon.esb.jms.transport.test;
 
 import org.apache.axiom.om.OMElement;
+import org.awaitility.Awaitility;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -36,6 +37,8 @@ import org.wso2.esb.integration.services.jaxrs.customersample.CustomerConfig;
 import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
@@ -48,6 +51,7 @@ public class MSMPCronForwarderCase extends ESBIntegrationTest {
 
     private TomcatServerManager tomcatServerManager;
     private LoggingAdminClient logAdmin;
+    private final int NUMBER_OF_MESSAGES = 4;
 
     @BeforeClass(alwaysRun = true)
     protected void init() throws Exception {
@@ -58,7 +62,10 @@ public class MSMPCronForwarderCase extends ESBIntegrationTest {
                 CustomerConfig.class.getName(), TomcatServerType.jaxrs.name(), 8080);
 
         tomcatServerManager.startServer();  // staring tomcat server instance
-        Thread.sleep(10000);
+        Awaitility.await()
+                  .pollInterval(50, TimeUnit.MILLISECONDS)
+                  .atMost(60, TimeUnit.SECONDS)
+                  .until(isServerStarted());
         logAdmin = new LoggingAdminClient(contextUrls.getBackEndUrl(), getSessionCookie());
     }
 
@@ -89,25 +96,10 @@ public class MSMPCronForwarderCase extends ESBIntegrationTest {
         assertEquals(response4.getResponseCode(), 202, "ESB failed to send 202 even after setting FORCE_SC_ACCEPTED");
 
         // WAIT FOR THE MESSAGE PROCESSOR TO TRIGGER
-        Thread.sleep(30000);
-
-        // ASSERT RESULTS
-        LogViewerClient logViewerClient =
-                new LogViewerClient(contextUrls.getBackEndUrl(), getSessionCookie());
-        LogEvent[] logEvents = logViewerClient.getAllSystemLogs();
-
-        boolean success = false;
-        int msgCount = 0;
-        for (int i = 0; i < logEvents.length ; i++) {
-            if (logEvents[i].getMessage().contains("Jack")) {
-                if (4 == ++msgCount) {
-                    success = true;
-                    break;
-                }
-            }
-        }
-
-        assertTrue(success, "Message process Forwarding does not work with cron expression");
+        Awaitility.await()
+                  .pollInterval(50, TimeUnit.MILLISECONDS)
+                  .atMost(60, TimeUnit.SECONDS)
+                  .until(isLogWritten());
     }
 
     @AfterClass(alwaysRun = true)
@@ -118,5 +110,39 @@ public class MSMPCronForwarderCase extends ESBIntegrationTest {
             tomcatServerManager.stop();
         }
         super.cleanup();
+    }
+
+    private Callable<Boolean> isServerStarted() {
+        return new Callable<Boolean>() {
+            @Override
+            public Boolean call() throws Exception {
+
+                return tomcatServerManager.isRunning();
+            }
+        };
+    }
+
+    private Callable<Boolean> isLogWritten() {
+        return new Callable<Boolean>() {
+            @Override
+            public Boolean call() throws Exception {
+                LogViewerClient logViewerClient =
+                        new LogViewerClient(contextUrls.getBackEndUrl(), getSessionCookie());
+                LogEvent[] logEvents = logViewerClient.getAllSystemLogs();
+
+                boolean success = false;
+                int msgCount = 0;
+                for (int i = 0; i < logEvents.length; i++) {
+                    if (logEvents[i].getMessage().contains("Jack")) {
+                        msgCount = ++msgCount;
+                        if (NUMBER_OF_MESSAGES == msgCount) {
+                            success = true;
+                            break;
+                        }
+                    }
+                }
+                return success;
+            }
+        };
     }
 }

--- a/integration/mediation-tests/tests-transport/src/test/java/org/wso2/carbon/esb/jms/transport/test/SpecialCharacterTestCase.java
+++ b/integration/mediation-tests/tests-transport/src/test/java/org/wso2/carbon/esb/jms/transport/test/SpecialCharacterTestCase.java
@@ -22,6 +22,7 @@ import org.apache.commons.io.IOUtils;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpEntityEnclosingRequest;
 import org.apache.http.HttpRequest;
+import org.awaitility.Awaitility;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -29,6 +30,7 @@ import org.wso2.carbon.automation.engine.annotations.ExecutionEnvironment;
 import org.wso2.carbon.automation.engine.annotations.SetEnvironment;
 import org.wso2.carbon.automation.extensions.servers.httpserver.RequestInterceptor;
 import org.wso2.carbon.automation.extensions.servers.httpserver.SimpleHttpServer;
+import org.wso2.carbon.automation.extensions.servers.jmsserver.client.JMSQueueMessageConsumer;
 import org.wso2.carbon.automation.test.utils.http.client.HttpRequestUtil;
 import org.wso2.esb.integration.common.utils.ESBIntegrationTest;
 import org.wso2.esb.integration.common.utils.JMSEndpointManager;
@@ -40,6 +42,8 @@ import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Properties;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
 
 import static org.testng.Assert.assertTrue;
 
@@ -56,8 +60,10 @@ public class SpecialCharacterTestCase extends ESBIntegrationTest {
     public void init() throws Exception {
         httpServer = new SimpleHttpServer(8097, new Properties());
         httpServer.start();
-        Thread.sleep(5000);
-
+        Awaitility.await()
+                  .pollInterval(50, TimeUnit.MILLISECONDS)
+                  .atMost(60, TimeUnit.SECONDS)
+                  .until(isStarted());
         interceptor = new TestRequestInterceptor();
         httpServer.getRequestHandler().setInterceptor(interceptor);
 
@@ -117,5 +123,14 @@ public class SpecialCharacterTestCase extends ESBIntegrationTest {
 
             httpServer.stop();
         }
+    }
+
+    private Callable<Boolean> isStarted() {
+        return new Callable<Boolean>() {
+            @Override
+            public Boolean call() throws Exception {
+                return httpServer.isStarted();
+            }
+        };
     }
 }

--- a/integration/mediation-tests/tests-transport/src/test/java/org/wso2/carbon/esb/nhttp/transport/test/ConfiguringNhttpAccessLogLocationTestCase.java
+++ b/integration/mediation-tests/tests-transport/src/test/java/org/wso2/carbon/esb/nhttp/transport/test/ConfiguringNhttpAccessLogLocationTestCase.java
@@ -16,6 +16,8 @@
 
 package org.wso2.carbon.esb.nhttp.transport.test;
 
+import org.apache.axiom.om.OMElement;
+import org.awaitility.Awaitility;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -34,7 +36,10 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.util.List;
 import java.util.Properties;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
 
 import static java.io.File.separator;
 
@@ -73,7 +78,10 @@ public class ConfiguringNhttpAccessLogLocationTestCase extends ESBIntegrationTes
 
         super.init();
         loadESBConfigurationFromClasspath("/artifacts/ESB/synapseconfig/nhttp_transport/nhttp_test_synapse.xml");
-        Thread.sleep(30000);
+        Awaitility.await()
+                  .pollInterval(50, TimeUnit.MILLISECONDS)
+                  .atMost(300, TimeUnit.SECONDS)
+                  .until(isServiceDeployed("NhttpLogsTestProxy"));
     }
 
     /**
@@ -137,5 +145,16 @@ public class ConfiguringNhttpAccessLogLocationTestCase extends ESBIntegrationTes
             serverConfigurationManager = null;
             nhttpLogDir = null;
         }
+    }
+
+    private Callable<Boolean> isServiceDeployed(final String proxyName) {
+
+        return new Callable<Boolean>() {
+            @Override
+            public Boolean call() throws Exception {
+
+                return isProxySuccesfullyDeployed(proxyName);
+            }
+        };
     }
 }

--- a/integration/mediation-tests/tests-transport/src/test/java/org/wso2/carbon/esb/vfs/transport/test/VFSTransportTestCase.java
+++ b/integration/mediation-tests/tests-transport/src/test/java/org/wso2/carbon/esb/vfs/transport/test/VFSTransportTestCase.java
@@ -20,6 +20,7 @@ package org.wso2.carbon.esb.vfs.transport.test;
 
 import org.apache.axiom.om.util.AXIOMUtil;
 import org.apache.commons.io.FileUtils;
+import org.awaitility.Awaitility;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -34,6 +35,8 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URL;
 import java.net.URLConnection;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
 
 import static org.testng.Assert.assertTrue;
 
@@ -163,8 +166,10 @@ public class VFSTransportTestCase extends ESBIntegrationTest {
         File outfile = new File(pathToVfsDir + "test" + File.separator + "out" + File.separator + "out.xml");
         try {
             FileUtils.copyFile(sourceFile, targetFile);
-            Thread.sleep(2000);
-
+            Awaitility.await()
+                      .pollInterval(50, TimeUnit.MILLISECONDS)
+                      .atMost(60, TimeUnit.SECONDS)
+                      .until(isFileExist(outfile));
             Assert.assertTrue(outfile.exists());
             String vfsOut = FileUtils.readFileToString(outfile);
             Assert.assertTrue(vfsOut.contains("WSO2 Company"));
@@ -191,7 +196,10 @@ public class VFSTransportTestCase extends ESBIntegrationTest {
 
         try {
             FileUtils.copyFile(sourceFile, targetFile);
-            Thread.sleep(2000);
+            Awaitility.await()
+                      .pollInterval(50, TimeUnit.MILLISECONDS)
+                      .atMost(60, TimeUnit.SECONDS)
+                      .until(isFileExist(outfile));
             Assert.assertTrue(outfile.exists());
             String vfsOut = FileUtils.readFileToString(outfile);
             Assert.assertTrue(vfsOut.contains("andun@wso2.com"));
@@ -218,8 +226,10 @@ public class VFSTransportTestCase extends ESBIntegrationTest {
         File outfile = new File(pathToVfsDir + "test" + File.separator + "out" + File.separator + "out.txt");
         try {
             FileUtils.copyFile(sourceFile, targetFile);
-            Thread.sleep(2000);
-
+            Awaitility.await()
+                      .pollInterval(50, TimeUnit.MILLISECONDS)
+                      .atMost(60, TimeUnit.SECONDS)
+                      .until(isFileExist(outfile));
             Assert.assertTrue(outfile.exists());
             String vfsOut = FileUtils.readFileToString(outfile);
             Assert.assertTrue(vfsOut.contains("andun@wso2.com"));
@@ -245,7 +255,10 @@ public class VFSTransportTestCase extends ESBIntegrationTest {
         File outfile = new File(pathToVfsDir + "test" + File.separator + "out" + File.separator + "out.txt");
         try {
             FileUtils.copyFile(sourceFile, targetFile);
-            Thread.sleep(2000);
+            Awaitility.await().
+                    pollInterval(50, TimeUnit.MILLISECONDS)
+                      .atMost(60, TimeUnit.SECONDS)
+                      .until(isFileNotExist(outfile));
             Assert.assertTrue(!outfile.exists());
         } finally {
             deleteFile(targetFile);
@@ -269,8 +282,10 @@ public class VFSTransportTestCase extends ESBIntegrationTest {
         File outfile = new File(pathToVfsDir + "test" + File.separator + "out" + File.separator + "out.txt");
         try {
             FileUtils.copyFile(sourceFile, targetFile);
-            Thread.sleep(2000);
-
+            Awaitility.await()
+                      .pollInterval(50, TimeUnit.MILLISECONDS)
+                      .atMost(60, TimeUnit.SECONDS)
+                      .until(isFileExist(outfile));
             Assert.assertTrue(outfile.exists());
             String vfsOut = FileUtils.readFileToString(outfile);
             Assert.assertTrue(vfsOut.contains("andun@wso2.com"));
@@ -297,11 +312,17 @@ public class VFSTransportTestCase extends ESBIntegrationTest {
 
         try {
             FileUtils.copyFile(sourceFile, targetFile);
-            Thread.sleep(1000);
 
+            Awaitility.await()
+                      .pollInterval(50, TimeUnit.MILLISECONDS)
+                      .atMost(60, TimeUnit.SECONDS)
+                      .until(isFileNotExist(outfile));
             Assert.assertTrue(!outfile.exists());
 
-            Thread.sleep(31000);
+            Awaitility.await()
+                      .pollInterval(50, TimeUnit.MILLISECONDS)
+                      .atMost(60, TimeUnit.SECONDS)
+                      .until(isFileExist(outfile));
             Assert.assertTrue(outfile.exists());
             String vfsOut = FileUtils.readFileToString(outfile);
             Assert.assertTrue(vfsOut.contains("andun@wso2.com"));
@@ -330,8 +351,11 @@ public class VFSTransportTestCase extends ESBIntegrationTest {
 
         try {
             FileUtils.copyFile(sourceFile, targetFile);
-            Thread.sleep(2000);
 
+            Awaitility.await()
+                      .pollInterval(50, TimeUnit.MILLISECONDS)
+                      .atMost(60, TimeUnit.SECONDS)
+                      .until(isFileExist(outfile));
             Assert.assertTrue(outfile.exists());
             String vfsOut = FileUtils.readFileToString(outfile);
             Assert.assertTrue(vfsOut.contains("andun@wso2.com"));
@@ -365,8 +389,11 @@ public class VFSTransportTestCase extends ESBIntegrationTest {
 
         try {
             FileUtils.copyFile(sourceFile, targetFile);
-            Thread.sleep(2000);
 
+            Awaitility.await()
+                      .pollInterval(50, TimeUnit.MILLISECONDS)
+                      .atMost(60, TimeUnit.SECONDS)
+                      .until(isFileExist(outfile));
             Assert.assertTrue(outfile.exists());
             String vfsOut = FileUtils.readFileToString(outfile);
             Assert.assertTrue(vfsOut.contains("andun@wso2.com"));
@@ -398,8 +425,11 @@ public class VFSTransportTestCase extends ESBIntegrationTest {
         File outfile = new File(pathToVfsDir + "test" + File.separator + "out" + File.separator + "out.txt");
         try {
             FileUtils.copyFile(sourceFile, targetFile);
-            Thread.sleep(2000);
 
+            Awaitility.await()
+                      .pollInterval(50, TimeUnit.MILLISECONDS)
+                      .atMost(60, TimeUnit.SECONDS)
+                      .until(isFileExist(outfile));
             Assert.assertTrue(outfile.exists());
             String vfsOut = FileUtils.readFileToString(outfile);
             Assert.assertTrue(vfsOut.contains("andun@wso2.com"));
@@ -427,8 +457,11 @@ public class VFSTransportTestCase extends ESBIntegrationTest {
         File outfile = new File(pathToVfsDir + "test" + File.separator + "out" + File.separator + "out123@wso2_text.txt");
         try {
             FileUtils.copyFile(sourceFile, targetFile);
-            Thread.sleep(2000);
 
+            Awaitility.await()
+                      .pollInterval(50, TimeUnit.MILLISECONDS)
+                      .atMost(60, TimeUnit.SECONDS)
+                      .until(isFileExist(outfile));
             Assert.assertTrue(outfile.exists());
             String vfsOut = FileUtils.readFileToString(outfile);
             Assert.assertTrue(vfsOut.contains("andun@wso2.com"));
@@ -455,8 +488,11 @@ public class VFSTransportTestCase extends ESBIntegrationTest {
         File outfile = new File(pathToVfsDir + "test" + File.separator + "out" + File.separator + "response.xml");
         try {
             FileUtils.copyFile(sourceFile, targetFile);
-            Thread.sleep(2000);
 
+            Awaitility.await()
+                      .pollInterval(50, TimeUnit.MILLISECONDS)
+                      .atMost(60, TimeUnit.SECONDS)
+                      .until(isFileExist(outfile));
             Assert.assertTrue(outfile.exists());
             String vfsOut = FileUtils.readFileToString(outfile);
             Assert.assertTrue(vfsOut.contains("andun@wso2.com"));
@@ -484,8 +520,15 @@ public class VFSTransportTestCase extends ESBIntegrationTest {
         File originalFile = new File(pathToVfsDir + "test" + File.separator + "failure" + File.separator + "fail.xml");
         try {
             FileUtils.copyFile(sourceFile, targetFile);
-            Thread.sleep(2000);
 
+            Awaitility.await()
+                      .pollInterval(50, TimeUnit.MILLISECONDS)
+                      .atMost(60, TimeUnit.SECONDS)
+                      .until(isFileNotExist(outfile));
+            Awaitility.await()
+                      .pollInterval(50, TimeUnit.MILLISECONDS)
+                      .atMost(60, TimeUnit.SECONDS)
+                      .until(isFileExist(originalFile));
             Assert.assertTrue(!outfile.exists());
 
             Assert.assertTrue(originalFile.exists());
@@ -549,8 +592,11 @@ public class VFSTransportTestCase extends ESBIntegrationTest {
         File originalFile = new File(pathToVfsDir + "test" + File.separator + "failure" + File.separator + "fail.xml");
         try {
             FileUtils.copyFile(sourceFile, targetFile);
-            Thread.sleep(2000);
 
+            Awaitility.await()
+                      .pollInterval(50, TimeUnit.MILLISECONDS)
+                      .atMost(60, TimeUnit.SECONDS)
+                      .until(isFileNotExist(outfile));
             Assert.assertTrue(!outfile.exists());
             Assert.assertTrue(!originalFile.exists());
             Assert.assertFalse(new File(pathToVfsDir + "test" + File.separator + "in" + File.separator +
@@ -597,7 +643,11 @@ public class VFSTransportTestCase extends ESBIntegrationTest {
         File outfile = new File(pathToVfsDir + "test" + File.separator + "out" + File.separator + "out.xml");
         try {
             FileUtils.copyFile(sourceFile, targetFile);
-            Thread.sleep(2000);
+
+            Awaitility.await()
+                      .pollInterval(50, TimeUnit.MILLISECONDS)
+                      .atMost(60, TimeUnit.SECONDS)
+                      .until(isFileExist(outfile));
 
             Assert.assertTrue(outfile.exists());
             String vfsOut = FileUtils.readFileToString(outfile);
@@ -626,7 +676,10 @@ public class VFSTransportTestCase extends ESBIntegrationTest {
         File outfile = new File(pathToVfsDir + "test" + File.separator + "out" + File.separator + "out.xml");
         try {
             FileUtils.copyFile(sourceFile, targetFile);
-            Thread.sleep(2000);
+            Awaitility.await()
+                      .pollInterval(50, TimeUnit.MILLISECONDS)
+                      .atMost(60, TimeUnit.SECONDS)
+                      .until(isFileNotExist(outfile));
 
             Assert.assertTrue(!outfile.exists());
         } finally {
@@ -652,7 +705,11 @@ public class VFSTransportTestCase extends ESBIntegrationTest {
         File outfile = new File(pathToVfsDir + "test" + File.separator + "out" + File.separator + "out.xml");
         try {
             FileUtils.copyFile(sourceFile, targetFile);
-            Thread.sleep(2000);
+
+            Awaitility.await()
+                      .pollInterval(50, TimeUnit.MILLISECONDS)
+                      .atMost(60, TimeUnit.SECONDS)
+                      .until(isFileNotExist(outfile));
             //The poll interval will be set to 300s here,
 
             Assert.assertTrue(!outfile.exists());
@@ -680,8 +737,10 @@ public class VFSTransportTestCase extends ESBIntegrationTest {
         File originalFile = new File(pathToVfsDir + "test" + File.separator + "original" + File.separator + "test.xml");
         try {
             FileUtils.copyFile(sourceFile, targetFile);
-            Thread.sleep(2000);
-
+            Awaitility.await()
+                      .pollInterval(50, TimeUnit.MILLISECONDS)
+                      .atMost(60, TimeUnit.SECONDS)
+                      .until(isFileExist(outfile));
             Assert.assertTrue(outfile.exists());
             String vfsOut = FileUtils.readFileToString(outfile);
             Assert.assertTrue(vfsOut.contains("WSO2 Company"));
@@ -713,8 +772,18 @@ public class VFSTransportTestCase extends ESBIntegrationTest {
         File originalFile = new File(pathToVfsDir + "test" + File.separator + "failure" + File.separator + "fail.xml");
         try {
             FileUtils.copyFile(sourceFile, targetFile);
-            Thread.sleep(2000);
-
+            Awaitility.await()
+                      .pollInterval(50, TimeUnit.MILLISECONDS)
+                      .atMost(60, TimeUnit.SECONDS)
+                      .until(isFileNotExist(outfile));
+            Awaitility.await()
+                      .pollInterval(50, TimeUnit.MILLISECONDS)
+                      .atMost(60, TimeUnit.SECONDS)
+                      .until(isFileExist(originalFile));
+            Awaitility.await()
+                      .pollInterval(50, TimeUnit.MILLISECONDS)
+                      .atMost(60, TimeUnit.SECONDS)
+                      .until(isFileExist(targetFile));
             Assert.assertTrue(!outfile.exists());
             Assert.assertTrue(!originalFile.exists());
             Assert.assertTrue(!targetFile.exists());
@@ -744,7 +813,10 @@ public class VFSTransportTestCase extends ESBIntegrationTest {
         File originalFile = new File(pathToVfsDir + "test" + File.separator + "processed" + File.separator + "test.xml");
         try {
             FileUtils.copyFile(sourceFile, targetFile);
-            Thread.sleep(2000);
+            Awaitility.await()
+                      .pollInterval(50, TimeUnit.MILLISECONDS)
+                      .atMost(60, TimeUnit.SECONDS)
+                      .until(isFileExist(outfile));
 
             Assert.assertFalse(outfile.exists(), "Out put file found");
             Assert.assertFalse(originalFile.exists(), "Input file moved even if file processing is failed");
@@ -773,7 +845,10 @@ public class VFSTransportTestCase extends ESBIntegrationTest {
         File originalFileAfterProcessed = new File(pathToVfsDir + "test" + File.separator + "processed" + File.separator + "test.xml");
         try {
             FileUtils.copyFile(sourceFile, targetFile);
-            Thread.sleep(2000);
+            Awaitility.await()
+                      .pollInterval(50, TimeUnit.MILLISECONDS)
+                      .atMost(60, TimeUnit.SECONDS)
+                      .until(isFileExist(outfile));
 
             Assert.assertTrue(outfile.exists(), "out put file not found");
             String vfsOut = FileUtils.readFileToString(outfile);
@@ -808,7 +883,18 @@ public class VFSTransportTestCase extends ESBIntegrationTest {
                                  "fail.xml.lock");*/
         try {
             FileUtils.copyFile(sourceFile, targetFile);
-            Thread.sleep(2000);
+            Awaitility.await()
+                      .pollInterval(50, TimeUnit.MILLISECONDS)
+                      .atMost(60, TimeUnit.SECONDS)
+                      .until(isFileExist(outfile));
+            Awaitility.await()
+                      .pollInterval(50, TimeUnit.MILLISECONDS)
+                      .atMost(60, TimeUnit.SECONDS)
+                      .until(isFileExist(originalFile));
+            Awaitility.await()
+                      .pollInterval(50, TimeUnit.MILLISECONDS)
+                      .atMost(60, TimeUnit.SECONDS)
+                      .until(isFileExist(targetFile));
 
             Assert.assertFalse(outfile.exists(), "Out put file found");
             Assert.assertTrue(originalFile.exists(), "Input file not moved even if failure happens while building message");
@@ -842,8 +928,11 @@ public class VFSTransportTestCase extends ESBIntegrationTest {
         FileUtils.cleanDirectory(new File(pathToVfsDir + "test" + File.separator + "in"));
         try {
             FileUtils.copyFile(sourceFile, targetFile);
-            Thread.sleep(4000);
 
+            Awaitility.await()
+                      .pollInterval(50, TimeUnit.MILLISECONDS)
+                      .atMost(60, TimeUnit.SECONDS)
+                      .until(isFileExist(outfile));
             Assert.assertTrue(outfile.exists());
             String vfsOut = FileUtils.readFileToString(outfile);
             Assert.assertTrue(vfsOut.contains("WSO2 Company"));
@@ -870,7 +959,10 @@ public class VFSTransportTestCase extends ESBIntegrationTest {
         File outfile = new File(pathToVfsDir + "test" + File.separator + "out" + File.separator + "out.xml");
         try {
             FileUtils.copyFile(sourceFile, targetFile);
-            Thread.sleep(2000);
+            Awaitility.await()
+                      .pollInterval(50, TimeUnit.MILLISECONDS)
+                      .atMost(60, TimeUnit.SECONDS)
+                      .until(isFileNotExist(outfile));
             Assert.assertTrue(!outfile.exists());
         } finally {
             deleteFile(targetFile);
@@ -1509,6 +1601,24 @@ public class VFSTransportTestCase extends ESBIntegrationTest {
 
     private boolean deleteFile(File file) throws IOException {
         return file.exists() && file.delete();
+    }
+
+    private Callable<Boolean> isFileExist(final File file) {
+        return new Callable<Boolean>() {
+            @Override
+            public Boolean call() throws Exception {
+                return file.exists();
+            }
+        };
+    }
+
+    private Callable<Boolean> isFileNotExist(final File file) {
+        return new Callable<Boolean>() {
+            @Override
+            public Boolean call() throws Exception {
+                return !file.exists();
+            }
+        };
     }
 }
 


### PR DESCRIPTION
## Purpose

We observed unnecessary usages of thread sleep, In most test cases in mediation-tests/tests-transport. This exercise is carried out to remove those as much.