### PR TITLE
Fix file accessing issue in Windows environment of test-patches module

### DIFF
--- a/integration/mediation-tests/tests-patches/src/test/java/org/wso2/carbon/esb/passthru/transport/test/ESBJAVA3336HostHeaderValuePortCheckTestCase.java
+++ b/integration/mediation-tests/tests-patches/src/test/java/org/wso2/carbon/esb/passthru/transport/test/ESBJAVA3336HostHeaderValuePortCheckTestCase.java
@@ -103,9 +103,7 @@ public class ESBJAVA3336HostHeaderValuePortCheckTestCase extends ESBIntegrationT
             fos = new FileOutputStream(destinationFile);
             Properties properties = new Properties();
             properties.load(fis);
-            if (fis != null) {
-                fis.close();
-            }
+            fis.close();
             properties.setProperty(key, value);
             properties.store(fos, null);
             fos.flush();

--- a/integration/mediation-tests/tests-patches/src/test/java/org/wso2/carbon/esb/passthru/transport/test/ESBJAVA3336HostHeaderValuePortCheckTestCase.java
+++ b/integration/mediation-tests/tests-patches/src/test/java/org/wso2/carbon/esb/passthru/transport/test/ESBJAVA3336HostHeaderValuePortCheckTestCase.java
@@ -103,18 +103,17 @@ public class ESBJAVA3336HostHeaderValuePortCheckTestCase extends ESBIntegrationT
             fos = new FileOutputStream(destinationFile);
             Properties properties = new Properties();
             properties.load(fis);
+            fis.close();
             properties.setProperty(key, value);
             properties.store(fos, null);
+            fos.flush();
+            fos.close();
             serverConfigurationManager.applyConfigurationWithoutRestart(destinationFile);
         } catch (Exception e) {
             Assert.assertTrue(false, "Exception occured with the message: " + e.getMessage());
         } finally {
-            if (fis != null) {
-                fis.close();
-            }
-            if (fos != null) {
-                fos.close();
-            }
+            fis = null;
+            fos = null;
         }
     }
 }

--- a/integration/mediation-tests/tests-patches/src/test/java/org/wso2/carbon/esb/passthru/transport/test/ESBJAVA3336HostHeaderValuePortCheckTestCase.java
+++ b/integration/mediation-tests/tests-patches/src/test/java/org/wso2/carbon/esb/passthru/transport/test/ESBJAVA3336HostHeaderValuePortCheckTestCase.java
@@ -103,17 +103,22 @@ public class ESBJAVA3336HostHeaderValuePortCheckTestCase extends ESBIntegrationT
             fos = new FileOutputStream(destinationFile);
             Properties properties = new Properties();
             properties.load(fis);
-            fis.close();
+            if (fis != null) {
+                fis.close();
+            }
             properties.setProperty(key, value);
             properties.store(fos, null);
             fos.flush();
-            fos.close();
             serverConfigurationManager.applyConfigurationWithoutRestart(destinationFile);
         } catch (Exception e) {
             Assert.assertTrue(false, "Exception occured with the message: " + e.getMessage());
         } finally {
-            fis = null;
-            fos = null;
+            if (fis != null) {
+                fis.close();
+            }
+            if (fos != null) {
+                fos.close();
+            }
         }
     }
 }

--- a/integration/mediation-tests/tests-patches/src/test/java/org/wso2/carbon/esb/passthru/transport/test/HttpAccessLogTestCase.java
+++ b/integration/mediation-tests/tests-patches/src/test/java/org/wso2/carbon/esb/passthru/transport/test/HttpAccessLogTestCase.java
@@ -135,17 +135,22 @@ public class HttpAccessLogTestCase extends ESBIntegrationTest {
             fos = new FileOutputStream(destinationFile);
             Properties properties = new Properties();
             properties.load(fis);
-            fis.close();
+            if (fis != null) {
+                fis.close();
+            }
             properties.setProperty(key, value);
             properties.store(fos, null);
             fos.flush();
-            fos.close();
             serverConfigurationManager.applyConfigurationWithoutRestart(destinationFile);
         } catch (Exception e) {
             Assert.assertTrue(false, "Exception occured with the message: " + e.getMessage());
         } finally {
-            fis = null;
-            fos = null;
+            if (fis != null) {
+                fis.close();
+            }
+            if (fos != null) {
+                fos.close();
+            }
         }
     }
 

--- a/integration/mediation-tests/tests-patches/src/test/java/org/wso2/carbon/esb/passthru/transport/test/HttpAccessLogTestCase.java
+++ b/integration/mediation-tests/tests-patches/src/test/java/org/wso2/carbon/esb/passthru/transport/test/HttpAccessLogTestCase.java
@@ -135,18 +135,17 @@ public class HttpAccessLogTestCase extends ESBIntegrationTest {
             fos = new FileOutputStream(destinationFile);
             Properties properties = new Properties();
             properties.load(fis);
+            fis.close();
             properties.setProperty(key, value);
             properties.store(fos, null);
+            fos.flush();
+            fos.close();
             serverConfigurationManager.applyConfigurationWithoutRestart(destinationFile);
         } catch (Exception e) {
             Assert.assertTrue(false, "Exception occured with the message: " + e.getMessage());
         } finally {
-            if (fis != null) {
-                fis.close();
-            }
-            if (fos != null) {
-                fos.close();
-            }
+            fis = null;
+            fos = null;
         }
     }
 

--- a/integration/mediation-tests/tests-patches/src/test/java/org/wso2/carbon/esb/passthru/transport/test/HttpAccessLogTestCase.java
+++ b/integration/mediation-tests/tests-patches/src/test/java/org/wso2/carbon/esb/passthru/transport/test/HttpAccessLogTestCase.java
@@ -135,9 +135,7 @@ public class HttpAccessLogTestCase extends ESBIntegrationTest {
             fos = new FileOutputStream(destinationFile);
             Properties properties = new Properties();
             properties.load(fis);
-            if (fis != null) {
-                fis.close();
-            }
+            fis.close();
             properties.setProperty(key, value);
             properties.store(fos, null);
             fos.flush();


### PR DESCRIPTION
## Purpose
Tests run in Windows environment gives an error saying as the the process cannot access the file because it is being used by another process. Error is because of resource leak due to FileInputStream , FileOutputStream are not closed on method exit. Therefore made a fix to the issue.

## Goals
> Modify the scripts by closing the resources before method exit.
