### PR TITLE
interminant issue fixes BpelRetireDeploymentTest

### DIFF
--- a/integration/business-process-tests/tests-integration/bpel/pom.xml
+++ b/integration/business-process-tests/tests-integration/bpel/pom.xml
@@ -277,5 +277,11 @@
             <artifactId>automation-extensions</artifactId>
             <version>${product.ei.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <version>${awaitility.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
## Purpose
> Fixes for the intermittent issue of BpelRetireDeploymentTest for business process module.

## Approach
> Added the Awaitility library to continuously check whether server is updated with new configurations instead of waiting for fixed timeout.