### PR TITLE
Fix test case failure  due to "java.net.SocketTimeoutException : Read Timed Out"

### DIFF
--- a/integration/mediation-tests/tests-service/src/test/resources/artifacts/ESB/synapseconfig/rest/RestPostFixUrl.xml
+++ b/integration/mediation-tests/tests-service/src/test/resources/artifacts/ESB/synapseconfig/rest/RestPostFixUrl.xml
@@ -32,7 +32,7 @@
                     <endpoint>
                         <address statistics="disable" trace="disable" uri="http://localhost:8480/services/testAPI">
                             <timeout>
-                                <duration>0</duration>
+                                <duration>10000</duration>
                                 <responseAction>discard</responseAction>
                             </timeout>
                             <markForSuspension>


### PR DESCRIPTION
## Purpose
The test case cannot run in windows and centOS, because of "java.net.SocketTimeoutException: Read Timed Out"

## Goals
fix the issue, by increasing the endpoint timeout value.

## Test environment
> Windows - 2016, ORACLE_JDK8, mysql - 5.7
Windows - 2016, ORACLE_JDK8, oracle-se2 - 12.1.0.2.v12
