### PR TITLE
Fix to increase wait timeout until the task remove from user

### DIFF
--- a/integration/business-process-tests/tests-integration/bpmn/pom.xml
+++ b/integration/business-process-tests/tests-integration/bpmn/pom.xml
@@ -312,5 +312,10 @@
             <artifactId>automation-extensions</artifactId>
             <version>${product.ei.version}</version>
         </dependency>
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <version>${awaitility.version}</version>
+        </dependency>
     </dependencies>
 </project>

--- a/integration/business-process-tests/tests-integration/bpmn/src/test/java/org/wso2/ei/businessprocess/integration/tests/bpmn/BPMNUserSubstitutionTestCase.java
+++ b/integration/business-process-tests/tests-integration/bpmn/src/test/java/org/wso2/ei/businessprocess/integration/tests/bpmn/BPMNUserSubstitutionTestCase.java
@@ -158,12 +158,11 @@ public class BPMNUserSubstitutionTestCase extends BPSMasterTest {
         String getSubResponse = getSubstitute(USER4);
         JSONObject jsonResponse = new JSONObject(getSubResponse);
         Assert.assertTrue("null".equals(jsonResponse.getString("endTime")), "Add sub with endTime null");
-        Thread.sleep(2 * 60 * 1000); // need to wait till activation time passed
 
         //task should be assigned to user1, user4 should have no tasks
         Awaitility.await()
                 .pollInterval(50, TimeUnit.MILLISECONDS)
-                .atMost(180000, TimeUnit.MILLISECONDS)
+                .atMost(300000, TimeUnit.MILLISECONDS)
                 .until(isTaskRemoveFromUser(USER4));
 
         JSONObject user4TasksJson = findTasksWithGivenAssignee(USER4);

--- a/integration/business-process-tests/tests-integration/bpmn/src/test/java/org/wso2/ei/businessprocess/integration/tests/bpmn/BPMNUserSubstitutionTestCase.java
+++ b/integration/business-process-tests/tests-integration/bpmn/src/test/java/org/wso2/ei/businessprocess/integration/tests/bpmn/BPMNUserSubstitutionTestCase.java
@@ -42,6 +42,9 @@ import java.io.File;
 import java.io.IOException;
 import java.rmi.RemoteException;
 import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+import org.awaitility.Awaitility;
 
 public class BPMNUserSubstitutionTestCase extends BPSMasterTest {
     private static final Log log = LogFactory.getLog(BPMNUserSubstitutionTestCase.class);
@@ -156,7 +159,13 @@ public class BPMNUserSubstitutionTestCase extends BPSMasterTest {
         JSONObject jsonResponse = new JSONObject(getSubResponse);
         Assert.assertTrue("null".equals(jsonResponse.getString("endTime")), "Add sub with endTime null");
         Thread.sleep(2 * 60 * 1000); // need to wait till activation time passed
+
         //task should be assigned to user1, user4 should have no tasks
+        Awaitility.await()
+                .pollInterval(50, TimeUnit.MILLISECONDS)
+                .atMost(180000, TimeUnit.MILLISECONDS)
+                .until(isTaskRemoveFromUser(USER4));
+
         JSONObject user4TasksJson = findTasksWithGivenAssignee(USER4);
         Assert.assertEquals(user4TasksJson.getInt("total"), 0, "Substitution activation by scheduler");
     }
@@ -328,6 +337,19 @@ public class BPMNUserSubstitutionTestCase extends BPSMasterTest {
 
         HttpResponse response = BPMNTestUtils.putRequest(backEndUrl + SUBSTITUTE_URL + "/" + assignee, payload);
         return response.getStatusLine().getStatusCode();
+    }
+
+    private Callable<Boolean> isTaskRemoveFromUser(final String assignee) {
+        return new Callable<Boolean>() {
+            @Override
+            public Boolean call() throws Exception {
+                if (findTasksWithGivenAssignee(assignee).getInt("total")==0) {
+                    return true;
+                } else {
+                    return false;
+                }
+            }
+        };
     }
 
     @AfterClass(alwaysRun = true)


### PR DESCRIPTION
## Purpose
Take more than the specified amount of time to remove task from a user after assigning it to another user. According to the test, it waits for 2 min till the task activation within the new user. After the activation, the task should remove from the previous user. But it takes more than 2 mins. Due to the slowness, the test considers as the task has already been activated within the previous user.

## Goals
Wait till the task remove from previous user.

## Approach
Use Awaitility to wait until task remove from user.

## Automation tests
 - Integration tests

## Test environment
OS: Windows 
JDK: ORACLE_JDK8 
DB: mysql 5.7