### PR TITLE
Fix time out issue due to slowness

### DIFF
--- a/integration/business-process-tests/tests-integration/bpel/src/test/java/org/wso2/ei/businessprocess/integration/tests/bpel/upload/BpelRetireDeploymentTest.java
+++ b/integration/business-process-tests/tests-integration/bpel/src/test/java/org/wso2/ei/businessprocess/integration/tests/bpel/upload/BpelRetireDeploymentTest.java
@@ -71,7 +71,7 @@ public class BpelRetireDeploymentTest extends BPSMasterTest {
 
         Awaitility.await()
                   .pollInterval(50, TimeUnit.MILLISECONDS)
-                  .atMost(60, TimeUnit.SECONDS)
+                  .atMost(150, TimeUnit.SECONDS)
                   .until(isServiceDeployed("HelloWorld-retire"));
 
         String processId = bpelProcessManagementClient.getProcessId("HelloWorld-retire");

--- a/integration/business-process-tests/tests-integration/bpel/src/test/java/org/wso2/ei/businessprocess/integration/tests/bpel/upload/BpelVersioningTest.java
+++ b/integration/business-process-tests/tests-integration/bpel/src/test/java/org/wso2/ei/businessprocess/integration/tests/bpel/upload/BpelVersioningTest.java
@@ -52,6 +52,7 @@ public class BpelVersioningTest extends BPSMasterTest {
     BpelPackageManagementClient bpelPackageManagementClient;
     BpelProcessManagementClient bpelProcessManagementClient;
     BpelInstanceManagementClient bpelInstanceManagementClient;
+    private final int MAX_TIME = 1000;
 
     private RequestSender requestSender;
     private LinkedList<String> activeStatus;
@@ -80,7 +81,7 @@ public class BpelVersioningTest extends BPSMasterTest {
 
         Awaitility.await()
                 .pollInterval(50, TimeUnit.MILLISECONDS)
-                .atMost(100, TimeUnit.SECONDS)
+                .atMost(MAX_TIME, TimeUnit.SECONDS)
                 .until(isInforListAvailable("HelloWorld2"));
         List<String> processBefore = bpelProcessManagementClient.getProcessInfoList("HelloWorld2");
         activeStatus = new LinkedList<String>();
@@ -119,13 +120,13 @@ public class BpelVersioningTest extends BPSMasterTest {
 
             Awaitility.await()
                     .pollInterval(50, TimeUnit.MILLISECONDS)
-                    .atMost(1000, TimeUnit.SECONDS)
+                    .atMost(MAX_TIME, TimeUnit.SECONDS)
                     .until(isInforListAvailable("HelloWorld2"));
             processAfter = bpelProcessManagementClient.getProcessInfoList("HelloWorld2");
 
             Awaitility.await()
                     .pollInterval(20, TimeUnit.MILLISECONDS)
-                    .atMost(1000, TimeUnit.SECONDS)
+                    .atMost(MAX_TIME, TimeUnit.SECONDS)
                     .until(isProcessRetired());
             if (bpelProcessManagementClient.getStatus(activeStatus.get(0)).equals(ProcessStatus.RETIRED.toString()))
                 break;
@@ -161,9 +162,8 @@ public class BpelVersioningTest extends BPSMasterTest {
             public Boolean call() throws Exception {
                 if (bpelProcessManagementClient.getProcessInfoList(packageName) != null) {
                     return true;
-                } else {
-                    return false;
                 }
+                    return false;
             }
         };
     }
@@ -174,9 +174,8 @@ public class BpelVersioningTest extends BPSMasterTest {
             public Boolean call() throws Exception {
                 if (bpelProcessManagementClient.getStatus(activeStatus.get(0)).equals(ProcessStatus.RETIRED.toString())) {
                     return true;
-                } else {
-                    return false;
                 }
+                    return false;
             }
         };
     }

--- a/integration/business-process-tests/tests-integration/bpel/src/test/java/org/wso2/ei/businessprocess/integration/tests/bpel/upload/BpelVersioningTest.java
+++ b/integration/business-process-tests/tests-integration/bpel/src/test/java/org/wso2/ei/businessprocess/integration/tests/bpel/upload/BpelVersioningTest.java
@@ -75,7 +75,7 @@ public class BpelVersioningTest extends BPSMasterTest {
     public void getVersion() throws RemoteException, XMLStreamException, InterruptedException,
             ProcessManagementException {
 
-        Thread.sleep(5000);
+        Thread.sleep(10000);
         List<String> processBefore = bpelProcessManagementClient.getProcessInfoList("HelloWorld2");
         activeStatus = new LinkedList<String>();
         for (String processid : processBefore) {
@@ -110,7 +110,7 @@ public class BpelVersioningTest extends BPSMasterTest {
         uploadBpelForTest("HelloWorld2", artifactLocation);
         List<String> processAfter = null;
         for (int a = 0; a <= 10; a++) {
-            Thread.sleep(5000);
+            Thread.sleep(10000);
             processAfter = bpelProcessManagementClient.getProcessInfoList("HelloWorld2");
             if (bpelProcessManagementClient.getStatus(activeStatus.get(0)).equals(ProcessStatus.RETIRED.toString()))
                 break;

--- a/integration/mediation-tests/tests-common/integration-test-utils/src/main/java/org/wso2/esb/integration/common/utils/clients/stockquoteclient/StockQuoteClient.java
+++ b/integration/mediation-tests/tests-common/integration-test-utils/src/main/java/org/wso2/esb/integration/common/utils/clients/stockquoteclient/StockQuoteClient.java
@@ -41,6 +41,7 @@ import java.util.List;
 public class StockQuoteClient {
 
     private static final Log log = LogFactory.getLog(StockQuoteClient.class);
+    private final int MAX_TIME = 60000;
 
     private List<Header> httpHeaders = new ArrayList<Header>();
 
@@ -280,7 +281,7 @@ public class StockQuoteClient {
         if (httpHeaders.size() > 0) {
             options.setProperty(HTTPConstants.HTTP_HEADERS, httpHeaders);
         }
-        options.setTimeOutInMilliSeconds(60000);
+        options.setTimeOutInMilliSeconds(MAX_TIME);
       /*  options.setProperty(HTTPConstants.CHUNKED, Constants.VALUE_FALSE);
         options.setProperty(Constants.Configuration.MESSAGE_TYPE,HTTPConstants.MEDIA_TYPE_APPLICATION_ECHO_XML);
         options.setProperty(Constants.Configuration.DISABLE_SOAP_ACTION,Boolean.TRUE);*/

--- a/integration/mediation-tests/tests-common/integration-test-utils/src/main/java/org/wso2/esb/integration/common/utils/clients/stockquoteclient/StockQuoteClient.java
+++ b/integration/mediation-tests/tests-common/integration-test-utils/src/main/java/org/wso2/esb/integration/common/utils/clients/stockquoteclient/StockQuoteClient.java
@@ -280,7 +280,7 @@ public class StockQuoteClient {
         if (httpHeaders.size() > 0) {
             options.setProperty(HTTPConstants.HTTP_HEADERS, httpHeaders);
         }
-        options.setTimeOutInMilliSeconds(45000);
+        options.setTimeOutInMilliSeconds(60000);
       /*  options.setProperty(HTTPConstants.CHUNKED, Constants.VALUE_FALSE);
         options.setProperty(Constants.Configuration.MESSAGE_TYPE,HTTPConstants.MEDIA_TYPE_APPLICATION_ECHO_XML);
         options.setProperty(Constants.Configuration.DISABLE_SOAP_ACTION,Boolean.TRUE);*/


### PR DESCRIPTION
## Purpose
Get read timeout issues while test execution, due to slowness in the system.

## Goals
Increase the wait time in thread.sleep and Awaitility.

## Automation tests
 - Integration tests

## Test environment
OS: CentOS
JDK: ORACLE_JDK8
DB: mysql 5.7, oracle-se2 - 12.1.0.2.v12, sqlserver-se - 13.00
