### PR TITLE
Fix MTOM Forward test-case

### DIFF
--- a/integration/mediation-tests/tests-patches/src/test/resources/artifacts/ESB/server/repository/deployment/server/synapse-configs/default/proxy-services/MTOMChecker.xml
+++ b/integration/mediation-tests/tests-patches/src/test/resources/artifacts/ESB/server/repository/deployment/server/synapse-configs/default/proxy-services/MTOMChecker.xml
@@ -13,14 +13,14 @@
             <header name="Action" value="uploadFileUsingMTOM"/>
             <send>
                 <endpoint>
-                    <address uri="http://localhost:9001/services/MTOMSwASampleService"/>
+                    <address uri="http://localhost:9001/services/MTOMSwASampleService" optimize="mtom"/>
                 </endpoint>
             </send>
         </inSequence>
         <outSequence>
+            <property name="enableMTOM" value="true" scope="axis2"/>
             <send/>
         </outSequence>
     </target>
-    <parameter name="enableMTOM">true</parameter>
     <description/>
 </proxy>


### PR DESCRIPTION
## Purpose

Test-suite is failing after the fix introduced by PR: 
https://github.com/wso2/carbon-mediation/pull/1108

Reason was testcase was not written in a way to enable MTOM. 


## Goals

Fix test case ESBJAVA4909MultipartRelatedTestCase

## Approach


**Without the fix - always use SOAP 12 at BinaryRelayBuilder**

It does not build the message and return as it is SOAP 12  [1]

**With fix - if client sends SOAP 11, use SOAP 11 factory otherwise use SOAP 12 factory at BinaryRelayBuilder**

It builds the message, changing to messageType to text/xml [2]
As described on previous mail, this causes ESB to select SOAPMessageFormatter instead of ExpandingMessageFormatter, causing MIME response to be malformed. 


if ((Boolean) isClientDoingSOAP11Obj) {     // If request is in SOAP11 format

    if (isResponseSOAP11) {  // Response is also in the SOAP11 format - no conversion required
        return;
    }

    try {                   // Message need to be built prior to the conversion
        RelayUtils.buildMessage(((Axis2MessageContext) synCtx).getAxis2MessageContext(), false);
    } catch (Exception e) {
        handleException("Error while building message", e);
    }

**Special Treatment to MTOM**

Apart from above observations I see MTOM messages are treated in special in the code. It is designed to skip message conversion if MTOM is enabled. [3] So to me fix should be enabling it. It supposed to get gets enabled at SynapseCallbackReceiver, but in this scenario axisOutMsgCtx.isDoingMTOM() if false [4]

by enabling MTOM by axis2 property at [3] it skips setting messageType to text/xml from multipart/related.

[1]. wso2-synapse - modules/core/src/main/java/org/apache/synapse/core/axis2/Axis2Sender.java#L390
[2]. wso2-synapse - modules/core/src/main/java/org/apache/synapse/core/axis2/Axis2Sender.java#L374
[3]. wso2-synapse - modules/core/src/main/java/org/apache/synapse/core/axis2/Axis2Sender.java#L344
[4]. wso2-synapse - /modules/core/src/main/java/org/apache/synapse/core/axis2/SynapseCallbackReceiver.java#L390

