### PR TITLE
Fix synapse cache update issue

### DIFF
--- a/distribution/src/conf/registry.xml
+++ b/distribution/src/conf/registry.xml
@@ -117,6 +117,18 @@
         <targetPath>/_system/nodes</targetPath>
     </mount-->
 
+    <!--
+    Following handler used to clear synapse cache for the put, move, rename and delete operation on the
+    registry resources.
+    -->
+    <handler class="org.wso2.carbon.mediation.library.RegistryCachingHandler">
+        <filter class="org.wso2.carbon.registry.core.jdbc.handlers.filters.URLMatcher">
+            <property name="putPattern">.*</property>
+            <property name="movePattern">.*</property>
+            <property name="renamePattern">.*</property>
+            <property name="deletePattern">.*</property>
+        </filter>
+    </handler>
     
     <versionResourcesOnChange>false</versionResourcesOnChange>
 


### PR DESCRIPTION
## Purpose
> Synapse cache maintain its own cache to store registry entries. When the registry resource get change, ESB should be restart or wait until cachableDuration to clear the mediation cache. This PR is to instead of waiting for cachableDuration, remove relavant entry in Synapse cache when registry is updated.

## Approach
> Registry handler can be used to send notification to Synapse cache if some registry entry is changed. New RegistryCachingHandler handler class added to the Carbon mediation to clear cache in Synapse cache. This handler will remove cache for put, delete, rename and move operations on registry entry.  

Resolve https://github.com/wso2/product-ei/issues/2361