### PR TITLE
Add TestExecutionListener for CApp deployment

### DIFF
--- a/product-scenarios/4-gateway/4.1-Extend-the-reach-for-existing-or-legacy-applications/4.1.1-Expose-back-ends-exposed-over-HTTP-as-SOAP-service/4.1.1.1-Expose-a-SOAP-service-as-SOAP-service-using-proxy-service/pom.xml
+++ b/product-scenarios/4-gateway/4.1-Extend-the-reach-for-existing-or-legacy-applications/4.1.1-Expose-back-ends-exposed-over-HTTP-as-SOAP-service/4.1.1.1-Expose-a-SOAP-service-as-SOAP-service-using-proxy-service/pom.xml
@@ -25,6 +25,7 @@
         <groupId>org.wso2.ei</groupId>
         <artifactId>4.1.1-Expose-back-ends-exposed-over-HTTP-as-SOAP-service</artifactId>
         <version>6.4.0</version>
+        <relativePath>../pom.xml</relativePath>
     </parent>
 
     <artifactId>4.1.1.1-Expose-a-SOAP-service-as-SOAP-service-using-proxy-service</artifactId>
@@ -45,15 +46,25 @@
                     </suiteXmlFiles>
                     <systemProperties>
                         <property>
+                            <!-- Common resource directory (eg: Key stores, certificates, etc.)-->
                             <name>test.resources.dir</name>
                             <value>
                                 ${basedir}/../../resources/
                             </value>
                         </property>
                         <property>
-                            <name>framework.resource.location</name>
+                            <!-- Directory containing carbon applications -->
+                            <name>test.resources.carbonApplications.dir</name>
                             <value>
-                                ${basedir}/src/test/resources/
+                                ${basedir}/../../resources/artifacts/
+                            </value>
+                        </property>
+                        <property>
+                            <!-- Related carbon applications (comma separated) to deploy -->
+                            <name>test.resources.carbonApplications.list</name>
+                            <value>
+                                scenario_4_1-synapse-configCompositeApplication_1.0.0,
+                                scenario_1_3-synapse-configCompositeApplication_1.0.0
                             </value>
                         </property>
                         <property>
@@ -68,9 +79,6 @@
                         </property>
                         <sec.verifier.dir>${basedir}/target/security-verifier/</sec.verifier.dir>
                         <maven.test.haltafterfailure>false</maven.test.haltafterfailure>
-                        <carbon.zip>
-                            ${basedir}/../../../distribution/target/wso2ei-${product.ei.version}.zip
-                        </carbon.zip>
                         <instr.file>${basedir}/../coverage-report/instrumentation.txt</instr.file>
                         <filters.file>${basedir}/../coverage-report/filters.txt</filters.file>
                     </systemProperties>

--- a/product-scenarios/4-gateway/4.1-Extend-the-reach-for-existing-or-legacy-applications/4.1.1-Expose-back-ends-exposed-over-HTTP-as-SOAP-service/4.1.1.1-Expose-a-SOAP-service-as-SOAP-service-using-proxy-service/pom.xml
+++ b/product-scenarios/4-gateway/4.1-Extend-the-reach-for-existing-or-legacy-applications/4.1.1-Expose-back-ends-exposed-over-HTTP-as-SOAP-service/4.1.1.1-Expose-a-SOAP-service-as-SOAP-service-using-proxy-service/pom.xml
@@ -63,8 +63,7 @@
                             <!-- Related carbon applications (comma separated) to deploy -->
                             <name>test.resources.carbonApplications.list</name>
                             <value>
-                                scenario_4_1-synapse-configCompositeApplication_1.0.0,
-                                scenario_1_3-synapse-configCompositeApplication_1.0.0
+                                scenario_4_1-synapse-configCompositeApplication_1.0.0
                             </value>
                         </property>
                         <property>

--- a/product-scenarios/4-gateway/4.1-Extend-the-reach-for-existing-or-legacy-applications/4.1.1-Expose-back-ends-exposed-over-HTTP-as-SOAP-service/4.1.1.1-Expose-a-SOAP-service-as-SOAP-service-using-proxy-service/src/test/java/org/wso2/carbon/esb/scenario/test/ExposeSOAPasSOAPTest.java
+++ b/product-scenarios/4-gateway/4.1-Extend-the-reach-for-existing-or-legacy-applications/4.1.1-Expose-back-ends-exposed-over-HTTP-as-SOAP-service/4.1.1.1-Expose-a-SOAP-service-as-SOAP-service-using-proxy-service/src/test/java/org/wso2/carbon/esb/scenario/test/ExposeSOAPasSOAPTest.java
@@ -43,13 +43,9 @@ public class ExposeSOAPasSOAPTest extends ScenarioTestBase {
 
     private static final Log log = LogFactory.getLog(ExposeSOAPasSOAPTest.class);
 
-    private static final String cappNameWithVersion = "scenario_4_1-synapse-configCompositeApplication_1.0.0";
-    private String cappName = "scenario_4_1-synapse-configCompositeApplication";
-
     @BeforeClass(alwaysRun = true)
     public void init() throws Exception {
         super.init();
-        deployCarbonApplication(cappNameWithVersion);
     }
 
     @Test(description = "4.1.1.1.1 Front the back-end using pass-through proxy template")
@@ -60,8 +56,6 @@ public class ExposeSOAPasSOAPTest extends ScenarioTestBase {
     @AfterClass(description = "Server Cleanup", alwaysRun = true)
     public void cleanup() throws Exception {
         super.cleanup();
-        //TODO perform capp undeployment: temporarily disabled till test environment stabilization
-        undeployCarbonApplication(cappName);
     }
 
     private void invokeSOAPProxyAndAssert(String url) throws IOException, XMLStreamException {

--- a/product-scenarios/4-gateway/4.1-Extend-the-reach-for-existing-or-legacy-applications/4.1.1-Expose-back-ends-exposed-over-HTTP-as-SOAP-service/4.1.1.1-Expose-a-SOAP-service-as-SOAP-service-using-proxy-service/src/test/resources/testng.xml
+++ b/product-scenarios/4-gateway/4.1-Extend-the-reach-for-existing-or-legacy-applications/4.1.1-Expose-back-ends-exposed-over-HTTP-as-SOAP-service/4.1.1.1-Expose-a-SOAP-service-as-SOAP-service-using-proxy-service/src/test/resources/testng.xml
@@ -18,7 +18,11 @@
 <!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
 <suite name="ESBTestSuite" parallel="false">
     <listeners>
-        <listener class-name="org.wso2.carbon.esb.scenario.test.common.testng.listeners.TestExecutionListener"/>
+        <!-- TestPrepExecutionListener : TestNG execution listener for perform test execution preparation -->
+        <listener class-name="org.wso2.carbon.esb.scenario.test.common.testng.listeners.TestPrepExecutionListener"/>
+
+        <!-- TestLoggingListener : Test listener to log test execution events -->
+        <listener class-name="org.wso2.carbon.esb.scenario.test.common.testng.listeners.TestLoggingListener"/>
     </listeners>
     <test name="ProxyService-Test" preserve-order="true" verbose="2" parallel="false">
         <classes>

--- a/product-scenarios/4-gateway/4.1-Extend-the-reach-for-existing-or-legacy-applications/4.1.1-Expose-back-ends-exposed-over-HTTP-as-SOAP-service/4.1.1.1-Expose-a-SOAP-service-as-SOAP-service-using-proxy-service/src/test/resources/testng.xml
+++ b/product-scenarios/4-gateway/4.1-Extend-the-reach-for-existing-or-legacy-applications/4.1.1-Expose-back-ends-exposed-over-HTTP-as-SOAP-service/4.1.1.1-Expose-a-SOAP-service-as-SOAP-service-using-proxy-service/src/test/resources/testng.xml
@@ -17,6 +17,9 @@
   -->
 <!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
 <suite name="ESBTestSuite" parallel="false">
+    <listeners>
+        <listener class-name="org.wso2.carbon.esb.scenario.test.common.testng.listeners.TestExecutionListener"/>
+    </listeners>
     <test name="ProxyService-Test" preserve-order="true" verbose="2" parallel="false">
         <classes>
             <class name="org.wso2.carbon.esb.scenario.test.ExposeSOAPasSOAPTest"/>

--- a/product-scenarios/scenarios-commons/pom.xml
+++ b/product-scenarios/scenarios-commons/pom.xml
@@ -81,5 +81,9 @@
             <groupId>commons-lang.wso2</groupId>
             <artifactId>commons-lang</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/product-scenarios/scenarios-commons/src/main/java/org/wso2/carbon/esb/scenario/test/common/ScenarioConstants.java
+++ b/product-scenarios/scenarios-commons/src/main/java/org/wso2/carbon/esb/scenario/test/common/ScenarioConstants.java
@@ -1,9 +1,50 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 package org.wso2.carbon.esb.scenario.test.common;
 
+/**
+ * This class holds common constants used scenario tests and framework
+ */
 public class ScenarioConstants {
 
     public static final String SOURCE_FILES = "source_files";
     public static final String REQUEST = "request";
     public static final String RESPONSE = "response";
     public static final String MESSAGE_ID = "messageId";
+
+    /**
+     *  StandaloneDeployment property define whether to skip CApp deployment by the test case or not
+     *  If true, test case will deploy the CApp
+     *  If false, infra will take care CApp deployment
+     */
+    public static final String STANDALONE_DEPLOYMENT = "StandaloneDeployment";
+
+    public static final String TEST_RESOURCES_DIR = "test.resources.dir";
+    public static final String TEST_RESOURCES_CARBON_APPLICATIONS_LIST = "test.resources.carbonApplications.list";
+    public static final String TEST_RESOURCES_CARBON_APPLICATIONS_DIR = "test.resources.carbonApplications.dir";
+
+    public static final String MGT_CONSOLE_URL = "MgtConsoleUrl";
+    public static final String CARBON_SERVER_URL = "CarbonServerUrl";
+    public static final String ESB_HTTP_URL = "ESBHttpUrl";
+    public static final String ESB_HTTPS_URL = "ESBHttpsUrl";
+
+    public static final String CAPP_EXTENSION = ".car";
+
+    public static final int ARTIFACT_DEPLOYMENT_WAIT_TIME_MS = 120000;
 }

--- a/product-scenarios/scenarios-commons/src/main/java/org/wso2/carbon/esb/scenario/test/common/testng/listeners/TestExecutionListener.java
+++ b/product-scenarios/scenarios-commons/src/main/java/org/wso2/carbon/esb/scenario/test/common/testng/listeners/TestExecutionListener.java
@@ -1,0 +1,237 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.esb.scenario.test.common.testng.listeners;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.awaitility.Awaitility;
+import org.testng.IExecutionListener;
+import org.wso2.carbon.application.mgt.stub.ApplicationAdminExceptionException;
+import org.wso2.carbon.esb.scenario.test.common.AuthenticatorClient;
+import org.wso2.carbon.esb.scenario.test.common.ScenarioConstants;
+import org.wso2.carbon.esb.scenario.test.common.ScenarioTestBase;
+import org.wso2.carbon.integration.common.admin.client.ApplicationAdminClient;
+import org.wso2.carbon.integration.common.admin.client.CarbonAppUploaderClient;
+
+import java.io.File;
+import java.rmi.RemoteException;
+import java.util.Properties;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+import javax.activation.DataHandler;
+import javax.activation.FileDataSource;
+
+/**
+ * TestNG execution listener for perform test execution preparation
+ * - deploy carbon applications if not already deployed
+ */
+public class TestExecutionListener implements IExecutionListener {
+
+    private static final Log log = LogFactory.getLog(TestExecutionListener.class);
+    private boolean standaloneMode = false;
+    private String backendURL;
+    private String mgtConsoleUrl;
+    private String sessionCookie;
+
+    private CarbonAppUploaderClient carbonAppUploaderClient = null;
+    private ApplicationAdminClient applicationAdminClient = null;
+
+    private static final String resourceLocation = System.getProperty(ScenarioConstants.TEST_RESOURCES_DIR);
+    private static final String carbonApplicationsDir =
+            System.getProperty(ScenarioConstants.TEST_RESOURCES_CARBON_APPLICATIONS_DIR);
+
+    private Properties infraProperties;
+
+    @Override
+    public void onExecutionStart() {
+
+        infraProperties = ScenarioTestBase.getDeploymentProperties();
+        // TODO : uncomment this once test environment is stable and remove hardcoded value
+        //standaloneMode = Boolean.valueOf(infraProperties.getProperty(ScenarioConstants.STANDALONE_DEPLOYMENT));
+        standaloneMode = true;
+
+        if (standaloneMode) {
+            log.info("Test execution standalone mode : " + standaloneMode);
+            String carbonAppListStr = System.getProperty(ScenarioConstants.TEST_RESOURCES_CARBON_APPLICATIONS_LIST);
+
+            backendURL = infraProperties.getProperty(ScenarioConstants.CARBON_SERVER_URL) +
+                    (infraProperties.getProperty(ScenarioConstants.CARBON_SERVER_URL).endsWith("/") ? "" : "/");
+            mgtConsoleUrl = infraProperties.getProperty(ScenarioConstants.MGT_CONSOLE_URL);
+
+            setKeyStoreProperties();
+
+            // login
+            try {
+                AuthenticatorClient authenticatorClient = new AuthenticatorClient(backendURL);
+                sessionCookie = authenticatorClient.login("admin", "admin", getServerHost(mgtConsoleUrl));
+            } catch (Exception e) {
+                throw new RuntimeException("Login failed", e);
+            }
+
+            try {
+                String[] cAppList = carbonAppListStr.split(",");
+                for (String cApp : cAppList) {
+                    // deploy carbon application
+                    deployCarbonApplication(cApp.trim());
+                }
+            } catch (RemoteException | ApplicationAdminExceptionException e) {
+                throw new RuntimeException("Error occurred while deploying carbon application : " + carbonAppListStr, e);
+            }
+        }
+    }
+
+    @Override
+    public void onExecutionFinish() {
+        log.info("#onExecutionFinish");
+    }
+
+    /**
+     * Function to upload carbon application
+     *
+     * @param carFileName
+     * @return
+     * @throws RemoteException
+     */
+    private void deployCarbonApplication(String carFileName) throws RemoteException, ApplicationAdminExceptionException {
+
+        if (standaloneMode) {
+            if (applicationAdminClient == null) {
+                applicationAdminClient = new ApplicationAdminClient(backendURL, sessionCookie);
+            }
+
+            if (!checkCAppDeployed(applicationAdminClient, carFileName)) {
+
+                log.info("Deploying carbon application : " + carFileName);
+                // If standalone mode, deploy the CApp to the server
+                String cappFilePath = carbonApplicationsDir + File.separator + carFileName + ScenarioConstants.CAPP_EXTENSION;
+
+                if (carbonAppUploaderClient == null) {
+                    carbonAppUploaderClient = new CarbonAppUploaderClient(backendURL, sessionCookie);
+                }
+
+                DataHandler dh = new DataHandler(new FileDataSource(new File(cappFilePath)));
+                // Upload carbon application
+                carbonAppUploaderClient.uploadCarbonAppArtifact(carFileName + ScenarioConstants.CAPP_EXTENSION, dh);
+
+                //TODO - This thread sleep is added temporarily to wait until the ESB Instances sync in the cluster in clustered test environment
+                if (!Boolean.valueOf(infraProperties.getProperty(ScenarioConstants.STANDALONE_DEPLOYMENT))) {
+                    log.info("Waiting for artifacts synchronized across cluster nodes");
+                    try {
+                        Thread.sleep(120000);
+                    } catch (InterruptedException e) {
+                        // log and ignore
+                        log.error("Error occurred while waiting for artifacts synchronized across cluster nodes", e);
+                    }
+                }
+
+                // Wait for Capp to sync
+                log.info("Waiting for Carbon Application deployment ..");
+                Awaitility.await()
+                        .pollInterval(500, TimeUnit.MILLISECONDS)
+                        .atMost(ScenarioConstants.ARTIFACT_DEPLOYMENT_WAIT_TIME_MS, TimeUnit.MILLISECONDS)
+                        .until(isCAppDeployed(applicationAdminClient, carFileName));
+
+            } else {
+                log.info("Carbon application : " + carFileName + " already deployed");
+            }
+        }
+    }
+
+    /**
+     * Function to undeploy carbon application
+     *
+     * @param applicationName
+     * @throws ApplicationAdminExceptionException
+     * @throws RemoteException
+     */
+    private void undeployCarbonApplication(String applicationName)
+            throws ApplicationAdminExceptionException, RemoteException {
+        if (standaloneMode) {
+            applicationAdminClient.deleteApplication(applicationName);
+
+            // Wait for Capp to undeploy
+            Awaitility.await()
+                    .pollInterval(500, TimeUnit.MILLISECONDS)
+                    .atMost(ScenarioConstants.ARTIFACT_DEPLOYMENT_WAIT_TIME_MS, TimeUnit.MILLISECONDS)
+                    .until(isCAppUnDeployed(applicationAdminClient, applicationName));
+        }
+    }
+
+    private void setKeyStoreProperties() {
+        System.setProperty("javax.net.ssl.trustStore", resourceLocation + "/keystores/wso2carbon.jks");
+        System.setProperty("javax.net.ssl.trustStorePassword", "wso2carbon");
+        System.setProperty("javax.net.ssl.trustStoreType", "JKS");
+    }
+
+    private String getServerHost(String url) {
+        if (url != null && url.contains("/")) {
+            url = url.split("/")[2].split(":")[0];
+        } else if (url == null) {
+            url = "localhost";
+        }
+        log.info("Backend URL is set as : " + url);
+        return url;
+    }
+
+    private Callable<Boolean> isCAppDeployed(final ApplicationAdminClient applicationAdminClient, final String cAppName) {
+        return new Callable<Boolean>() {
+            @Override
+            public Boolean call() throws Exception {
+
+                log.info("Check CApp deployment : " + cAppName);
+                return checkCAppDeployed(applicationAdminClient, cAppName);
+            }
+        };
+    }
+
+    private boolean checkCAppDeployed(ApplicationAdminClient applicationAdminClient, final String cAppName)
+            throws ApplicationAdminExceptionException, RemoteException {
+        log.info("Check CApp deployment : " + cAppName);
+        String[] applicationList = applicationAdminClient.listAllApplications();
+        if (applicationList != null) {
+            for (String app : applicationList) {
+                if (app.equals(cAppName)) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private Callable<Boolean> isCAppUnDeployed(final ApplicationAdminClient applicationAdminClient, final String cAppName) {
+        return new Callable<Boolean>() {
+            @Override
+            public Boolean call() throws Exception {
+
+                log.info("Check CApp un-deployment : " + cAppName);
+                boolean undeployed = true;
+                String[] applicationList = applicationAdminClient.listAllApplications();
+                if (applicationList != null) {
+                    for (String app : applicationList) {
+                        if (app.equals(cAppName)) {
+                            undeployed = false;
+                        }
+                    }
+                }
+                if (undeployed) log.info("Carbon Application : " + cAppName + " Successfully un-deployed");
+                return undeployed;
+            }
+        };
+    }
+}

--- a/product-scenarios/scenarios-commons/src/main/java/org/wso2/carbon/esb/scenario/test/common/testng/listeners/TestLoggingListener.java
+++ b/product-scenarios/scenarios-commons/src/main/java/org/wso2/carbon/esb/scenario/test/common/testng/listeners/TestLoggingListener.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.esb.scenario.test.common.testng.listeners;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.testng.ITestContext;
+import org.testng.ITestListener;
+import org.testng.ITestResult;
+
+/**
+ * Test listener to log test execution events
+ */
+public class TestLoggingListener implements ITestListener {
+    private static final Log log = LogFactory.getLog(TestLoggingListener.class);
+
+    public void onTestStart(ITestResult iTestResult) {
+        log.info("=================== Running the test method " + iTestResult.getTestClass().getName() + "."
+                 + iTestResult.getMethod().getMethodName() + " ===================");
+    }
+
+    public void onTestSuccess(ITestResult iTestResult) {
+        log.info("=================== On test success " + iTestResult.getTestClass().getName() + "."
+                + iTestResult.getMethod().getMethodName() + " ===================");
+    }
+
+    public void onTestFailure(ITestResult iTestResult) {
+        log.info("=================== On test failure " + iTestResult.getTestClass().getName() + "."
+                + iTestResult.getMethod().getMethodName() + " ===================");
+    }
+
+    public void onTestSkipped(ITestResult iTestResult) {
+        log.info("=================== On test skipped " + iTestResult.getTestClass().getName() + "."
+                 + iTestResult.getMethod().getMethodName() + " ===================");
+    }
+
+    public void onTestFailedButWithinSuccessPercentage(ITestResult iTestResult) {
+        log.info("On test failed but within success percentage...");
+    }
+
+    public void onStart(ITestContext iTestContext) {
+    }
+
+    public void onFinish(ITestContext iTestContext) {
+    }
+}

--- a/product-scenarios/scenarios-commons/src/main/java/org/wso2/carbon/esb/scenario/test/common/testng/listeners/TestPrepExecutionListener.java
+++ b/product-scenarios/scenarios-commons/src/main/java/org/wso2/carbon/esb/scenario/test/common/testng/listeners/TestPrepExecutionListener.java
@@ -41,9 +41,9 @@ import javax.activation.FileDataSource;
  * TestNG execution listener for perform test execution preparation
  * - deploy carbon applications if not already deployed
  */
-public class TestExecutionListener implements IExecutionListener {
+public class TestPrepExecutionListener implements IExecutionListener {
 
-    private static final Log log = LogFactory.getLog(TestExecutionListener.class);
+    private static final Log log = LogFactory.getLog(TestPrepExecutionListener.class);
     private boolean standaloneMode = false;
     private String backendURL;
     private String mgtConsoleUrl;
@@ -98,7 +98,7 @@ public class TestExecutionListener implements IExecutionListener {
 
     @Override
     public void onExecutionFinish() {
-        log.info("#onExecutionFinish");
+        //Nothing to do yet
     }
 
     /**

--- a/product-scenarios/scenarios-commons/src/main/java/org/wso2/carbon/esb/scenario/test/common/testng/listeners/TestPrepExecutionListener.java
+++ b/product-scenarios/scenarios-commons/src/main/java/org/wso2/carbon/esb/scenario/test/common/testng/listeners/TestPrepExecutionListener.java
@@ -202,7 +202,6 @@ public class TestPrepExecutionListener implements IExecutionListener {
 
     private boolean checkCAppDeployed(ApplicationAdminClient applicationAdminClient, final String cAppName)
             throws ApplicationAdminExceptionException, RemoteException {
-        log.info("Check CApp deployment : " + cAppName);
         String[] applicationList = applicationAdminClient.listAllApplications();
         if (applicationList != null) {
             for (String app : applicationList) {
@@ -220,15 +219,7 @@ public class TestPrepExecutionListener implements IExecutionListener {
             public Boolean call() throws Exception {
 
                 log.info("Check CApp un-deployment : " + cAppName);
-                boolean undeployed = true;
-                String[] applicationList = applicationAdminClient.listAllApplications();
-                if (applicationList != null) {
-                    for (String app : applicationList) {
-                        if (app.equals(cAppName)) {
-                            undeployed = false;
-                        }
-                    }
-                }
+                boolean undeployed = !checkCAppDeployed(applicationAdminClient, cAppName);
                 if (undeployed) log.info("Carbon Application : " + cAppName + " Successfully un-deployed");
                 return undeployed;
             }


### PR DESCRIPTION

New system properties introduced that should be included in maven-surefire-plugin.
    - test.resources.carbonApplications.dir : Directory containing carbon applications
    - test.resources.carbonApplications.list : Related carbon applications (comma separated) to deploy