### PR TITLE
Ability to run tests on specific product versions

### DIFF
--- a/product-scenarios/infrastructure.properties
+++ b/product-scenarios/infrastructure.properties
@@ -1,3 +1,4 @@
+ProductVersion=EI-6.5.0-SNAPSHOT
 ESBHttpUrl=http://localhost:8280/
 MgtConsoleUrl=https://localhost:9443/carbon
 ESBHttpsUrl=https://localhost:8243

--- a/product-scenarios/scenarios-commons/src/main/java/org/wso2/carbon/esb/scenario/test/common/ScenarioConstants.java
+++ b/product-scenarios/scenarios-commons/src/main/java/org/wso2/carbon/esb/scenario/test/common/ScenarioConstants.java
@@ -27,6 +27,16 @@ public class ScenarioConstants {
     public static final String REQUEST = "request";
     public static final String RESPONSE = "response";
     public static final String MESSAGE_ID = "messageId";
+    public static final String VERSION_490 = "ESB-4.9.0";
+    public static final String VERSION_500 = "ESB-5.0.0";
+    public static final String VERSION_600 = "EI-6.0.0";
+    public static final String VERSION_610 = "EI-6.1.0";
+    public static final String VERSION_611 = "EI-6.1.1";
+    public static final String VERSION_620 = "EI-6.2.0";
+    public static final String VERSION_630 = "EI-6.3.0";
+    public static final String VERSION_640 = "EI-6.4.0";
+    public static final String VERSION_650_SNAPSHOT = "EI-6.5.0-SNAPSHOT";
+
 
     /**
      *  StandaloneDeployment property define whether to skip CApp deployment by the test case or not

--- a/product-scenarios/test.sh
+++ b/product-scenarios/test.sh
@@ -83,9 +83,25 @@ export DATA_BUCKET_LOCATION=${INPUT_DIR}
 
 #=============== Execute Scenarios ===============================================
 
-mvn clean install -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn \
--fae -B -f ./pom.xml
+#Retreive product version
 
+IFS='=' read -r -a array <<< "$(head -n 1 infrastructure.properties)"
+key=${array[0]}
+if [ $key = "ProductVersion" ]
+then
+    productVersion=${array[1]}
+    case ${productVersion} in
+        ESB-4.9.0|ESB-5.0.0|EI-6.0.0|EI-6.1.0|EI-6.1.1|EI-6.2.0|EI-6.3.0|EI-6.4.0|EI-6.5.0-SNAPSHOT)
+            echo "Executing tests for the product version: $productVersion"
+            mvn clean install -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn \
+             -fae -B -f ./pom.xml ;;
+        *)
+            echo "Unknown product version: " ${productVersion} "read from infrastructure.properties. Aborting the execution.";;
+    esac
+
+else
+    echo "infrastructure.properties file does not contain the product version. Aborting the execution."
+fi
 
 #=============== Copy Surefire Reports ===========================================
 


### PR DESCRIPTION
## Purpose
Adds the capability restrict tests for specific product versions. The usage of the funcationality is as follows. e.g., if TestESB needs to run only on ESB-4.9.0 and ESB-5.0.0, the init method of it should be wrtten as follows.
```
@BeforeClass(alwaysRun = true)
    public void init() throws Exception {
        super.init();
        validateCompatibleProductVersions(ScenarioConstants.VERSION_490, ScenarioConstants.VERSION_500);
    }
```