### PR TITLE
Update messages in assert for HTTPUtils (#3063)

### DIFF
--- a/product-scenarios/1-integrating-systems-that-communicate-in-heterogeneous-message-formats/1.1-converting-soap-to-json/1.1.1-soap-to-json-using-payloadfactory-mediator/pom.xml
+++ b/product-scenarios/1-integrating-systems-that-communicate-in-heterogeneous-message-formats/1.1-converting-soap-to-json/1.1.1-soap-to-json-using-payloadfactory-mediator/pom.xml
@@ -26,7 +26,6 @@
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>1.1.1-convert-using-payload-factory-mediator</artifactId>
-    <name>SOAP to JSON Using Payload Factory Mediator</name>
     <packaging>jar</packaging>
     <build>
         <plugins>

--- a/product-scenarios/1-integrating-systems-that-communicate-in-heterogeneous-message-formats/1.1-converting-soap-to-json/pom.xml
+++ b/product-scenarios/1-integrating-systems-that-communicate-in-heterogeneous-message-formats/1.1-converting-soap-to-json/pom.xml
@@ -28,7 +28,6 @@
 
     <modelVersion>4.0.0</modelVersion>
     <artifactId>1.1-converting-soap-to-json</artifactId>
-    <name>Converting SOAP to JSON</name>
     <packaging>pom</packaging>
 
     <modules>

--- a/product-scenarios/scenarios-commons/src/main/java/org/wso2/carbon/esb/scenario/test/common/http/HTTPUtils.java
+++ b/product-scenarios/scenarios-commons/src/main/java/org/wso2/carbon/esb/scenario/test/common/http/HTTPUtils.java
@@ -154,11 +154,12 @@ public class HTTPUtils {
         HttpResponse httpResponse = soapClient.sendSimpleSOAPMessage(serviceUrl, request, soapAction, headers);
 
         Assert.assertEquals(httpResponse.getStatusLine().getStatusCode(), statusCode, testcaseName + " failed");
-        OMElement respElement = HTTPUtils.getOMFromResponse(httpResponse);
-        Assert.assertNotNull(respElement, "Invalid response");
-        boolean compareResponse = XMLUtils.compareOMElements(XMLUtils.StringASOM(expectedResponse), respElement);
-        Assert.assertTrue(compareResponse,
-                          "Actual Response and Expected Response mismatch in test case : " + messageId);
+        OMElement actualOMResponse = HTTPUtils.getOMFromResponse(httpResponse);
+        OMElement expectedOMResponse = XMLUtils.StringASOM(expectedResponse);
+        Assert.assertNotNull(actualOMResponse, "Invalid response");
+        boolean compareResponse = XMLUtils.compareOMElements(expectedOMResponse, actualOMResponse);
+        Assert.assertTrue(compareResponse,"Expected : <" + expectedResponse + "> but was <" + actualOMResponse
+                                          + "> in test case : " + messageId);
     }
 
     /**
@@ -186,7 +187,8 @@ public class HTTPUtils {
 
         Assert.assertEquals(httpResponse.getStatusLine().getStatusCode(), statusCode, testcaseName + " failed");
         Assert.assertTrue(StringUtil.trimTabsSpaceNewLinesBetweenXMLTags(responsePayload).contains(responseSubstring),
-                          "Actual Response and Expected Response mismatch in test case : " + messageId);
+                          "\""+ responseSubstring + "\" does not contain in actual Response Recieved : <" +
+                          responsePayload + "> in test case : " + messageId);
     }
 
     /**


### PR DESCRIPTION
## Purpose
The purpose of this PR is to add proper messages in util functions in HTTPUtils.

## Approach
* Update invokeSoapActionAndAssert()
* Update invokeSoapActionAndCheckContains()

## Test environment
This is tested locally in following environment.
JDK - 1.8
OS - macOS High Sierra
