### PR TITLE
Added ViewPopEnqueueTests and Admin_Services file

### DIFF
--- a/gh-docs/steps-to-add-adminservices/Admin_Services.md
+++ b/gh-docs/steps-to-add-adminservices/Admin_Services.md
@@ -1,0 +1,104 @@
+# How to create admin-services
+When creating Admin Services you would generally follow the same set of steps. In this instance, the Message Processor is used as an example.
+
+### Creation Flow
+
+1. Define your Admin Service function
+2. Generate the stub using WSDL
+3. Define function in MessageProcessorAdminServiceClient to call Admin Service function
+4. Call the function from the Message Processor UI JSP
+
+### 1. Defining your Admin Service
+Message Processor Admin Services are defined in the `MessageProcessorAdminService.java` class in the carbon-mediation repo. 
+Repo Link : `components/mediation-admin/org.wso2.carbon.message.processor/src/main/java/org/wso2/carbon/message/processor/service/MessageProcessorAdminService.java`
+
+Go to `<repo-home>/components/mediation-admin/org.wso2.carbon.message.processor/` and navigate to the 'service' directory
+to find the 'MessageProcessorAdminService.java' class.
+
+
+In this example we can consider this function 
+```$xslt
+public String getMessage(String processorName) {
+        SynapseConfiguration configuration = getSynapseConfiguration();
+        MessageConsumer messageConsumer = 
+            getMessageConsumer(configuration,processorName);
+
+        String msg = getMessageAsString(messageConsumer);
+        messageConsumer.cleanup();
+        return msg;
+    }
+```
+
+Once you define your function, generate the `MessageProcessorAdminServiceStub.java` file. 
+
+### 2. Generating the MessageProcessorAdminServiceStub using WSDL
+To generate the stub file, the WSDL file in `<repo-home>/service-stubs/mediation-admin/org.wso2.carbon.message.processor.stub/`
+needs to be edited and then built to generate the stub. 
+
+#### To obtain the contents of the WSDL
+ 1. Build `MessageProcessorAdminService.java` using `$ mvn clean install` on the IntelliJ console. 
+ 
+ 2. Copy the generated '.jar' file found in `<repo-home>/components/mediation-admin/org.wso2.carbon.message.processor/target/org.wso2.carbon.message.processor-4.6.106-SNAPSHOT.jar`
+ 
+ 3. Create a `patch9999` folder in `/Patches` directory and Paste the '.jar' file into it.
+ 
+ 4. Run `$ sh integrator.sh -DosgiConsole` from the product-ui `/bin` folder and list the admin services using 
+ `$ listAdminServices` command. Make sure you set the <HideAdminServiceWSDLs> element to false in the `<product-home>/repository/conf/carbon.xml` file.
+ 
+ 5. From the list of admin services, locate the `MessageProcessorAdminService` URL and then paste it in your browser with '?wsdl' at the end
+ It should look something like `https://<machine.local>:8243/services/MessageProcessorAdminService?wsdl`
+ 
+ 6. Select-all and copy the contents of the WSDL on the webpage
+ 
+ 7. Overwrite the copied contents onto `MessageProcessorAdminService.wsdl` found in `<repo-home>/service-stubs/mediation-admin/org.wso2.carbon.message.processor.stub`
+ 
+For further clarification refer 'Discovering Admin Services" : https://docs.wso2.com/display/EI630/Working+with+Admin+Services'
+
+If you generated the WSDL properly it should include your defined function
+
+```$xslt
+ <xs:element name="getMessage">
+   <xs:complexType>
+    <xs:sequence>
+     <xs:element minOccurs="0" name="processorName" nillable="true" type="xs:string"/>
+    </xs:sequence>
+   </xs:complexType>
+ </xs:element>
+```
+ 
+Now that the contents of the WSDL file in the stub folder have been properly edited, you need to build the message.processor.stub folder to 
+generate the  message.processor.stub.jar file. 
+
+### 3. Defining the Admin Service Client function 
+If the stub has been generate properly you can call the defined function from the `MessageProcessorAdminServiceClient.java` using the 'stub' object. 
+
+This is an example of how the you can use the stub to call the function.
+```$xslt
+public String getMessage(String processorName) throws Exception {
+        String msg = null;
+        try{
+            if(processorName!=null) {
+                msg = stub.getMessage(processorName);
+            }
+        } catch (Exception e) {
+            handleException(e);
+        }
+        return msg;
+    }
+```
+
+A function needs to be defined here to be called from the front-end Message Processor UI JSP.  
+
+
+
+### 4. Calling the defined function from MessageProcessor UI JSP. 
+If the calling function has been properly defined in MessageProcessorAdminServiceClient.java, you can call the function using 
+the client object defined in the JSP. 
+
+```
+    String url = CarbonUIUtil.getServerURL(this.getServletConfig().getServletContext(),session);
+    ConfigurationContext configContext = (ConfigurationContext)config.getServletContext().getAttribute(CarbonConstants.CONFIGURATION_CONTEXT);
+    String cookie = (String) session.getAttribute(ServerConstants.ADMIN_SERVICE_COOKIE);
+    
+    MessageProcessorAdminServiceClient client = new MessageProcessorAdminServiceClient(cookie,url,configContext);
+```

--- a/integration/mediation-tests/tests-common/admin-clients/src/main/java/org/wso2/esb/integration/common/clients/mediation/MessageProcessorClient.java
+++ b/integration/mediation-tests/tests-common/admin-clients/src/main/java/org/wso2/esb/integration/common/clients/mediation/MessageProcessorClient.java
@@ -121,5 +121,33 @@ public class MessageProcessorClient {
         return messageProcessorAdminServiceStub.isActive(processorName);
     }
 
+    /**
+     * Check the functionality of the getMessage function
+     * @param processorName name of Processor
+     * @return message stored in the subscribed queue
+     * @throws RemoteException
+     */
+    public String getMessage(String processorName) throws RemoteException {
+        return messageProcessorAdminServiceStub.getMessage(processorName);
+    }
+
+    /**
+     * Check the functionality of the popMessage function
+     * @param processorName name of the Processor
+     * @throws RemoteException
+     */
+    public void popMessage(String processorName) throws RemoteException {
+        messageProcessorAdminServiceStub.popMessage(processorName);
+    }
+
+    /**
+     * Check the functionality of the popAndEnqueueFunction
+     * @param processorName name of the Processor
+     * @param storeName name of the destination store
+     * @throws RemoteException
+     */
+    public void popAndRedirectMessage(String processorName, String storeName) throws RemoteException {
+        messageProcessorAdminServiceStub.popAndRedirectMessage(processorName,storeName);
+    }
 
 }

--- a/integration/mediation-tests/tests-common/admin-clients/src/main/java/org/wso2/esb/integration/common/clients/mediation/MessageProcessorClient.java
+++ b/integration/mediation-tests/tests-common/admin-clients/src/main/java/org/wso2/esb/integration/common/clients/mediation/MessageProcessorClient.java
@@ -122,13 +122,13 @@ public class MessageProcessorClient {
     }
 
     /**
-     * Check the functionality of the getMessage function
+     * Check the functionality of the browseMessage function
      * @param processorName name of Processor
      * @return message stored in the subscribed queue
      * @throws RemoteException
      */
-    public String getMessage(String processorName) throws RemoteException {
-        return messageProcessorAdminServiceStub.getMessage(processorName);
+    public String browseMessage(String processorName) throws RemoteException {
+        return messageProcessorAdminServiceStub.browseMessage(processorName);
     }
 
     /**

--- a/integration/mediation-tests/tests-transport/src/test/java/org/wso2/carbon/esb/jms/ViewPopRedirectTests/RedirectTest.java
+++ b/integration/mediation-tests/tests-transport/src/test/java/org/wso2/carbon/esb/jms/ViewPopRedirectTests/RedirectTest.java
@@ -69,7 +69,7 @@ public class RedirectTest extends ESBIntegrationTest {
     /**
      * 1. Send one payload to the proxy while the backend is unavailable
      * 2. Check if the Message Processor has successfully deactivated
-     * 3. Call the popandRedirect fucntion and verify that getMessage function is returning is expected message
+     * 3. Call the popandRedirect fucntion and verify that browseMessage function is returning is expected message
      */
 
     @Test(groups = {"wso2.esb"}, description = "Test Redirect service for Message processor")
@@ -124,7 +124,7 @@ public class RedirectTest extends ESBIntegrationTest {
 
 
         //Call the getMessage function from the REDIRECT_PROCESSOR
-        String returnedMessage = messageProcessorClient.getMessage(REDIRECT_PROCESSOR_NAME);
+        String returnedMessage = messageProcessorClient.browseMessage(REDIRECT_PROCESSOR_NAME);
         System.out.println("=== RETURNED MESSAGE === \n" + returnedMessage);
         Assert.assertEquals(returnedMessage, expectedMessage, "Returned message is not the same as expected message.");
 

--- a/integration/mediation-tests/tests-transport/src/test/java/org/wso2/carbon/esb/jms/ViewPopRedirectTests/RedirectTest.java
+++ b/integration/mediation-tests/tests-transport/src/test/java/org/wso2/carbon/esb/jms/ViewPopRedirectTests/RedirectTest.java
@@ -1,0 +1,132 @@
+/*
+ *Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *WSO2 Inc. licenses this file to you under the Apache License,
+ *Version 2.0 (the "License"); you may not use this file except
+ *in compliance with the License.
+ *You may obtain a copy of the License at
+ *
+ *http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *Unless required by applicable law or agreed to in writing,
+ *software distributed under the License is distributed on an
+ *"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *KIND, either express or implied.  See the License for the
+ *specific language governing permissions and limitations
+ *under the License.
+ */
+
+package org.wso2.carbon.esb.jms.ViewPopRedirectTests;
+
+import org.apache.axis2.context.ConfigurationContext;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import org.wso2.carbon.automation.extensions.servers.jmsserver.client.JMSQueueMessageProducer;
+import org.wso2.carbon.automation.test.utils.http.client.HttpRequestUtil;
+import org.wso2.esb.integration.common.clients.mediation.MessageProcessorClient;
+import org.wso2.esb.integration.common.clients.mediation.MessageStoreAdminClient;
+import org.wso2.esb.integration.common.utils.ESBIntegrationTest;
+
+import java.net.URL;
+import java.util.HashMap;
+import java.util.Map;
+
+public class RedirectTest extends ESBIntegrationTest {
+    private MessageStoreAdminClient messageStoreAdminClient;
+    private MessageProcessorClient messageProcessorClient;
+    private JMSQueueMessageProducer jmsQueueMessageProducer;
+
+    private ConfigurationContext configurationContext;
+
+    private final String STORE_NAME = "BASE_Store";
+    private final String PROCESSOR_NAME = "BASE_Processor";
+    private final String PROXY_NAME = "BASE_Proxy";
+
+    private final String REDIRECT_STORE_NAME = "REDIRECT_Store";
+    private final String REDIRECT_PROCESSOR_NAME = "REDIRECT_Processor";
+
+    /**
+     * Initializing environment variables
+     */
+
+    @BeforeClass(alwaysRun = true, description = "Test Message processor Redirect service")
+    protected void setup() throws Exception {
+        super.init();
+        loadESBConfigurationFromClasspath("artifacts/ESB/messageProcessorConfig/RedirectTest.xml");
+
+        // Initialization
+        messageStoreAdminClient = new MessageStoreAdminClient(context.getContextUrls().getBackEndUrl(), sessionCookie);
+        messageProcessorClient = new MessageProcessorClient(context.getContextUrls().getBackEndUrl(), sessionCookie);
+
+        verifyMessageStoreExistence(STORE_NAME);
+        verifyMessageStoreExistence(REDIRECT_STORE_NAME);
+        verifyMessageProcessorExistence(PROCESSOR_NAME);
+        verifyMessageProcessorExistence(REDIRECT_PROCESSOR_NAME);
+        isProxySuccesfullyDeployed(PROXY_NAME);
+    }
+
+    /**
+     * 1. Send one payload to the proxy while the backend is unavailable
+     * 2. Check if the Message Processor has successfully deactivated
+     * 3. Call the popandRedirect fucntion and verify that getMessage function is returning is expected message
+     */
+
+    @Test(groups = {"wso2.esb"}, description = "Test Redirect service for Message processor")
+    public void testRedirect() throws Exception {
+
+        //Initializing Payload
+        String inputPayload = "<soapenv:Envelope xmlns:soapenv=\"http://schemas.xmlsoap.org/soap/envelope/\">\n"
+                + "<soapenv:Header/>\n"
+                + "<soapenv:Body>\n"
+                + "<m0:getQuote xmlns:m0=\"http://services.samples\">\n"
+                + " <m0:request>IBM\n"
+                + " </m0:request>\n"
+                + "   <m0:request>WSO2\n"
+                + " </m0:request>\n"
+                + "</m0:getQuote>\n"
+                + "</soapenv:Body>\n"
+                + "</soapenv:Envelope>";
+
+        String expectedMessage = "<?xml version='1.0' encoding='utf-8'?><soapenv:Envelope xmlns:soapenv=\"http://schemas.xmlsoap.org/soap/envelope/\">"
+                + "<soapenv:Body>"
+                + "<m0:getQuote xmlns:m0=\"http://services.samples\">\n"
+                + " <m0:request>IBM\n"
+                + " </m0:request>\n"
+                + "   <m0:request>WSO2\n"
+                + " </m0:request>\n"
+                + "</m0:getQuote>"
+                + "</soapenv:Body>"
+                + "</soapenv:Envelope>";
+
+        Map<String, String> requestHeader = new HashMap<>();
+        requestHeader.put("Content-type", "text/xml");
+        requestHeader.put("SOAPAction", "urn:mediate");
+        requestHeader.put("Accept", "application/json");
+
+        //Send payload to the proxy
+        System.out.println("=== Sending payload to " + PROXY_NAME + ":" + getProxyServiceURLHttp(PROXY_NAME));
+        HttpRequestUtil.doPost(new URL(getProxyServiceURLHttp(PROXY_NAME)), inputPayload, requestHeader);
+
+        Thread.sleep(5000); //Make sure that the Message Processor has time to deactivate
+
+        //Check if the message processor has deactivated
+        Assert.assertFalse(messageProcessorClient.isActive(PROCESSOR_NAME), "Message processor" + PROCESSOR_NAME + "should not be active, " +
+                "but it is active.");
+
+        //Deactivate the REDIRECT_PROCESSOR
+        messageProcessorClient.deactivateProcessor(REDIRECT_PROCESSOR_NAME);
+        Assert.assertFalse(messageProcessorClient.isActive(REDIRECT_PROCESSOR_NAME), "Message processor" + REDIRECT_PROCESSOR_NAME + " should not be active, " +
+                "but it is active.");
+
+        //Call popAndRedirect function to pass the message to REDIRECT_STORE
+        messageProcessorClient.popAndRedirectMessage(PROCESSOR_NAME, REDIRECT_STORE_NAME);
+
+
+        //Call the getMessage function from the REDIRECT_PROCESSOR
+        String returnedMessage = messageProcessorClient.getMessage(REDIRECT_PROCESSOR_NAME);
+        System.out.println("=== RETURNED MESSAGE === \n" + returnedMessage);
+        Assert.assertEquals(returnedMessage, expectedMessage, "Returned message is not the same as expected message.");
+
+    }
+}

--- a/integration/mediation-tests/tests-transport/src/test/java/org/wso2/carbon/esb/jms/ViewPopRedirectTests/ViewPopTest.java
+++ b/integration/mediation-tests/tests-transport/src/test/java/org/wso2/carbon/esb/jms/ViewPopRedirectTests/ViewPopTest.java
@@ -65,8 +65,8 @@ public class ViewPopTest extends ESBIntegrationTest {
     /**
      *  1. Send one payload to the proxy while the backend is unavailable
      *  2. Check if the Message Processor has successfully deactivated
-     *  3. Call getMessage function and verify that the queue is sending the expected message
-     *  4. Call popMessage function and verify that getMessage function is returning null
+     *  3. Call browseMessage function and verify that the queue is sending the expected message
+     *  4. Call popMessage function and verify that browseMessage function is returning null
      */
     @Test(groups = {"wso2.esb"}, description = "Test View and Pop and service for Message processor")
     public void testViewInMessageStore() throws Exception {
@@ -110,17 +110,17 @@ public class ViewPopTest extends ESBIntegrationTest {
         Assert.assertFalse(messageProcessorClient.isActive(PROCESSOR_NAME), "Message processor should not be active, " +
                 "but it is active.");
 
-        //Call getMessage function passing the PROCESSOR_NAME and assert the message
+        //Call browseMessage function passing the PROCESSOR_NAME and assert the message
         System.out.println("=== Retrieving msg from Queue. Passing processor : " + PROCESSOR_NAME +" ===");
 
-        String returnedMessage = messageProcessorClient.getMessage(PROCESSOR_NAME);
+        String returnedMessage = messageProcessorClient.browseMessage(PROCESSOR_NAME);
         System.out.println("=== RETURNED MESSAGE === \n" + returnedMessage );
         Assert.assertEquals(returnedMessage,expectedMessage,"Returned message is not the same as expected message.");
 
         //Call popMessage function passing the PROCESSOR_NAME and assert the empty queue
         System.out.println("=== Popping msg from Queue. Passing processor :" + PROCESSOR_NAME +" ===");
         messageProcessorClient.popMessage(PROCESSOR_NAME);
-        returnedMessage = messageProcessorClient.getMessage(PROCESSOR_NAME);
+        returnedMessage = messageProcessorClient.browseMessage(PROCESSOR_NAME);
         System.out.println("=== AFTER POPPING Returned Message :" + returnedMessage);
         Assert.assertEquals(returnedMessage,null);
     }

--- a/integration/mediation-tests/tests-transport/src/test/java/org/wso2/carbon/esb/jms/ViewPopRedirectTests/ViewPopTest.java
+++ b/integration/mediation-tests/tests-transport/src/test/java/org/wso2/carbon/esb/jms/ViewPopRedirectTests/ViewPopTest.java
@@ -1,0 +1,128 @@
+/*
+ *Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *WSO2 Inc. licenses this file to you under the Apache License,
+ *Version 2.0 (the "License"); you may not use this file except
+ *in compliance with the License.
+ *You may obtain a copy of the License at
+ *
+ *http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *Unless required by applicable law or agreed to in writing,
+ *software distributed under the License is distributed on an
+ *"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *KIND, either express or implied.  See the License for the
+ *specific language governing permissions and limitations
+ *under the License.
+ */
+
+package org.wso2.carbon.esb.jms.ViewPopRedirectTests;
+
+import org.apache.axis2.context.ConfigurationContext;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import org.wso2.carbon.automation.extensions.servers.jmsserver.client.JMSQueueMessageProducer;
+import org.wso2.carbon.automation.test.utils.http.client.HttpRequestUtil;
+import org.wso2.esb.integration.common.clients.mediation.MessageProcessorClient;
+import org.wso2.esb.integration.common.clients.mediation.MessageStoreAdminClient;
+import org.wso2.esb.integration.common.utils.ESBIntegrationTest;
+
+import java.net.URL;
+import java.util.HashMap;
+import java.util.Map;
+
+
+public class ViewPopTest extends ESBIntegrationTest {
+
+    private MessageStoreAdminClient messageStoreAdminClient;
+    private MessageProcessorClient messageProcessorClient;
+    private JMSQueueMessageProducer jmsQueueMessageProducer;
+
+    private ConfigurationContext configurationContext;
+
+    private final String STORE_NAME = "VPE_Store";
+    private final String PROCESSOR_NAME = "VPE_Processor";
+    private final String PROXY_NAME = "VPE_Proxy";
+
+    /**
+     *  Initializing environment variables
+     */
+    @BeforeClass(alwaysRun = true, description = "Test Message processor View and Pop service")
+    protected void setup() throws Exception {
+        super.init();
+        loadESBConfigurationFromClasspath("artifacts/ESB/messageProcessorConfig/ViewPopTest.xml");
+
+        // Initialization
+        messageStoreAdminClient = new MessageStoreAdminClient(context.getContextUrls().getBackEndUrl(), sessionCookie);
+        messageProcessorClient = new MessageProcessorClient(context.getContextUrls().getBackEndUrl(),sessionCookie);
+
+        verifyMessageStoreExistence(STORE_NAME);
+        verifyMessageProcessorExistence(PROCESSOR_NAME);
+        isProxySuccesfullyDeployed(PROXY_NAME);
+    }
+
+    /**
+     *  1. Send one payload to the proxy while the backend is unavailable
+     *  2. Check if the Message Processor has successfully deactivated
+     *  3. Call getMessage function and verify that the queue is sending the expected message
+     *  4. Call popMessage function and verify that getMessage function is returning null
+     */
+    @Test(groups = {"wso2.esb"}, description = "Test View and Pop and service for Message processor")
+    public void testViewInMessageStore() throws Exception {
+
+        //Initializing Payload
+        String inputPayload = "<soapenv:Envelope xmlns:soapenv=\"http://schemas.xmlsoap.org/soap/envelope/\">\n"
+                + "<soapenv:Header/>\n"
+                + "<soapenv:Body>\n"
+                + "<m0:getQuote xmlns:m0=\"http://services.samples\">\n"
+                + " <m0:request>IBM\n"
+                + " </m0:request>\n"
+                + "   <m0:request>WSO2\n"
+                + " </m0:request>\n"
+                + "</m0:getQuote>\n"
+                + "</soapenv:Body>\n"
+                + "</soapenv:Envelope>";
+
+        String expectedMessage = "<?xml version='1.0' encoding='utf-8'?><soapenv:Envelope xmlns:soapenv=\"http://schemas.xmlsoap.org/soap/envelope/\">"
+                + "<soapenv:Body>"
+                + "<m0:getQuote xmlns:m0=\"http://services.samples\">\n"
+                + " <m0:request>IBM\n"
+                + " </m0:request>\n"
+                + "   <m0:request>WSO2\n"
+                + " </m0:request>\n"
+                + "</m0:getQuote>"
+                + "</soapenv:Body>"
+                + "</soapenv:Envelope>";
+
+        Map<String, String> requestHeader = new HashMap<>();
+        requestHeader.put("Content-type", "text/xml");
+        requestHeader.put("SOAPAction", "urn:mediate");
+        requestHeader.put("Accept", "application/json");
+
+        //Send payload to the proxy
+        System.out.println("=== Sending payload to " + PROXY_NAME +":"+ getProxyServiceURLHttp(PROXY_NAME));
+        HttpRequestUtil.doPost(new URL(getProxyServiceURLHttp(PROXY_NAME)), inputPayload, requestHeader);
+
+        Thread.sleep(5000); //Make sure that the Message Processor has time to deactivate
+
+        //Check if the message processor has deactivated
+        Assert.assertFalse(messageProcessorClient.isActive(PROCESSOR_NAME), "Message processor should not be active, " +
+                "but it is active.");
+
+        //Call getMessage function passing the PROCESSOR_NAME and assert the message
+        System.out.println("=== Retrieving msg from Queue. Passing processor : " + PROCESSOR_NAME +" ===");
+
+        String returnedMessage = messageProcessorClient.getMessage(PROCESSOR_NAME);
+        System.out.println("=== RETURNED MESSAGE === \n" + returnedMessage );
+        Assert.assertEquals(returnedMessage,expectedMessage,"Returned message is not the same as expected message.");
+
+        //Call popMessage function passing the PROCESSOR_NAME and assert the empty queue
+        System.out.println("=== Popping msg from Queue. Passing processor :" + PROCESSOR_NAME +" ===");
+        messageProcessorClient.popMessage(PROCESSOR_NAME);
+        returnedMessage = messageProcessorClient.getMessage(PROCESSOR_NAME);
+        System.out.println("=== AFTER POPPING Returned Message :" + returnedMessage);
+        Assert.assertEquals(returnedMessage,null);
+    }
+
+}

--- a/integration/mediation-tests/tests-transport/src/test/resources/artifacts/ESB/messageProcessorConfig/RedirectTest.xml
+++ b/integration/mediation-tests/tests-transport/src/test/resources/artifacts/ESB/messageProcessorConfig/RedirectTest.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<definitions xmlns="http://ws.apache.org/ns/synapse">
+
+    <!-- Initial Message Store. Message will be sent to this store from the Proxy -->
+    <messageStore xmlns="http://ws.apache.org/ns/synapse"
+                  class="org.apache.synapse.message.store.impl.jms.JmsStore"
+                  name="BASE_Store">
+        <parameter name="java.naming.factory.initial">org.apache.activemq.jndi.ActiveMQInitialContextFactory</parameter>
+        <parameter name="store.jms.destination">BASE_Queue</parameter>
+        <parameter name="store.producer.guaranteed.delivery.enable">false</parameter>
+        <parameter name="store.jms.cache.connection">true</parameter>
+        <parameter name="java.naming.provider.url">tcp://localhost:61616</parameter>
+        <parameter name="store.jms.JMSSpecVersion">1.1</parameter>
+    </messageStore>
+
+    <!-- Redirected Message Store. The message will be redirectedd to this store -->
+    <messageStore xmlns="http://ws.apache.org/ns/synapse"
+                  class="org.apache.synapse.message.store.impl.jms.JmsStore"
+                  name="REDIRECT_Store">
+        <parameter name="java.naming.factory.initial">org.apache.activemq.jndi.ActiveMQInitialContextFactory</parameter>
+        <parameter name="store.jms.destination">REDIRECT_Queue</parameter>
+        <parameter name="store.producer.guaranteed.delivery.enable">false</parameter>
+        <parameter name="store.jms.cache.connection">true</parameter>
+        <parameter name="java.naming.provider.url">tcp://localhost:61616</parameter>
+        <parameter name="store.jms.JMSSpecVersion">1.1</parameter>
+    </messageStore>
+
+    <!-- Initial Message Processor. Subscribed to Queue. Uses REDIRECT service -->
+    <messageProcessor xmlns="http://ws.apache.org/ns/synapse"
+                      class="org.apache.synapse.message.processor.impl.forwarder.ScheduledMessageForwardingProcessor"
+                      name="BASE_Processor"
+                      messageStore="BASE_Store">
+        <parameter name="max.delivery.drop">Disabled</parameter>
+        <parameter name="client.retry.interval">4000</parameter>
+        <parameter name="max.delivery.attempts">1</parameter>
+        <parameter name="interval">4000</parameter>
+        <parameter name="throttle">false</parameter>
+        <parameter name="is.active">true</parameter>
+    </messageProcessor>
+
+    <!-- Redirected Message Processor. Only required for testing to verify integrity of the redirected message -->
+    <messageProcessor xmlns="http://ws.apache.org/ns/synapse"
+                      class="org.apache.synapse.message.processor.impl.forwarder.ScheduledMessageForwardingProcessor"
+                      name="REDIRE_Processor"
+                      messageStore="ENQUEUE_Store">
+        <parameter name="max.delivery.drop">Disabled</parameter>
+        <parameter name="client.retry.interval">4000</parameter>
+        <parameter name="max.delivery.attempts">1</parameter>
+        <parameter name="interval">4000</parameter>
+        <parameter name="throttle">false</parameter>
+        <parameter name="is.active">true</parameter>
+    </messageProcessor>
+
+    <!-- Initial Proxy. Forwards the payload to the Message Store -->
+    <proxy name="BASE_Proxy" startOnLoad="true" transports="http https" xmlns="http://ws.apache.org/ns/synapse">
+        <target>
+            <inSequence>
+                <property name="FORCE_SC_ACCEPTED" scope="axis2" type="STRING" value="true"/>
+                <property name="OUT_ONLY" value="true"/>
+                <log level="full"/>
+                <store messageStore="BASE_Store"/>
+            </inSequence>
+            <outSequence/>
+            <faultSequence/>
+        </target>
+    </proxy>
+
+</definitions>

--- a/integration/mediation-tests/tests-transport/src/test/resources/artifacts/ESB/messageProcessorConfig/ViewPopTest.xml
+++ b/integration/mediation-tests/tests-transport/src/test/resources/artifacts/ESB/messageProcessorConfig/ViewPopTest.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~ http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<definitions xmlns="http://ws.apache.org/ns/synapse">
+
+    <!-- Initial Message Store. Forwards to Queue -->
+    <messageStore xmlns="http://ws.apache.org/ns/synapse"
+                  class="org.apache.synapse.message.store.impl.jms.JmsStore"
+                  name="VPE_Store">
+        <parameter name="java.naming.factory.initial">org.apache.activemq.jndi.ActiveMQInitialContextFactory</parameter>
+        <parameter name="store.jms.destination">VPE_Queue</parameter>
+        <parameter name="store.producer.guaranteed.delivery.enable">false</parameter>
+        <parameter name="store.jms.cache.connection">true</parameter>
+        <parameter name="java.naming.provider.url">tcp://localhost:61616</parameter>
+        <parameter name="store.jms.JMSSpecVersion">1.1</parameter>
+    </messageStore>
+
+    <!-- Initial Message Processor. Subscribed to Queue. Uses View and Pop services -->
+    <messageProcessor xmlns="http://ws.apache.org/ns/synapse"
+                      class="org.apache.synapse.message.processor.impl.forwarder.ScheduledMessageForwardingProcessor"
+                      name="VPE_Processor"
+                      messageStore="VPE_Store">
+        <parameter name="max.delivery.drop">Disabled</parameter>
+        <parameter name="client.retry.interval">4000</parameter>
+        <parameter name="max.delivery.attempts">1</parameter>
+        <parameter name="interval">4000</parameter>
+        <parameter name="throttle">false</parameter>
+        <parameter name="is.active">true</parameter>
+    </messageProcessor>
+
+    <!-- Initial Proxy. Sends the payload to the Message Store -->
+    <proxy name="VPE_Proxy" startOnLoad="true" transports="http https" xmlns="http://ws.apache.org/ns/synapse">
+        <target>
+            <inSequence>
+                <property name="FORCE_SC_ACCEPTED" scope="axis2" type="STRING" value="true"/>
+                <property name="OUT_ONLY" value="true"/>
+                <log level="full"/>
+                <store messageStore="VPE_Store"/>
+            </inSequence>
+            <outSequence/>
+            <faultSequence/>
+        </target>
+    </proxy>
+
+</definitions>

--- a/integration/mediation-tests/tests-transport/src/test/resources/testng.xml
+++ b/integration/mediation-tests/tests-transport/src/test/resources/testng.xml
@@ -21,6 +21,13 @@
         </classes>
     </test>
 
+    <test name="ViewPopRedirectTests" preserve-order="true" verbose="2">
+        <classes>
+            <class name="org.wso2.carbon.esb.jms.ViewPopRedirectTests.RedirectTest"/>
+            <class name="org.wso2.carbon.esb.jms.ViewPopRedirectTests.ViewPopTest"/>
+        </classes>
+    </test>
+
     <test name="passthru-Transport-Test" preserve-order="true" verbose="2">
         <classes>
             <class name="org.wso2.carbon.esb.passthru.transport.test.CheckAuthHeaderOrderTestCase"/>


### PR DESCRIPTION
## Purpose
- To test the newly added MessageProcessor Admin Servcies
- To document how to add Admin Services

## Goals
Successfully run tests for View, Pop and Enqueue functionality.
Describe the steps taken to add Admin Services

## Approach
Added test cases in tests-transport file to automatically test the functionality
Documented the entire steps with added code snippets on how to add Admin Services 
