### PR TITLE
Skip tests for incompatible versions

### DIFF
--- a/product-scenarios/5-route-messages-between-systems/5.3-load-balance-messages-among-systems/5.3.1-load-balance-messages-received-over-http/5.3.1.1-load-balance-with-load-balance-group/src/test/java/org/wso2/carbon/ei/scenario/test/LoadBalanceEndpointsWithLoadBalanceGroupTest.java
+++ b/product-scenarios/5-route-messages-between-systems/5.3-load-balance-messages-among-systems/5.3.1-load-balance-messages-received-over-http/5.3.1.1-load-balance-with-load-balance-group/src/test/java/org/wso2/carbon/ei/scenario/test/LoadBalanceEndpointsWithLoadBalanceGroupTest.java
@@ -46,8 +46,9 @@ public class LoadBalanceEndpointsWithLoadBalanceGroupTest extends ScenarioTestBa
 
     @BeforeClass()
     public void init() throws Exception {
-        skipTestsForIncompatibleProductVersions(ScenarioConstants.VERSION_490, ScenarioConstants.VERSION_600,
-                                                ScenarioConstants.VERSION_610, ScenarioConstants.VERSION_611);
+        skipTestsForIncompatibleProductVersions(ScenarioConstants.VERSION_490, ScenarioConstants.VERSION_500,
+                                                ScenarioConstants.VERSION_600, ScenarioConstants.VERSION_610,
+                                                ScenarioConstants.VERSION_611);
         super.init();
     }
 


### PR DESCRIPTION
## Purpose
The purpose of this PR is to skip tests to incompatible product versions

## Approach
Skip approach 5.3.1.1 to ESB-5.0.0

## Test environment
This is tested locally in following environment.
JDK - 1.8
OS - macOS High Sierra