### PR TITLE
Update synapse config in 1.1.1 and 1.1.3

### DIFF
--- a/product-scenarios/1-integrating-systems-that-communicate-in-heterogeneous-message-formats/01-SynapseConfigProject/01-synapseConfig/src/main/synapse-config/proxy-services/1_1_1_Proxy_soap_to_json_using_payload_factory.xml
+++ b/product-scenarios/1-integrating-systems-that-communicate-in-heterogeneous-message-formats/01-SynapseConfigProject/01-synapseConfig/src/main/synapse-config/proxy-services/1_1_1_Proxy_soap_to_json_using_payload_factory.xml
@@ -33,6 +33,7 @@
                     <arg evaluator="json" expression="$.LookupCityResult.Zip"/>
                 </args>
             </payloadFactory>
+            <property name="messageType" scope="axis2" type="STRING" value="text/xml"/>
             <respond description="Respond to client"/>
         </outSequence>
         <faultSequence>

--- a/product-scenarios/1-integrating-systems-that-communicate-in-heterogeneous-message-formats/01-SynapseConfigProject/01-synapseConfig/src/main/synapse-config/proxy-services/1_1_3_Proxy_soap_to_json_using_data_mapper.xml
+++ b/product-scenarios/1-integrating-systems-that-communicate-in-heterogeneous-message-formats/01-SynapseConfigProject/01-synapseConfig/src/main/synapse-config/proxy-services/1_1_3_Proxy_soap_to_json_using_data_mapper.xml
@@ -10,6 +10,7 @@
         </inSequence>
         <outSequence>
             <datamapper config="gov:datamapper/config_convert_json_to_soap.dmc" inputSchema="gov:datamapper/config_convert_json_to_soap_inputSchema.json" inputType="JSON" outputSchema="gov:datamapper/config_convert_json_to_soap_outputSchema.json" outputType="XML" xsltStyleSheet="gov:datamapper/config_convert_json_to_soap_xsltStyleSheet.xml"/>
+            <property name="messageType" scope="axis2" type="STRING" value="text/xml"/>
             <respond/>
         </outSequence>
         <faultSequence>


### PR DESCRIPTION
## Purpose
The purpose of this PR is to set messageType property in approach 1.1.1 and 1.1.3

## Approach
Set messageType property in approach 1.1.1-soap-to-json-using-payloadfactory-mediator and 1.1.3-soap-to-json-using-data-mapper

## Test environment
This is tested locally in following environment.
JDK - 1.8
OS - macOS High Sierra
