### PR TITLE
Add ballerina resource to count number of service invocations

### DIFF
--- a/product-scenarios/backend-service/ballerinaService/src/.gitignore
+++ b/product-scenarios/backend-service/ballerinaService/src/.gitignore
@@ -1,1 +1,3 @@
 target
+ballerina-internal.log
+ballerina-internal.log.lck


### PR DESCRIPTION
## Purpose
Adds a ballerina resource to count number of service invocations. This will be used in testing scheduled tasks to verify if they've run with the configured interval/cron. 