### PR TITLE
Add test case 10.1.1.1-Read file from FTP location

### DIFF
--- a/product-scenarios/10-file-processing/10-SynapseConfigProject/10-synapseConfig-filter/pom.xml
+++ b/product-scenarios/10-file-processing/10-SynapseConfigProject/10-synapseConfig-filter/pom.xml
@@ -30,7 +30,7 @@
   <version>1.0.0</version>
   <build>
     <filters>
-      <filter>${data.bucket.location}/deployment.properties</filter>
+      <filter>${env.DATA_BUCKET_LOCATION}/deployment.properties</filter>
     </filters>
     <plugins>
       <plugin>
@@ -60,6 +60,7 @@
               <goal>copy-resources</goal>
             </goals>
             <configuration>
+              <escapeString>\</escapeString>
               <outputDirectory>${project.build.directory}/temp/src/</outputDirectory>
               <resources>
                 <resource>

--- a/product-scenarios/10-file-processing/10-SynapseConfigProject/10-synapseConfig/artifact.xml
+++ b/product-scenarios/10-file-processing/10-SynapseConfigProject/10-synapseConfig/artifact.xml
@@ -29,4 +29,7 @@
     <artifact name="10_SOAP_EP" groupId="org.wso2.ei.product-scenarios.scenario_10.endpoint" version="1.0.0" type="synapse/endpoint" serverRole="EnterpriseServiceBus">
         <file>src/main/synapse-config/endpoints/10_SOAP_EP.xml</file>
     </artifact>
+    <artifact name="10_1_1_1_1_Proxy_reading_a_file_from_ftp_location_using_vfs_listener" groupId="org.wso2.ei.product-scenarios.scenario_10.proxy-service" version="1.0.0" type="synapse/proxy-service" serverRole="EnterpriseServiceBus">
+        <file>src/main/synapse-config/proxy-services/10_1_1_1_1_Proxy_reading_a_file_from_ftp_location_using_vfs_listener.xml</file>
+    </artifact>
 </artifacts>

--- a/product-scenarios/10-file-processing/10-SynapseConfigProject/10-synapseConfig/src/main/synapse-config/proxy-services/10_1_1_1_1_Proxy_reading_a_file_from_ftp_location_using_vfs_listener.xml
+++ b/product-scenarios/10-file-processing/10-SynapseConfigProject/10-synapseConfig/src/main/synapse-config/proxy-services/10_1_1_1_1_Proxy_reading_a_file_from_ftp_location_using_vfs_listener.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied. See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<proxy name="10_1_1_1_1_Proxy_reading_a_file_from_ftp_location_using_vfs_listener" startOnLoad="true" transports="vfs" xmlns="http://ws.apache.org/ns/synapse">
+    <target>
+        <endpoint>
+            <address format="soap12" uri="http://ei-backend.scenarios.wso2.org:8080/axis2/services/SimpleStockQuoteService"/>
+        </endpoint>
+        <inSequence/>
+        <outSequence>
+            <log level="full"/>
+            <property expression="fn:concat(fn:substring-after(get-property('MessageID'), 'urn:uuid:'), '.xml')" name="transport.vfs.ReplyFileName" scope="transport" type="STRING"/>
+            <property name="OUT_ONLY" scope="default" type="STRING" value="true"/>
+            <log level="full"/>
+            <send>
+                <endpoint>
+                    <address uri="vfs:ftp://${FTPUserName}:${FTPUserPassword}\@${FTPHostname}/vfs/output/stockQuote.xml?vfs.passive=false"/>
+                </endpoint>
+            </send>
+        </outSequence>
+        <faultSequence/>
+    </target>
+    <publishWSDL preservePolicy="true" uri="file:samples/service-bus/resources/proxy/sample_proxy_1.wsdl"/>
+    <parameter name="transport.PollInterval">15</parameter>
+    <parameter name="transport.vfs.FileURI">vfs:ftp://${FTPUserName}:${FTPUserPassword}\@${FTPHostname}/vfs/input/?vfs.passive=false</parameter>
+    <parameter name="transport.vfs.ContentType">text/xml</parameter>
+    <parameter name="transport.vfs.ActionAfterProcess">MOVE</parameter>
+    <parameter name="transport.vfs.MoveAfterFailure">vfs:ftp://${FTPUserName}:${FTPUserPassword}\@${FTPHostname}/vfs/failure/?vfs.passive=false</parameter>
+    <parameter name="transport.vfs.ActionAfterFailure">MOVE</parameter>
+    <parameter name="transport.vfs.FileNamePattern">.*\.xml</parameter>
+    <parameter name="transport.vfs.MoveAfterProcess">vfs:ftp://${FTPUserName}:${FTPUserPassword}\@${FTPHostname}/vfs/original/?vfs.passive=false</parameter>
+</proxy>

--- a/product-scenarios/10-file-processing/10-SynapseConfigProject/10-synapseConfigCompositeApplication/pom.xml
+++ b/product-scenarios/10-file-processing/10-SynapseConfigProject/10-synapseConfigCompositeApplication/pom.xml
@@ -31,21 +31,28 @@
     <org.wso2.ei.product-scenarios.scenario_10.endpoint_._10_SOAP_EP>capp/EnterpriseServiceBus</org.wso2.ei.product-scenarios.scenario_10.endpoint_._10_SOAP_EP>
     <org.wso2.ei.product-scenarios.scenario_10.api_._API_file_operations>capp/EnterpriseServiceBus</org.wso2.ei.product-scenarios.scenario_10.api_._API_file_operations>
     <org.wso2.ei.product-scenarios.scenario_10.api_._10_1_1_7_3_API_reading_a_file_from_local_location_using_file_connector>capp/EnterpriseServiceBus</org.wso2.ei.product-scenarios.scenario_10.api_._10_1_1_7_3_API_reading_a_file_from_local_location_using_file_connector>
+    <org.wso2.ei.product-scenarios.scenario_10.proxy-service_._10_1_1_1_1_Proxy_reading_a_file_from_ftp_location_using_vfs_listener>capp/EnterpriseServiceBus</org.wso2.ei.product-scenarios.scenario_10.proxy-service_._10_1_1_1_1_Proxy_reading_a_file_from_ftp_location_using_vfs_listener>
     <artifact.types>jaggery/app=zip,synapse/priority-executor=xml,synapse/inbound-endpoint=xml,service/rule=aar,synapse/message-store=xml,event/stream=json,service/meta=xml,datasource/datasource=xml,synapse/proxy-service=xml,bpel/workflow=zip,synapse/sequence=xml,synapse/endpointTemplate=xml,carbon/application=car,wso2/gadget=dar,synapse/api=xml,synapse/event-source=xml,synapse/message-processors=xml,event/receiver=xml,lib/dataservice/validator=jar,synapse/template=xml,synapse/endpoint=xml,lib/carbon/ui=jar,lib/synapse/mediator=jar,event/publisher=xml,synapse/local-entry=xml,synapse/task=xml,webapp/jaxws=war,registry/resource=zip,synapse/configuration=xml,service/axis2=aar,synapse/lib=zip,synapse/sequenceTemplate=xml,event/execution-plan=siddhiql,service/dataservice=dbs,web/application=war,lib/library/bundle=jar</artifact.types>
     <org.wso2.ei.product-scenarios.scenario_10.proxy-service_._10_1_1_7_1_Proxy_reading_a_file_from_local_location_using_vfs_listener>capp/EnterpriseServiceBus</org.wso2.ei.product-scenarios.scenario_10.proxy-service_._10_1_1_7_1_Proxy_reading_a_file_from_local_location_using_vfs_listener>
   </properties>
   <dependencies>
     <dependency>
-      <groupId>org.wso2.ei.product-scenarios.scenario_10.lib</groupId>
-      <artifactId>fileconnector-connector</artifactId>
-      <version>2.0.12</version>
-      <type>zip</type>
-    </dependency>
-    <dependency>
       <groupId>org.wso2.ei.product-scenarios.scenario_10.proxy-service</groupId>
       <artifactId>10_1_1_7_1_Proxy_reading_a_file_from_local_location_using_vfs_listener</artifactId>
       <version>1.0.0</version>
       <type>xml</type>
+    </dependency>
+    <dependency>
+      <groupId>org.wso2.ei.product-scenarios.scenario_10.proxy-service</groupId>
+      <artifactId>10_1_1_1_1_Proxy_reading_a_file_from_ftp_location_using_vfs_listener</artifactId>
+      <version>1.0.0</version>
+      <type>xml</type>
+    </dependency>
+    <dependency>
+      <groupId>org.wso2.ei.product-scenarios.scenario_10.lib</groupId>
+      <artifactId>fileconnector-connector</artifactId>
+      <version>2.0.12</version>
+      <type>zip</type>
     </dependency>
     <dependency>
       <groupId>org.wso2.ei.product-scenarios.scenario_10.api</groupId>

--- a/product-scenarios/10-file-processing/10.1-simple-file-movement-between-two-systems/10.1.1-reading-a-file-from-a-specified-location-in-file-system/10.1.1.1-reading-a-file-from-FTP-location/pom.xml
+++ b/product-scenarios/10-file-processing/10.1-simple-file-movement-between-two-systems/10.1.1-reading-a-file-from-a-specified-location-in-file-system/10.1.1.1-reading-a-file-from-FTP-location/pom.xml
@@ -1,0 +1,125 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied. See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.wso2.ei</groupId>
+        <artifactId>10.1.1-reading-a-file-from-a-specified-location-in-file-system</artifactId>
+        <version>6.4.0</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>10.1.1.1-reading-a-file-from-FTP-location</artifactId>
+
+    <packaging>jar</packaging>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <inherited>true</inherited>
+            </plugin>
+            <plugin>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy-jacoco-dependencies</id>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>copy-dependencies</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.build.directory}/jacoco</outputDirectory>
+                            <includeTypes>jar</includeTypes>
+                            <includeArtifactIds>org.jacoco.agent</includeArtifactIds>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>2.4</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>test-jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-resources-plugin</artifactId>
+                <version>2.6</version>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.wso2.ei</groupId>
+            <artifactId>admin-clients</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.wso2.carbon.mediation</groupId>
+                    <artifactId>org.wso2.carbon.rest.api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.ei</groupId>
+            <artifactId>integration-test-utils</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.wso2.carbon.mediation</groupId>
+                    <artifactId>org.wso2.carbon.rest.api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.ei</groupId>
+            <artifactId>automation-extensions</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.ei</groupId>
+            <artifactId>scenarios-commons</artifactId>
+        </dependency>
+
+        <!-- Jacoco Dependency-->
+        <dependency>
+            <groupId>org.jacoco</groupId>
+            <artifactId>org.jacoco.agent</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>commons-logging</groupId>
+            <artifactId>commons-logging</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.testng</groupId>
+            <artifactId>testng</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.json.wso2</groupId>
+            <artifactId>json</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/product-scenarios/10-file-processing/10.1-simple-file-movement-between-two-systems/10.1.1-reading-a-file-from-a-specified-location-in-file-system/10.1.1.1-reading-a-file-from-FTP-location/src/test/java/org/wso2/carbon/esb/scenario/test/ReadFileFromFTPLocationTest.java
+++ b/product-scenarios/10-file-processing/10.1-simple-file-movement-between-two-systems/10.1.1-reading-a-file-from-a-specified-location-in-file-system/10.1.1.1-reading-a-file-from-FTP-location/src/test/java/org/wso2/carbon/esb/scenario/test/ReadFileFromFTPLocationTest.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.esb.scenario.test;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.awaitility.Awaitility;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import org.wso2.carbon.esb.scenario.test.common.ScenarioConstants;
+import org.wso2.carbon.esb.scenario.test.common.ScenarioTestBase;
+import org.wso2.carbon.esb.scenario.test.common.StringUtil;
+import org.wso2.carbon.esb.scenario.test.common.ftp.FTPClientWrapper;
+
+import java.io.IOException;
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * This test class test reading a file from an FTP location
+ */
+public class ReadFileFromFTPLocationTest extends ScenarioTestBase {
+
+    private static final Log log = LogFactory.getLog(ReadFileFromFTPLocationTest.class);
+    private static FTPClientWrapper ftpClient;
+    private static int port = 21;
+
+    @BeforeClass(description = "Test init")
+    public void init() throws Exception {
+        super.init();
+    }
+
+    /**
+     * This test case test reading a file from a FTP location using VFS listener
+     *
+     * @throws IOException - if any REST API request fails
+     */
+    // TODO This testcase is disabled until infra is re-designed to enable FTP
+    @Test(description = "10.1.1.1.1", enabled = false)
+    public void testReadFileFromFTPLocationUsingVFSListener() throws IOException {
+        String messageID = "10.1.1.1.1";
+
+        ftpClient = connectToFTP(port);
+
+        ftpClient.makeDirectories("vfs/input");
+        ftpClient.makeDirectories("vfs/output");
+        ftpClient.makeDirectories("vfs/original");
+        ftpClient.makeDirectories("vfs/failure");
+
+        String quoteRequestDirUrl = getVfsSourceDir("vfs/source_files/requestQuote.xml");
+        ftpClient.ftpFileUpload(quoteRequestDirUrl, "/vfs/input/requestQuote.xml");
+
+        Awaitility.await()
+                  .pollInterval(500, TimeUnit.MILLISECONDS)
+                  .atMost(ScenarioConstants.FILE_WRITE_WAIT_TIME_MS, TimeUnit.MILLISECONDS)
+                  .until(isFileExist("vfs/output/stockQuote.xml"));
+
+        String stockQuoteResponse = ftpClient.readFile("vfs/output/stockQuote.xml");
+
+        boolean regexMatchStockQuote = StringUtil.stockQuoteXMLRegexMatch(stockQuoteResponse, "IBM", "IBM Company");
+        Assert.assertTrue(regexMatchStockQuote, "Expected response not received in " + messageID);
+    }
+
+    private boolean checkFileExist(String filePath) throws IOException {
+        if (ftpClient.checkFileExists(filePath)) {
+            String fileContent = ftpClient.readFile(filePath);
+            ftpClient.connectToFtp();
+            return !fileContent.isEmpty();
+        } else {
+            return false;
+        }
+    }
+
+    private Callable<Boolean> isFileExist(final String filepath) {
+        return new Callable<Boolean>() {
+            @Override
+            public Boolean call() throws Exception {
+                log.info("Check file exist : " + filepath);
+                return checkFileExist(filepath);
+            }
+        };
+    }
+
+    @AfterClass(description = "Server Cleanup", alwaysRun = true)
+    public void cleanup() throws Exception {
+        super.cleanup();
+    }
+
+}

--- a/product-scenarios/10-file-processing/10.1-simple-file-movement-between-two-systems/10.1.1-reading-a-file-from-a-specified-location-in-file-system/10.1.1.1-reading-a-file-from-FTP-location/src/test/resources/log4j.properties
+++ b/product-scenarios/10-file-processing/10.1-simple-file-movement-between-two-systems/10.1.1-reading-a-file-from-a-specified-location-in-file-system/10.1.1.1-reading-a-file-from-FTP-location/src/test/resources/log4j.properties
@@ -1,0 +1,35 @@
+#
+# Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+#
+# WSO2 Inc. licenses this file to you under the Apache License,
+# Version 2.0 (the "License"); you may not use this file except
+# in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied. See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+log4j.rootLogger=INFO, console, Default
+
+log4j.logger.org.wso2=INFO
+
+#Automation file apender
+log4j.appender.Default=org.apache.log4j.RollingFileAppender
+log4j.appender.Default.File=logs/automation.log
+log4j.appender.Default.Append=true
+log4j.appender.Default.MaxFileSize=10MB
+log4j.appender.Default.MaxBackupIndex=10
+log4j.appender.Default.layout=org.apache.log4j.PatternLayout
+log4j.appender.Default.layout.ConversionPattern=%d{ISO8601} %-5p [%c] - %m%n
+
+#Automation console apender
+log4j.appender.console=org.apache.log4j.ConsoleAppender
+log4j.appender.console.layout=org.apache.log4j.PatternLayout
+log4j.appender.console.layout.ConversionPattern=%-5p [%c] - %m%n

--- a/product-scenarios/10-file-processing/10.1-simple-file-movement-between-two-systems/10.1.1-reading-a-file-from-a-specified-location-in-file-system/10.1.1.1-reading-a-file-from-FTP-location/src/test/resources/testng.xml
+++ b/product-scenarios/10-file-processing/10.1-simple-file-movement-between-two-systems/10.1.1-reading-a-file-from-a-specified-location-in-file-system/10.1.1.1-reading-a-file-from-FTP-location/src/test/resources/testng.xml
@@ -1,0 +1,32 @@
+<!--
+  ~ Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied. See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+<!DOCTYPE suite SYSTEM "http://testng.org/testng-1.0.dtd" >
+<suite name="ESBTestSuite" parallel="false">
+    <listeners>
+        <!-- TestPrepExecutionListener : TestNG execution listener for perform test execution preparation -->
+        <listener class-name="org.wso2.carbon.esb.scenario.test.common.testng.listeners.TestPrepExecutionListener"/>
+
+        <!-- TestLoggingListener : Test listener to log test execution events -->
+        <listener class-name="org.wso2.carbon.esb.scenario.test.common.testng.listeners.TestLoggingListener"/>
+    </listeners>
+    <test name="ProxyService-Test" preserve-order="true" verbose="2" parallel="false">
+        <classes>
+            <class name="org.wso2.carbon.esb.scenario.test.ReadFileFromFTPLocationTest"/>
+        </classes>
+    </test>
+</suite>

--- a/product-scenarios/10-file-processing/10.1-simple-file-movement-between-two-systems/10.1.1-reading-a-file-from-a-specified-location-in-file-system/10.1.1.1-reading-a-file-from-FTP-location/src/test/resources/vfs/source_files/requestQuote.xml
+++ b/product-scenarios/10-file-processing/10.1-simple-file-movement-between-two-systems/10.1.1-reading-a-file-from-a-specified-location-in-file-system/10.1.1.1-reading-a-file-from-FTP-location/src/test/resources/vfs/source_files/requestQuote.xml
@@ -1,0 +1,10 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:wsa="http://www.w3.org/2005/08/addressing">
+    <soapenv:Body>
+        <m0:getQuote xmlns:m0="http://services.samples">
+            <m0:request>
+                <m0:symbol>IBM</m0:symbol>
+            </m0:request>
+        </m0:getQuote>
+    </soapenv:Body>
+</soapenv:Envelope>

--- a/product-scenarios/10-file-processing/10.1-simple-file-movement-between-two-systems/10.1.1-reading-a-file-from-a-specified-location-in-file-system/10.1.1.7-reading-a-file-from-local-location/src/test/java/org/wso2/carbon/esb/scenario/test/ReadFileFromLocalLocationTest.java
+++ b/product-scenarios/10-file-processing/10.1-simple-file-movement-between-two-systems/10.1.1-reading-a-file-from-a-specified-location-in-file-system/10.1.1.7-reading-a-file-from-local-location/src/test/java/org/wso2/carbon/esb/scenario/test/ReadFileFromLocalLocationTest.java
@@ -98,7 +98,7 @@ public class ReadFileFromLocalLocationTest extends ScenarioTestBase {
         JSONObject stockQuote = stockQuoteResponse.getJSONObject("Envelope").getJSONObject("Body")
                                                   .getJSONObject("getQuoteResponse").getJSONObject("return");
 
-        boolean regexMatchStockQuote = StringUtil.stockQuoteRegexMatch(stockQuote.toString(), "IBM", "IBM Company");
+        boolean regexMatchStockQuote = StringUtil.stockQuoteJsonRegexMatch(stockQuote.toString(), "IBM", "IBM Company");
         Assert.assertTrue(regexMatchStockQuote, "Expected response not received in " + messageID);
     }
 

--- a/product-scenarios/10-file-processing/10.1-simple-file-movement-between-two-systems/10.1.1-reading-a-file-from-a-specified-location-in-file-system/pom.xml
+++ b/product-scenarios/10-file-processing/10.1-simple-file-movement-between-two-systems/10.1.1-reading-a-file-from-a-specified-location-in-file-system/pom.xml
@@ -33,6 +33,7 @@
     <packaging>pom</packaging>
 
     <modules>
+        <module>10.1.1.1-reading-a-file-from-FTP-location</module>
         <module>10.1.1.7-reading-a-file-from-local-location</module>
     </modules>
 </project>

--- a/product-scenarios/10-file-processing/pom.xml
+++ b/product-scenarios/10-file-processing/pom.xml
@@ -31,9 +31,9 @@
     <packaging>pom</packaging>
     <modules>
         <module>10-SynapseConfigProject</module>
-        <!--<module>10.1-simple-file-movement-between-two-systems</module>
+        <module>10.1-simple-file-movement-between-two-systems</module>
         <module>10.2-file-movement-with-file-processing-between-two-systems</module>
-        <module>10.3-mask-valuable-business-data-stored-in-files</module>-->
+        <module>10.3-mask-valuable-business-data-stored-in-files</module>
     </modules>
     <build>
         <plugins>

--- a/product-scenarios/pom.xml
+++ b/product-scenarios/pom.xml
@@ -83,7 +83,8 @@
         <module>5-route-messages-between-systems</module>
         <module>7-connecting-with-packaged-applications</module>
         <module>8-connect-devices-to-enterprise</module>
-        <module>10-file-processing</module>
+        <!--TODO Scenario 10 is commented until VFS is supported-->
+        <!--<module>10-file-processing</module>-->
         <module>11-Asynchronous-message-processing</module>
         <module>13-micro-services</module>
         <module>14-periodically-execute-an-integration-process</module>

--- a/product-scenarios/scenarios-commons/src/main/java/org/wso2/carbon/esb/scenario/test/common/ScenarioConstants.java
+++ b/product-scenarios/scenarios-commons/src/main/java/org/wso2/carbon/esb/scenario/test/common/ScenarioConstants.java
@@ -82,6 +82,9 @@ public class ScenarioConstants {
     public static final String INFRA_EI_STACK_NAME = "EIStackName";
 
     public static final String TEST_RUN_UUID = "invocation.uuid";
+    public static final String FTP_HOST_NAME = "FTPHostname";
+    public static final String FTP_USERNAME = "FTPUserName";
+    public static final String FTP_PASSWORD = "FTPUserPassword";
 
     public static final String CAPP_EXTENSION = ".car";
 

--- a/product-scenarios/scenarios-commons/src/main/java/org/wso2/carbon/esb/scenario/test/common/ScenarioTestBase.java
+++ b/product-scenarios/scenarios-commons/src/main/java/org/wso2/carbon/esb/scenario/test/common/ScenarioTestBase.java
@@ -24,6 +24,7 @@ import org.apache.commons.logging.LogFactory;
 import org.awaitility.Awaitility;
 import org.testng.SkipException;
 import org.wso2.carbon.application.mgt.stub.ApplicationAdminExceptionException;
+import org.wso2.carbon.esb.scenario.test.common.ftp.FTPClientWrapper;
 import org.wso2.carbon.integration.common.admin.client.ApplicationAdminClient;
 import org.wso2.carbon.integration.common.admin.client.CarbonAppUploaderClient;
 
@@ -78,6 +79,9 @@ public class ScenarioTestBase {
     private String sessionCookie;
     private boolean standaloneMode;
 
+    private static String ftpHostName;
+    private static String ftpUsername;
+    private static String ftpPassword;
 
     private CarbonAppUploaderClient carbonAppUploaderClient = null;
     private ApplicationAdminClient applicationAdminClient = null;
@@ -407,6 +411,9 @@ public class ScenarioTestBase {
 
             deploymentStackName = infraProperties.getProperty(ScenarioConstants.INFRA_EI_STACK_NAME);
             elasticSearchHostname = infraProperties.getProperty(ScenarioConstants.ELASTICSEARCH_HOSTNAME);
+            ftpHostName = infraProperties.getProperty(ScenarioConstants.FTP_HOST_NAME);
+            ftpUsername = infraProperties.getProperty(ScenarioConstants.FTP_USERNAME);
+            ftpPassword = infraProperties.getProperty(ScenarioConstants.FTP_PASSWORD);
         }
     }
 
@@ -464,6 +471,19 @@ public class ScenarioTestBase {
             responseArray.add(fileContent);
         }
         return responseArray;
+    }
+
+    /**
+     * Function to connect to an FTP Server
+     *
+     * @param port - ftp port
+     * @return - VFSClient
+     * @throws IOException - if connecting to FTP server fails
+     */
+    protected FTPClientWrapper connectToFTP(int port) throws IOException {
+        FTPClientWrapper vfsClient = new FTPClientWrapper(ftpHostName, ftpUsername, ftpPassword, port);
+        vfsClient.connectToFtp();
+        return vfsClient;
     }
 }
 

--- a/product-scenarios/scenarios-commons/src/main/java/org/wso2/carbon/esb/scenario/test/common/StringUtil.java
+++ b/product-scenarios/scenarios-commons/src/main/java/org/wso2/carbon/esb/scenario/test/common/StringUtil.java
@@ -56,14 +56,14 @@ public class StringUtil {
     }
 
     /**
-     * Function to pattern match with regular expressions for stock quote response
+     * Function to pattern match with regular expressions for stock quote json response
      *
      * @param stockQuote - stockQuoteResponse as a String
      * @param symbol - stock quote symbol
      * @param companyName - company name of the stock quote response
      * @return - boolean if pattern matches with stock quote
      */
-    public static boolean stockQuoteRegexMatch(String stockQuote, String symbol, String companyName) {
+    public static boolean stockQuoteJsonRegexMatch(String stockQuote, String symbol, String companyName) {
         String regex = ".*marketCap\":" + ScenarioConstants.REGEX_EXPONENT +
                        ",\"symbol\":" + "\"" + symbol + "\"" +
                        ",\"last\":" + ScenarioConstants.REGEX_EXPONENT +
@@ -77,6 +77,35 @@ public class StringUtil {
                        ",\"low\":" + ScenarioConstants.REGEX_EXPONENT +
                        ",\"name\":" + "\"" + companyName + "\"" +
                        ".*open\":" + ScenarioConstants.REGEX_EXPONENT + "}";
+
+        Pattern pattern = Pattern.compile(regex, Pattern.DOTALL);
+        Matcher matcher = pattern.matcher(stockQuote);
+        return matcher.find();
+    }
+
+    /**
+     * Function to pattern match with regular expressions for stock quote xml response
+     *
+     * @param stockQuote - stockQuoteResponse as a String
+     * @param symbol - stock quote symbol
+     * @param companyName - company name of the stock quote response
+     * @return - boolean if pattern matches with stock quote
+     */
+    public static boolean stockQuoteXMLRegexMatch(String stockQuote, String symbol, String companyName) {
+        String regex = ".*<ns:getQuoteResponse.*<ns:return.*<ax21:change>" + ScenarioConstants.REGEX_EXPONENT +
+                       "</ax21:change><ax21:earnings>" + ScenarioConstants.REGEX_EXPONENT +
+                       "</ax21:earnings><ax21:high>" + ScenarioConstants.REGEX_EXPONENT +
+                       "</ax21:high><ax21:last>" + ScenarioConstants.REGEX_EXPONENT +
+                       "</ax21:last>.*<ax21:low>" + ScenarioConstants.REGEX_EXPONENT +
+                       "</ax21:low><ax21:marketCap>" +  ScenarioConstants.REGEX_EXPONENT +
+                       "</ax21:marketCap><ax21:name>" + companyName +
+                       "</ax21:name><ax21:open>" +  ScenarioConstants.REGEX_EXPONENT +
+                       "</ax21:open><ax21:peRatio>" + ScenarioConstants.REGEX_EXPONENT +
+                       "</ax21:peRatio><ax21:percentageChange>" + ScenarioConstants.REGEX_EXPONENT +
+                       "</ax21:percentageChange><ax21:prevClose>" + ScenarioConstants.REGEX_EXPONENT +
+                       "</ax21:prevClose><ax21:symbol>" + symbol +
+                       "</ax21:symbol><ax21:volume>" + ScenarioConstants.REGEX_EXPONENT +
+                       "</ax21:volume></ns:return></ns:getQuoteResponse>";
 
         Pattern pattern = Pattern.compile(regex, Pattern.DOTALL);
         Matcher matcher = pattern.matcher(stockQuote);


### PR DESCRIPTION
## Purpose
The purpose of this PR is to add test case 10.1.1.1 

## Approach
* Update pom file in `10-synapseConfig-filter` for escape filtering
* Add proxy `10_1_1_1_1_Proxy_reading_a_file_from_ftp_location_using_vfs_listener` to read a file from ftp location using vfs listener
* Update and add relevant pom files
* Add test case ReadFileFromFTPLocationTest
* Update `ScenarioTestBase` to retrieve `ftpHostName`, `ftpUsername`, `ftpPassword` from deployment.properties file
* Add function to pattern match with regular expressions for stock quote xml response

## Test environment
This is tested locally in following environment.
JDK - 1.8
OS - macOS High Sierra