### PR TITLE
Increase thread sleep time for artifacts to synchronized across cluster nodes

### DIFF
--- a/product-scenarios/scenarios-commons/src/main/java/org/wso2/carbon/esb/scenario/test/common/testng/listeners/TestPrepExecutionListener.java
+++ b/product-scenarios/scenarios-commons/src/main/java/org/wso2/carbon/esb/scenario/test/common/testng/listeners/TestPrepExecutionListener.java
@@ -135,7 +135,7 @@ public class TestPrepExecutionListener implements IExecutionListener {
                 if (!Boolean.valueOf(infraProperties.getProperty(ScenarioConstants.STANDALONE_DEPLOYMENT))) {
                     log.info("Waiting for artifacts synchronized across cluster nodes");
                     try {
-                        Thread.sleep(120000);
+                        Thread.sleep(300000);
                     } catch (InterruptedException e) {
                         // log and ignore
                         log.error("Error occurred while waiting for artifacts synchronized across cluster nodes", e);


### PR DESCRIPTION
## Purpose
The purpose of this PR is to increase the thread sleep time for artifacts to synchronized across cluster nodes. However this thread sleep will be removed in the future.

## Approach
Increase sleep time from 120,000 millis to 300,000 millis