### PR TITLE
Skip tests for incompatible product versions

### DIFF
--- a/product-scenarios/1-integrating-systems-that-communicate-in-heterogeneous-message-formats/1.6-xml-message-enrichment/1.6.12-Perform-Arithmetic-operations-in-XML-payload/src/test/java/org.wso2.carbon.ei.scenario.test/ArithmeticOperationsInXMLUsingDatamapperTest.java
+++ b/product-scenarios/1-integrating-systems-that-communicate-in-heterogeneous-message-formats/1.6-xml-message-enrichment/1.6.12-Perform-Arithmetic-operations-in-XML-payload/src/test/java/org.wso2.carbon.ei.scenario.test/ArithmeticOperationsInXMLUsingDatamapperTest.java
@@ -22,6 +22,7 @@ import org.apache.axis2.transport.http.HTTPConstants;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
+import org.wso2.carbon.esb.scenario.test.common.ScenarioConstants;
 import org.wso2.carbon.esb.scenario.test.common.ScenarioTestBase;
 import org.wso2.carbon.esb.scenario.test.common.http.HTTPUtils;
 
@@ -39,6 +40,7 @@ public class ArithmeticOperationsInXMLUsingDatamapperTest extends ScenarioTestBa
     @BeforeClass
     public void init() throws Exception {
         super.init();
+        skipTestsForIncompatibleProductVersions(ScenarioConstants.VERSION_490);
     }
 
     /**

--- a/product-scenarios/1-integrating-systems-that-communicate-in-heterogeneous-message-formats/1.6-xml-message-enrichment/1.6.13-Perform-String-operations-in-XML-payload/src/test/java/org.wso2.carbon.ei.scenario.test/StringOperationsUsingDatamapperTest.java
+++ b/product-scenarios/1-integrating-systems-that-communicate-in-heterogeneous-message-formats/1.6-xml-message-enrichment/1.6.13-Perform-String-operations-in-XML-payload/src/test/java/org.wso2.carbon.ei.scenario.test/StringOperationsUsingDatamapperTest.java
@@ -21,6 +21,7 @@ package org.wso2.carbon.ei.scenario.test;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
+import org.wso2.carbon.esb.scenario.test.common.ScenarioConstants;
 import org.wso2.carbon.esb.scenario.test.common.ScenarioTestBase;
 import org.wso2.carbon.esb.scenario.test.common.http.HTTPUtils;
 import org.apache.axis2.transport.http.HTTPConstants;
@@ -39,6 +40,7 @@ public class StringOperationsUsingDatamapperTest extends ScenarioTestBase {
     @BeforeClass
     public void init() throws Exception {
         super.init();
+        skipTestsForIncompatibleProductVersions(ScenarioConstants.VERSION_490);
     }
 
     /**


### PR DESCRIPTION
## Purpose
This PR contains skipping tests for product version ESB 4.9.0 for following test classes. 
- ArithmeticOperationsInXMLUsingDatamapperTest
- StringOperationsUsingDatamapperTest