### PR TITLE
Pass -Dmaven.repo.local to missing config poms

### DIFF
--- a/product-scenarios/1-integrating-systems-that-communicate-in-heterogeneous-message-formats/01-SynapseConfigProject/01-synapseConfigRegistry/pom.xml
+++ b/product-scenarios/1-integrating-systems-that-communicate-in-heterogeneous-message-formats/01-SynapseConfigProject/01-synapseConfigRegistry/pom.xml
@@ -90,6 +90,7 @@
                 <argument>clean</argument>
                 <argument>install</argument>
                 <argument>-Dmaven.test.skip=${maven.test.skip}</argument>
+                <argument>-Dmaven.repo.local=${maven.repo.local}</argument>
               </arguments>
             </configuration>
           </execution>
@@ -105,6 +106,7 @@
               <arguments>
                 <argument>deploy</argument>
                 <argument>-Dmaven.test.skip=${maven.test.skip}</argument>
+                <argument>-Dmaven.repo.local=${maven.repo.local}</argument>
               </arguments>
             </configuration>
           </execution>

--- a/product-scenarios/1-integrating-systems-that-communicate-in-heterogeneous-message-formats/1.3-converting-json-to-soap/scenario_1.3-test-artifacts/scenario_1_3-synapse-config/pom.xml
+++ b/product-scenarios/1-integrating-systems-that-communicate-in-heterogeneous-message-formats/1.3-converting-json-to-soap/scenario_1.3-test-artifacts/scenario_1_3-synapse-config/pom.xml
@@ -56,6 +56,7 @@
                 <argument>clean</argument>
                 <argument>package</argument>
                 <argument>-Dmaven.test.skip=${maven.test.skip}</argument>
+                <argument>-Dmaven.repo.local=${maven.repo.local}</argument>
               </arguments>
             </configuration>
           </execution>
@@ -72,6 +73,7 @@
                 <argument>clean</argument>
                 <argument>install</argument>
                 <argument>-Dmaven.test.skip=${maven.test.skip}</argument>
+                <argument>-Dmaven.repo.local=${maven.repo.local}</argument>
               </arguments>
             </configuration>
           </execution>
@@ -87,6 +89,7 @@
               <arguments>
                 <argument>deploy</argument>
                 <argument>-Dmaven.test.skip=${maven.test.skip}</argument>
+                <argument>-Dmaven.repo.local=${maven.repo.local}</argument>
               </arguments>
             </configuration>
           </execution>

--- a/product-scenarios/10-file-processing/10-SynapseConfigProject/10-synapseConfigConnectorExporter/pom.xml
+++ b/product-scenarios/10-file-processing/10-SynapseConfigProject/10-synapseConfigConnectorExporter/pom.xml
@@ -94,6 +94,7 @@
                 <argument>clean</argument>
                 <argument>package</argument>
                 <argument>-Dmaven.test.skip=${maven.test.skip}</argument>
+              <argument>-Dmaven.repo.local=${maven.repo.local}</argument>
               </arguments>
             </configuration>
           </execution>
@@ -110,6 +111,7 @@
                 <argument>clean</argument>
                 <argument>install</argument>
                 <argument>-Dmaven.test.skip=${maven.test.skip}</argument>
+              <argument>-Dmaven.repo.local=${maven.repo.local}</argument>
               </arguments>
             </configuration>
           </execution>
@@ -125,6 +127,7 @@
               <arguments>
                 <argument>deploy</argument>
                 <argument>-Dmaven.test.skip=${maven.test.skip}</argument>
+                <argument>-Dmaven.repo.local=${maven.repo.local}</argument>
               </arguments>
             </configuration>
           </execution>

--- a/product-scenarios/10-file-processing/10-SynapseConfigProject/10-synapseConfigRegistry/pom.xml
+++ b/product-scenarios/10-file-processing/10-SynapseConfigProject/10-synapseConfigRegistry/pom.xml
@@ -74,6 +74,7 @@
                 <argument>clean</argument>
                 <argument>install</argument>
                 <argument>-Dmaven.test.skip=${maven.test.skip}</argument>
+                <argument>-Dmaven.repo.local=${maven.repo.local}</argument>
               </arguments>
             </configuration>
           </execution>
@@ -89,6 +90,7 @@
               <arguments>
                 <argument>deploy</argument>
                 <argument>-Dmaven.test.skip=${maven.test.skip}</argument>
+                <argument>-Dmaven.repo.local=${maven.repo.local}</argument>
               </arguments>
             </configuration>
           </execution>

--- a/product-scenarios/11-Asynchronous-message-processing/11-SynapseConfigProject/11-synapseConfigRegistry/pom.xml
+++ b/product-scenarios/11-Asynchronous-message-processing/11-SynapseConfigProject/11-synapseConfigRegistry/pom.xml
@@ -73,6 +73,7 @@
                 <argument>clean</argument>
                 <argument>install</argument>
                 <argument>-Dmaven.test.skip=${maven.test.skip}</argument>
+                <argument>-Dmaven.repo.local=${maven.repo.local}</argument>
               </arguments>
             </configuration>
           </execution>
@@ -88,6 +89,7 @@
               <arguments>
                 <argument>deploy</argument>
                 <argument>-Dmaven.test.skip=${maven.test.skip}</argument>
+                <argument>-Dmaven.repo.local=${maven.repo.local}</argument>
               </arguments>
             </configuration>
           </execution>

--- a/product-scenarios/2-Bridging-systems-that-communicate-in-different-protocols/2.5-Switching-from-UDP-to-HTTP-or-HTTPS/02-synapseConfig/pom.xml
+++ b/product-scenarios/2-Bridging-systems-that-communicate-in-different-protocols/2.5-Switching-from-UDP-to-HTTP-or-HTTPS/02-synapseConfig/pom.xml
@@ -56,6 +56,7 @@
                 <argument>clean</argument>
                 <argument>package</argument>
                 <argument>-Dmaven.test.skip=${maven.test.skip}</argument>
+                <argument>-Dmaven.repo.local=${maven.repo.local}</argument>
               </arguments>
             </configuration>
           </execution>
@@ -72,6 +73,7 @@
                 <argument>clean</argument>
                 <argument>install</argument>
                 <argument>-Dmaven.test.skip=${maven.test.skip}</argument>
+                <argument>-Dmaven.repo.local=${maven.repo.local}</argument>
               </arguments>
             </configuration>
           </execution>
@@ -87,6 +89,7 @@
               <arguments>
                 <argument>deploy</argument>
                 <argument>-Dmaven.test.skip=${maven.test.skip}</argument>
+                <argument>-Dmaven.repo.local=${maven.repo.local}</argument>
               </arguments>
             </configuration>
           </execution>

--- a/product-scenarios/4-gateway/04-SynapseConfigProject/04-synapseConfigRegistry/pom.xml
+++ b/product-scenarios/4-gateway/04-SynapseConfigProject/04-synapseConfigRegistry/pom.xml
@@ -56,6 +56,7 @@
                 <argument>clean</argument>
                 <argument>install</argument>
                 <argument>-Dmaven.test.skip=${maven.test.skip}</argument>
+                <argument>-Dmaven.repo.local=${maven.repo.local}</argument>
               </arguments>
             </configuration>
           </execution>
@@ -71,6 +72,7 @@
               <arguments>
                 <argument>deploy</argument>
                 <argument>-Dmaven.test.skip=${maven.test.skip}</argument>
+                <argument>-Dmaven.repo.local=${maven.repo.local}</argument>
               </arguments>
             </configuration>
           </execution>

--- a/product-scenarios/5-route-messages-between-systems/05-synapseConfigProject/05-synapseConfigRegistry/pom.xml
+++ b/product-scenarios/5-route-messages-between-systems/05-synapseConfigProject/05-synapseConfigRegistry/pom.xml
@@ -56,6 +56,7 @@
                 <argument>clean</argument>
                 <argument>install</argument>
                 <argument>-Dmaven.test.skip=${maven.test.skip}</argument>
+                <argument>-Dmaven.repo.local=${maven.repo.local}</argument>
               </arguments>
             </configuration>
           </execution>
@@ -71,6 +72,7 @@
               <arguments>
                 <argument>deploy</argument>
                 <argument>-Dmaven.test.skip=${maven.test.skip}</argument>
+                <argument>-Dmaven.repo.local=${maven.repo.local}</argument>
               </arguments>
             </configuration>
           </execution>


### PR DESCRIPTION
## Purpose
Passes the argument -Dmaven.repo.local to missing config poms where the exec-maven.plugin is used.