### PR TITLE
Modify ElasticSearchClient to search for the exact query

### DIFF
--- a/product-scenarios/scenarios-commons/src/main/java/org/wso2/carbon/esb/scenario/test/common/elasticsearch/ElasticSearchClient.java
+++ b/product-scenarios/scenarios-commons/src/main/java/org/wso2/carbon/esb/scenario/test/common/elasticsearch/ElasticSearchClient.java
@@ -56,7 +56,7 @@ public class ElasticSearchClient {
      */
     public JSONObject searchCarbonLogs(String logSnippet) throws IOException {
 
-        String searchURL = hostName + "/" + deploymentStackID + "-carbonlogs*/_search?q=" + logSnippet;
+        String searchURL = hostName + "/" + deploymentStackID + "-carbonlogs*/_search?q=\"" + logSnippet + "\"";
 
         log.info("searchURL:" + searchURL);
         RESTClient restClient = new RESTClient();


### PR DESCRIPTION
## Purpose
Modifes ElasticSearchClient to search for the exact query to avoid getting entries that only contain a part of the search query.