### PR TITLE
Correct http url

### DIFF
--- a/product-scenarios/scenarios-commons/src/main/java/org/wso2/carbon/esb/scenario/test/common/elasticsearch/ElasticSearchClient.java
+++ b/product-scenarios/scenarios-commons/src/main/java/org/wso2/carbon/esb/scenario/test/common/elasticsearch/ElasticSearchClient.java
@@ -57,7 +57,7 @@ public class ElasticSearchClient {
      */
     private JSONObject searchCarbonLogs(String logSnippet) throws IOException {
 
-        String baseUrl = "http://" + hostName + "/" + deploymentStackID + "-carbonlogs*/_search?q=";
+        String baseUrl = hostName + "/" + deploymentStackID + "-carbonlogs*/_search?q=";
         String queryParam = URLEncoder.encode("\"" + logSnippet + "\"", "UTF-8");
         String searchUrl = baseUrl + queryParam;
 


### PR DESCRIPTION
## Purpose
Removes the protocol name from the url since it comes in deployment.properties as https://elasticSearchEndpointName