### PR TITLE
Fix [EI-3434] enable heartbeat delay in broker profile

### DIFF
--- a/distribution/src/broker/conf/advanced/qpid-config.xml
+++ b/distribution/src/broker/conf/advanced/qpid-config.xml
@@ -76,7 +76,8 @@
     <virtualhosts>${conf}/qpid-virtualhosts.xml</virtualhosts>
 
     <heartbeat>
-        <delay>0</delay>
+        <!-- heartbeat delay in seconds-->
+        <delay>30</delay>
         <timeoutFactor>2.0</timeoutFactor>
     </heartbeat>
     <queue>


### PR DESCRIPTION
## Purpose

```
<heartbeat>
        <delay>0</delay>
        <timeoutFactor>2.0</timeoutFactor>
 </heartbeat>
```

This PR is setting the default value to 30. 

Fix:https://github.com/wso2/product-ei/issues/3434