### PR TITLE
Fix failure of JMSEndpointTestCase due to endpoint name being common

### DIFF
--- a/integration/mediation-tests/tests-transport/src/test/resources/artifacts/ESB/jms/transport/jms_transport.xml
+++ b/integration/mediation-tests/tests-transport/src/test/resources/artifacts/ESB/jms/transport/jms_transport.xml
@@ -6,7 +6,8 @@
                 <property name="OUT_ONLY" value="true"/>
                 <property name="FORCE_SC_ACCEPTED" value="true" scope="axis2"/>
                 <send>
-                    <endpoint key="jmsAddressEP"/>
+                    <address
+                            uri="jms:/SimpleStockQuoteServiceJMSEndpointTestCase?transport.jms.DestinationType=queue&amp;transport.jms.ContentTypeProperty=contentType&amp;java.naming.provider.url=tcp://localhost:61616?jms.redeliveryPolicy.maximumRedeliveries=10&amp;java.naming.factory.initial=org.apache.activemq.jndi.ActiveMQInitialContextFactory&amp;transport.jms.SessionTransacted=true&amp;transport.jms.ConnectionFactoryType=queue&amp;transport.jms.SessionAcknowledgement=CLIENT_ACKNOWLEDGE&amp;transport.jms.ConnectionFactoryJNDIName=QueueConnectionFactory"/>
                 </send>
             </inSequence>
 
@@ -18,7 +19,4 @@
             </rules>
         </parameter>
     </proxy>
-    <endpoint name="jmsAddressEP">
-        <address uri="jms:/SimpleStockQuoteServiceJMSEndpointTestCase?transport.jms.DestinationType=queue&amp;transport.jms.ContentTypeProperty=contentType&amp;java.naming.provider.url=tcp://localhost:61616?jms.redeliveryPolicy.maximumRedeliveries=10&amp;java.naming.factory.initial=org.apache.activemq.jndi.ActiveMQInitialContextFactory&amp;transport.jms.SessionTransacted=true&amp;transport.jms.ConnectionFactoryType=queue&amp;transport.jms.SessionAcknowledgement=CLIENT_ACKNOWLEDGE&amp;transport.jms.ConnectionFactoryJNDIName=QueueConnectionFactory"/>
-    </endpoint>
 </definitions>


### PR DESCRIPTION
## Purpose
org.wso2.carbon.esb.jms.transport.test.JMSEndpointTestCase.testJMSProxy failes intermittently and during the test run, the following stack trace could be seen
```
 org.apache.activemq.ConnectionFailedException: The JMS connection has failed: java.io.EOFException
INFO  [org.wso2.carbon.automation.extensions.servers.utils.ServerLogReader] - 	at org.apache.activemq.ActiveMQConnection.checkClosedOrFailed(ActiveMQConnection.java:1483)
INFO  [org.wso2.carbon.automation.extensions.servers.utils.ServerLogReader] - 	at org.apache.activemq.ActiveMQConnection.createSession(ActiveMQConnection.java:326)
INFO  [org.wso2.carbon.automation.extensions.servers.utils.ServerLogReader] - 	at org.apache.axis2.transport.jms.JMSUtils.createSession(JMSUtils.java:851)
INFO  [org.wso2.carbon.automation.extensions.servers.utils.ServerLogReader] - 	at org.apache.axis2.transport.jms.JMSConnectionFactory.createSession(JMSConnectionFactory.java:458)
INFO  [org.wso2.carbon.automation.extensions.servers.utils.ServerLogReader] - 	at org.apache.axis2.transport.jms.JMSConnectionFactory.getSession(JMSConnectionFactory.java:516)
INFO  [org.wso2.carbon.automation.extensions.servers.utils.ServerLogReader] - 	at org.apache.axis2.transport.jms.JMSMessageSender.<init>(JMSMessageSender.java:141)
INFO  [org.wso2.carbon.automation.extensions.servers.utils.ServerLogReader] - 	at org.apache.axis2.transport.jms.JMSSender.sendMessage(JMSSender.java:163)
INFO  [org.wso2.carbon.automation.extensions.servers.utils.ServerLogReader] - 	at org.apache.axis2.transport.base.AbstractTransportSender.invoke(AbstractTransportSender.java:112)
INFO  [org.wso2.carbon.automation.extensions.servers.utils.ServerLogReader] - 	at org.apache.axis2.engine.AxisEngine$TransportNonBlockingInvocationWorker.run(AxisEngine.java:626)
INFO  [org.wso2.carbon.automation.extensions.servers.utils.ServerLogReader] - 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
INFO  [org.wso2.carbon.automation.extensions.servers.utils.ServerLogReader] - 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
INFO  [org.wso2.carbon.automation.extensions.servers.utils.ServerLogReader] - 	at java.lang.Thread.run(Thread.java:748)
INFO  [org.wso2.carbon.automation.extensions.servers.utils.ServerLogReader] - Caused by: java.io.EOFException
INFO  [org.wso2.carbon.automation.extensions.servers.utils.ServerLogReader] - 	at java.io.DataInputStream.readInt(DataInputStream.java:392)
INFO  [org.wso2.carbon.automation.extensions.servers.utils.ServerLogReader] - 	at org.apache.activemq.openwire.OpenWireFormat.unmarshal(OpenWireFormat.java:275)
INFO  [org.wso2.carbon.automation.extensions.servers.utils.ServerLogReader] - 	at org.apache.activemq.transport.tcp.TcpTransport.readCommand(TcpTransport.java:221)
INFO  [org.wso2.carbon.automation.extensions.servers.utils.ServerLogReader] - 	at org.apache.activemq.transport.tcp.TcpTransport.doRun(TcpTransport.java:213)
INFO  [org.wso2.carbon.automation.extensions.servers.utils.ServerLogReader] - 	at org.apache.activemq.transport.tcp.TcpTransport.run(TcpTransport.java:196)
INFO  [org.wso2.carbon.automation.extensions.servers.utils.ServerLogReader] - 	... 1 more
INFO  [org.wso2.carbon.automation.extensions.servers.utils.ServerLogReader] - [2019-03-28 17:52:27,941] [EI-Core] ERROR - JMSConnectionFactory Error creating JMS session from JMS CF : jms:/ResponseQue?transport.jms.DestinationType=queue&transport.jms.ContentTypeProperty=contentType&java.naming.provider.url=tcp://localhost:61616?jms.redeliveryPolicy.maximumRedeliveries=10&java.naming.factory.initial=org.apache.activemq.jndi.ActiveMQInitialContextFactory&transport.jms.SessionTransacted=true&transport.jms.ConnectionFactoryType=queue&transport.jms.SessionAcknowledgement=CLIENT_ACKNOWLEDGE&transport.jms.ConnectionFactoryJNDIName=QueueConnectionFactory
```
And as a result of it, the addressEP gets suspended.
```
EndpointContext Endpoint : jmsAddressEP with address jms:/SimpleStockQuoteServiceJMSEndpointTestCase?transport.jms.DestinationType=queue&transport.jms.ContentTypeProperty=contentType&java.naming.provider.url=tcp://localhost:61616?jms.redeliveryPolicy.maximumRedeliveries=10&java.naming.factory.initial=org.apache.activemq.jndi.ActiveMQInitialContextFactory&transport.jms.SessionTransacted=true&transport.jms.ConnectionFactoryType=queue&transport.jms.SessionAcknowledgement=CLIENT_ACKNOWLEDGE&transport.jms.ConnectionFactoryJNDIName=QueueConnectionFactory will be marked SUSPENDED as it failed
```
Hence, as the resolution the endpoint configuration was moved inside as an inline endpoint definition