### PR TITLE
Add Call Mediator test cases to check HTTP response status

### DIFF
--- a/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/call/CallMediatorHttpStatusResponseTestCase.java
+++ b/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/call/CallMediatorHttpStatusResponseTestCase.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package org.wso2.carbon.esb.mediator.test.call;
+
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import org.wso2.esb.integration.common.utils.ESBIntegrationTest;
+
+import java.io.File;
+import java.net.URL;
+
+import static org.wso2.carbon.esb.mediator.test.call.Util.executeAndAssert;
+
+public class CallMediatorHttpStatusResponseTestCase extends ESBIntegrationTest {
+
+    @BeforeClass(alwaysRun = true)
+    public void deployService() throws Exception {
+        super.init();
+        String[] configs = {"HTTPStatusResponseAPI", "AcceptedEndpointProxy", "BadRequestEndpointProxy",
+                "ConflictEndpointProxy", "ForbiddenEndpointProxy", "NotFoundEndpointProxy",
+                "ServerErrorEndpointProxy", "UnauthorizedEndpointProxy"};
+        for (String configName : configs) {
+            loadESBConfigurationFromClasspath(File.separator + "artifacts" + File.separator + "ESB"
+                    + File.separator + "mediatorconfig" + File.separator + "call" + File.separator
+                    + configName + ".xml");
+            if(configName.equals("HTTPStatusResponseAPI")){
+               verifyAPIExistence(configName);
+            } else
+                verifyProxyServiceExistence(configName);
+        }
+    }
+
+    @Test(groups = {"wso2.esb"},
+            description = "Test invoking accepted http status endpoint with blocking call", enabled = true)
+    public void testAcceptedHttpStatusEndpoint() throws Exception {
+        URL endpoint = new URL(getProxyServiceURLHttp("AcceptedEndpointProxy"));
+        executeAndAssert(endpoint, 202, "Accepted");
+    }
+
+
+    @Test(groups = {"wso2.esb"},
+            description = "Test invoking bad request http status endpoint with blocking call", enabled = true)
+    public void testBadRequestHttpStatusEndpoint() throws Exception {
+        URL endpoint = new URL(getProxyServiceURLHttp("BadRequestEndpointProxy"));
+        executeAndAssert(endpoint, 400, "Bad_Request");
+    }
+
+    @Test(groups = {"wso2.esb"},
+            description = "Test invoking unauthorized http status endpoint with blocking call", enabled = true)
+    public void testUnauthorizedHttpStatusEndpoint() throws Exception {
+        URL endpoint = new URL(getProxyServiceURLHttp("UnauthorizedEndpointProxy"));
+        executeAndAssert(endpoint, 401, "Unauthorized");
+    }
+
+    @Test(groups = {"wso2.esb"},
+            description = "Test invoking forbidden http status endpoint with blocking call", enabled = true)
+    public void testForbiddenHttpStatusEndpoint() throws Exception {
+        URL endpoint = new URL(getProxyServiceURLHttp("ForbiddenEndpointProxy"));
+        executeAndAssert(endpoint, 403, "Forbidden");
+    }
+
+    @Test(groups = {"wso2.esb"},
+            description = "Test invoking not found http status endpoint with blocking call", enabled = true)
+    public void testNotFoundHttpStatusEndpoint() throws Exception {
+        URL endpoint = new URL(getProxyServiceURLHttp("NotFoundEndpointProxy"));
+        executeAndAssert(endpoint, 404, "Not_Found");
+    }
+
+    @Test(groups = {"wso2.esb"},
+            description = "Test invoking conflict http status endpoint with blocking call", enabled = true)
+    public void testConflictHttpStatusEndpoint() throws Exception {
+        URL endpoint = new URL(getProxyServiceURLHttp("ConflictEndpointProxy"));
+        executeAndAssert(endpoint, 409, "Conflict");
+    }
+
+
+    @Test(groups = {"wso2.esb"},
+            description = "Test invoking server error http status endpoint with blocking call", enabled = true)
+    public void testServerErrorHttpStatusEndpoint() throws Exception {
+        URL endpoint = new URL(getProxyServiceURLHttp("ServerErrorEndpointProxy"));
+        executeAndAssert(endpoint, 500, "Internal_Server_Error");
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void destroy() throws Exception {
+        super.cleanup();
+    }
+}

--- a/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/call/Util.java
+++ b/integration/mediation-tests/tests-mediator-1/src/test/java/org/wso2/carbon/esb/mediator/test/call/Util.java
@@ -1,0 +1,116 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package org.wso2.carbon.esb.mediator.test.call;
+
+import org.wso2.carbon.automation.engine.exceptions.AutomationFrameworkException;
+import org.wso2.carbon.automation.test.utils.http.client.HttpResponse;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.ProtocolException;
+import java.net.URL;
+import java.nio.charset.Charset;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+public class Util {
+
+    public static HttpResponse sendRequest(URL endpoint, Map<String, String> headers)
+            throws AutomationFrameworkException, IOException {
+
+        HttpURLConnection urlConnection = null;
+
+        try {
+            urlConnection = (HttpURLConnection) endpoint.openConnection();
+            try {
+                urlConnection.setRequestMethod("GET");
+            } catch (ProtocolException e) {
+                throw new AutomationFrameworkException("Shouldn't happen: HttpURLConnection doesn't support GET ?? " + e);
+            }
+            urlConnection.setDoOutput(true);
+            urlConnection.setDoInput(true);
+            urlConnection.setUseCaches(false);
+            urlConnection.setAllowUserInteraction(false);
+            urlConnection.setReadTimeout(10000);
+            for (Map.Entry<String, String> e : headers.entrySet()) {
+                urlConnection.setRequestProperty(e.getKey(), e.getValue());
+            }
+
+            StringBuilder sb = new StringBuilder();
+            BufferedReader rd = null;
+
+            try {
+                rd = new BufferedReader(new InputStreamReader(urlConnection.getInputStream(), Charset.defaultCharset()));
+
+                String line;
+                while ((line = rd.readLine()) != null) {
+                    sb.append(line);
+                }
+            } finally {
+                if (rd != null) {
+                    rd.close();
+                }
+            }
+            Iterator<String> itr = urlConnection.getHeaderFields().keySet().iterator();
+            Object responseHeaders = new HashMap();
+            String key;
+            while (itr.hasNext()) {
+                key = itr.next();
+                if (key != null) {
+                    ((Map)responseHeaders).put(key, urlConnection.getHeaderField(key));
+                }
+            }
+            return new HttpResponse(sb.toString(), urlConnection.getResponseCode());
+        } catch (IOException e) {
+            StringBuilder sb = new StringBuilder();
+            BufferedReader rd = null;
+            rd = new BufferedReader(new InputStreamReader(urlConnection.getErrorStream(), Charset.defaultCharset()));
+
+            String line;
+            while ((line = rd.readLine()) != null) {
+                sb.append(line);
+            }
+            rd.close();
+            return new HttpResponse(sb.toString(), urlConnection.getResponseCode());
+        } finally {
+            if (urlConnection != null) {
+                urlConnection.disconnect();
+            }
+        }
+    }
+
+    public static void executeAndAssert(URL endpoint, int statusCode, String statusMessage)
+            throws Exception{
+        Map<String, String> header = new HashMap<String, String>();
+        header.put("Content-Type", "text/plain");
+
+        HttpResponse httpResponse = sendRequest(endpoint, header);
+
+        assertEquals(httpResponse.getResponseCode(), statusCode, "Expected " +
+                statusCode + ", found " + httpResponse.getResponseCode() + " http status code");
+        assertTrue(httpResponse.getData().equalsIgnoreCase("Received:" + statusCode + "," + statusMessage),
+                "Required payload not found");
+    }
+}

--- a/integration/mediation-tests/tests-mediator-1/src/test/resources/artifacts/ESB/mediatorconfig/call/AcceptedEndpointProxy.xml
+++ b/integration/mediation-tests/tests-mediator-1/src/test/resources/artifacts/ESB/mediatorconfig/call/AcceptedEndpointProxy.xml
@@ -1,0 +1,25 @@
+<definitions xmlns="http://ws.apache.org/ns/synapse">
+<proxy xmlns="http://ws.apache.org/ns/synapse"
+       name="AcceptedEndpointProxy"
+       startOnLoad="true"
+       statistics="disable"
+       trace="disable"
+       transports="http,https">
+    <target>
+        <inSequence>
+            <call>
+                <endpoint>
+                    <http method="GET"
+                          uri-template="http://localhost:8480/responsesample/accepted"/>
+                </endpoint>
+            </call>
+            <loopback/>
+        </inSequence>
+        <outSequence>
+            <send/>
+        </outSequence>
+        <faultSequence/>
+    </target>
+    <description/>
+</proxy>
+</definitions>

--- a/integration/mediation-tests/tests-mediator-1/src/test/resources/artifacts/ESB/mediatorconfig/call/BadRequestEndpointProxy.xml
+++ b/integration/mediation-tests/tests-mediator-1/src/test/resources/artifacts/ESB/mediatorconfig/call/BadRequestEndpointProxy.xml
@@ -1,0 +1,25 @@
+<definitions xmlns="http://ws.apache.org/ns/synapse">
+<proxy xmlns="http://ws.apache.org/ns/synapse"
+       name="BadRequestEndpointProxy"
+       startOnLoad="true"
+       statistics="disable"
+       trace="disable"
+       transports="http,https">
+    <target>
+        <inSequence>
+            <call>
+                <endpoint>
+                    <http method="GET"
+                          uri-template="http://localhost:8480/responsesample/bad_request"/>
+                </endpoint>
+            </call>
+            <loopback/>
+        </inSequence>
+        <outSequence>
+            <send/>
+        </outSequence>
+        <faultSequence/>
+    </target>
+    <description/>
+</proxy>
+</definitions>

--- a/integration/mediation-tests/tests-mediator-1/src/test/resources/artifacts/ESB/mediatorconfig/call/ConflictEndpointProxy.xml
+++ b/integration/mediation-tests/tests-mediator-1/src/test/resources/artifacts/ESB/mediatorconfig/call/ConflictEndpointProxy.xml
@@ -1,0 +1,28 @@
+<definitions xmlns="http://ws.apache.org/ns/synapse">
+<proxy xmlns="http://ws.apache.org/ns/synapse"
+       name="ConflictEndpointProxy"
+       startOnLoad="true"
+       statistics="disable"
+       trace="disable"
+       transports="http,https">
+    <target>
+        <inSequence>
+            <call>
+                <endpoint>
+                    <http method="GET"
+                          uri-template="http://localhost:8480/responsesample/conflict"/>
+                </endpoint>
+            </call>
+            <loopback/>
+        </inSequence>
+        <outSequence>
+            <log level="custom">
+                <property name="outsequence" value="OutSequence"/>
+            </log>
+            <send/>
+        </outSequence>
+        <faultSequence/>
+    </target>
+    <description/>
+</proxy>
+</definitions>

--- a/integration/mediation-tests/tests-mediator-1/src/test/resources/artifacts/ESB/mediatorconfig/call/ForbiddenEndpointProxy.xml
+++ b/integration/mediation-tests/tests-mediator-1/src/test/resources/artifacts/ESB/mediatorconfig/call/ForbiddenEndpointProxy.xml
@@ -1,0 +1,25 @@
+<definitions xmlns="http://ws.apache.org/ns/synapse">
+<proxy xmlns="http://ws.apache.org/ns/synapse"
+       name="ForbiddenEndpointProxy"
+       startOnLoad="true"
+       statistics="disable"
+       trace="disable"
+       transports="http,https">
+    <target>
+        <inSequence>
+            <call>
+                <endpoint>
+                    <http method="GET"
+                          uri-template="http://localhost:8480/responsesample/forbidden"/>
+                </endpoint>
+            </call>
+            <loopback/>
+        </inSequence>
+        <outSequence>
+            <send/>
+        </outSequence>
+        <faultSequence/>
+    </target>
+    <description/>
+</proxy>
+</definitions>

--- a/integration/mediation-tests/tests-mediator-1/src/test/resources/artifacts/ESB/mediatorconfig/call/HTTPStatusResponseAPI.xml
+++ b/integration/mediation-tests/tests-mediator-1/src/test/resources/artifacts/ESB/mediatorconfig/call/HTTPStatusResponseAPI.xml
@@ -1,0 +1,74 @@
+<definitions xmlns="http://ws.apache.org/ns/synapse">
+    <api xmlns="http://ws.apache.org/ns/synapse" name="HTTPStatusResponseAPI" context="/responsesample">
+        <resource methods="GET" uri-template="/accepted">
+            <inSequence>
+                <property name="HTTP_SC" value="202" scope="axis2"/>
+                <payloadFactory media-type="text">
+                    <format>Received:202,Accepted</format>
+                    <args/>
+                </payloadFactory>
+                <respond/>
+            </inSequence>
+        </resource>
+        <resource methods="GET" uri-template="/bad_request">
+            <inSequence>
+                <property name="HTTP_SC" value="400" scope="axis2"/>
+                <payloadFactory media-type="text">
+                    <format>Received:400,Bad_Request</format>
+                    <args/>
+                </payloadFactory>
+                <respond/>
+            </inSequence>
+        </resource>
+        <resource methods="GET" uri-template="/unauthorized">
+            <inSequence>
+                <property name="HTTP_SC" value="401" scope="axis2"/>
+                <payloadFactory media-type="text">
+                    <format>Received:401,Unauthorized</format>
+                    <args/>
+                </payloadFactory>
+                <respond/>
+            </inSequence>
+        </resource>
+        <resource methods="GET" uri-template="/forbidden">
+            <inSequence>
+                <property name="HTTP_SC" value="403" scope="axis2"/>
+                <payloadFactory media-type="text">
+                    <format>Received:403,Forbidden</format>
+                    <args/>
+                </payloadFactory>
+                <respond/>
+            </inSequence>
+        </resource>
+        <resource methods="GET" uri-template="/not_found">
+            <inSequence>
+                <property name="HTTP_SC" value="404" scope="axis2"/>
+                <payloadFactory media-type="text">
+                    <format>Received:404,Not_Found</format>
+                    <args/>
+                </payloadFactory>
+                <respond/>
+            </inSequence>
+        </resource>
+        <resource methods="GET" uri-template="/conflict">
+            <inSequence>
+                <property name="HTTP_SC" value="409" scope="axis2"/>
+                <payloadFactory media-type="text">
+                    <format>Received:409,Conflict</format>
+                    <args/>
+                </payloadFactory>
+                <respond/>
+            </inSequence>
+        </resource>
+        <resource methods="GET" uri-template="/internal_server_error">
+            <inSequence>
+                <property name="HTTP_SC" value="500" scope="axis2"/>
+                <payloadFactory media-type="text">
+                    <format>Received:500,Internal_Server_Error</format>
+                    <args/>
+                </payloadFactory>
+                <respond/>
+            </inSequence>
+        </resource>
+    </api>
+</definitions>

--- a/integration/mediation-tests/tests-mediator-1/src/test/resources/artifacts/ESB/mediatorconfig/call/NotFoundEndpointProxy.xml
+++ b/integration/mediation-tests/tests-mediator-1/src/test/resources/artifacts/ESB/mediatorconfig/call/NotFoundEndpointProxy.xml
@@ -1,0 +1,25 @@
+<definitions xmlns="http://ws.apache.org/ns/synapse">
+<proxy xmlns="http://ws.apache.org/ns/synapse"
+       name="NotFoundEndpointProxy"
+       startOnLoad="true"
+       statistics="disable"
+       trace="disable"
+       transports="http,https">
+    <target>
+        <inSequence>
+            <call>
+                <endpoint>
+                    <http method="GET"
+                          uri-template="http://localhost:8480/responsesample/not_found"/>
+                </endpoint>
+            </call>
+            <loopback/>
+        </inSequence>
+        <outSequence>
+            <send/>
+        </outSequence>
+        <faultSequence/>
+    </target>
+    <description/>
+</proxy>
+</definitions>

--- a/integration/mediation-tests/tests-mediator-1/src/test/resources/artifacts/ESB/mediatorconfig/call/ServerErrorEndpointProxy.xml
+++ b/integration/mediation-tests/tests-mediator-1/src/test/resources/artifacts/ESB/mediatorconfig/call/ServerErrorEndpointProxy.xml
@@ -1,0 +1,25 @@
+<definitions xmlns="http://ws.apache.org/ns/synapse">
+<proxy xmlns="http://ws.apache.org/ns/synapse"
+       name="ServerErrorEndpointProxy"
+       startOnLoad="true"
+       statistics="disable"
+       trace="disable"
+       transports="http,https">
+    <target>
+        <inSequence>
+            <call>
+                <endpoint>
+                    <http method="GET"
+                          uri-template="http://localhost:8480/responsesample/internal_server_error"/>
+                </endpoint>
+            </call>
+            <loopback/>
+        </inSequence>
+        <outSequence>
+            <send/>
+        </outSequence>
+        <faultSequence/>
+    </target>
+    <description/>
+</proxy>
+</definitions>

--- a/integration/mediation-tests/tests-mediator-1/src/test/resources/artifacts/ESB/mediatorconfig/call/UnauthorizedEndpointProxy.xml
+++ b/integration/mediation-tests/tests-mediator-1/src/test/resources/artifacts/ESB/mediatorconfig/call/UnauthorizedEndpointProxy.xml
@@ -1,0 +1,25 @@
+<definitions xmlns="http://ws.apache.org/ns/synapse">
+<proxy xmlns="http://ws.apache.org/ns/synapse"
+       name="UnauthorizedEndpointProxy"
+       startOnLoad="true"
+       statistics="disable"
+       trace="disable"
+       transports="http,https">
+    <target>
+        <inSequence>
+            <call>
+                <endpoint>
+                    <http method="GET"
+                          uri-template="http://localhost:8480/responsesample/unauthorized"/>
+                </endpoint>
+            </call>
+            <loopback/>
+        </inSequence>
+        <outSequence>
+            <send/>
+        </outSequence>
+        <faultSequence/>
+    </target>
+    <description/>
+</proxy>
+</definitions>

--- a/integration/mediation-tests/tests-mediator-1/src/test/resources/testng.xml
+++ b/integration/mediation-tests/tests-mediator-1/src/test/resources/testng.xml
@@ -73,6 +73,7 @@
 
     <test name="Call-mediator-Test" preserve-order="true" verbose="2">
         <classes>
+            <class name="org.wso2.carbon.esb.mediator.test.call.CallMediatorHttpStatusResponseTestCase"/>
             <!--<class name="org.wso2.carbon.esb.mediator.test.call.CallMediatorAPIWithNamedSeqCase"/>-->
             <class name="org.wso2.carbon.esb.mediator.test.call.CallMediatorBlockingAPITestCase"/>
             <class name="org.wso2.carbon.esb.mediator.test.call.CallMediatorBlockingDirectEndpointTestCase"/>


### PR DESCRIPTION

## Purpose
> Adding test cases to check the behaviour of how call mediator handles HTTP responses (with status in 4xx and 5xx range) when an HTTP endpoint is called in both blocking and non-blocking mode respectively.

## Note
> PR should be merged after merging [wso2-axis2/pull/166](https://github.com/wso2/wso2-axis2/pull/166#issue-265619751) in axis2 (which fixes [product-ei/issues/951](https://github.com/wso2/product-ei/issues/951#issue-253922454)), and upgrading the axis2 version in product-ei after the axis2 build.

## Related PRs
> [wso2-axis2/pull/166](https://github.com/wso2/wso2-axis2/pull/166#issue-265619751)

## Related Issues
> [product-ei/issues/951](https://github.com/wso2/product-ei/issues/951#issue-253922454)