### PR TITLE
Define transport http in samples

### DIFF
--- a/samples/product/src/main/conf/synapse/synapse_sample_155.xml
+++ b/samples/product/src/main/conf/synapse/synapse_sample_155.xml
@@ -21,7 +21,7 @@
 <!-- A proxy service with a dual channel invocation to the actual server -->
 <definitions xmlns="http://ws.apache.org/ns/synapse">
 
-    <proxy name="StockQuoteProxy">
+    <proxy name="StockQuoteProxy" transports="http https">
         <target>
             <endpoint>
                 <address uri="http://localhost:9000/services/SimpleStockQuoteService">

--- a/samples/product/src/main/conf/synapse/synapse_sample_400.xml
+++ b/samples/product/src/main/conf/synapse/synapse_sample_400.xml
@@ -21,7 +21,7 @@
 <!-- Message splitting and aggregating the responses -->
 <definitions xmlns="http://ws.apache.org/ns/synapse">
 
-    <proxy name="SplitAggregateProxy">
+    <proxy name="SplitAggregateProxy" transports="http https">
         <target>
             <inSequence>
                 <iterate xmlns:m0="http://services.samples" expression="//m0:getQuote/m0:request" preservePayload="true"

--- a/samples/product/src/main/conf/synapse/synapse_sample_652.xml
+++ b/samples/product/src/main/conf/synapse/synapse_sample_652.xml
@@ -21,7 +21,7 @@
 <!-- Introduction to priority based mediation -->
 <definitions xmlns="http://ws.apache.org/ns/synapse">
 
-    <proxy name="StockQuoteProxy">
+    <proxy name="StockQuoteProxy" transports="http https">
         <target>
             <inSequence>
                 <filter source="$trp:priority" regex="1">

--- a/samples/product/src/main/conf/synapse/synapse_sample_655.xml
+++ b/samples/product/src/main/conf/synapse/synapse_sample_655.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <definitions xmlns="http://ws.apache.org/ns/synapse">
-    <proxy name="StockQuoteProxy" startOnLoad="true">
+    <proxy name="StockQuoteProxy" transports="http https" startOnLoad="true">
         <target>
             <inSequence>
                 <log level="full"/>

--- a/samples/product/src/main/conf/synapse/synapse_sample_656.xml
+++ b/samples/product/src/main/conf/synapse/synapse_sample_656.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <definitions xmlns="http://ws.apache.org/ns/synapse">
-  <proxy name="StockQuoteProxy" startOnLoad="true">
+  <proxy name="StockQuoteProxy" transports="http https" startOnLoad="true">
     <target>
       <inSequence>
         <builder>


### PR DESCRIPTION
## Purpose
Explicitely defines the http transport for sample proxy services that were missing it.
Resolves: https://github.com/wso2/product-ei/issues/3631