### PR TITLE
Remove unnecessary config in wrapper.conf

### DIFF
--- a/distribution/src/conf/wrapper.conf
+++ b/distribution/src/conf/wrapper.conf
@@ -77,7 +77,6 @@ wrapper.java.classpath.1 = ${java_home}\\lib\\tools.jar
 wrapper.java.classpath.2 = ${carbon_home}\\bin\\*.jar
 wrapper.app.parameter.1 = org.wso2.carbon.bootstrap.Bootstrap
 wrapper.app.parameter.2 = RUN
-wrapper.java.additional.1 = -Xbootclasspath\/a:${carbon_home}\\wso2\\lib\\xboot\\*.jar
 wrapper.java.additional.2 = -Xms256m
 wrapper.java.additional.3 = -Xmx1024m
 wrapper.java.additional.4 = -XX:MaxPermSize=256m


### PR DESCRIPTION
Following config caused an issue in latest versions of yajsw due to the unnecessary escape character in -Xbootclasspath\\/a.

> wrapper.java.additional.1 = -Xbootclasspath\\/a:${carbon_home}\\wso2\\lib\\xboot\\*.jar

Removing the config since xboot dir does not exist in the pack.

Fixes wso2/product-ei#426
