### PR TITLE
Fix clustering tests of Broker Profile

### DIFF
--- a/integration/broker-tests/tests-common/platform-tests-utils/src/main/java/org/wso2/mb/platform/common/utils/MBPlatformBaseTest.java
+++ b/integration/broker-tests/tests-common/platform-tests-utils/src/main/java/org/wso2/mb/platform/common/utils/MBPlatformBaseTest.java
@@ -18,7 +18,6 @@
 
 package org.wso2.mb.platform.common.utils;
 
-import com.google.common.net.HostAndPort;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.wso2.carbon.andes.stub.AndesAdminServiceBrokerManagerAdminException;
@@ -35,6 +34,7 @@ import org.xml.sax.SAXException;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.xpath.XPathExpressionException;
 import java.io.IOException;
+import java.net.InetSocketAddress;
 import java.net.URISyntaxException;
 import java.rmi.RemoteException;
 import java.util.ArrayList;
@@ -212,7 +212,7 @@ public class MBPlatformBaseTest {
             for (Map.Entry<String, AutomationContext> entry : contextMap.entrySet()) {
                 AutomationContext tempContext = entry.getValue();
                 andesAdminClients.put(entry.getKey(), new AndesAdminClient(tempContext.getContextUrls().getBackEndUrl(),
-                        login(tempContext)));
+                                                                           login(tempContext)));
             }
         }
     }
@@ -240,7 +240,7 @@ public class MBPlatformBaseTest {
             for (Map.Entry<String, AutomationContext> entry : contextMap.entrySet()) {
                 AutomationContext tempContext = entry.getValue();
                 topicAdminClients.put(entry.getKey(), new TopicAdminClient(tempContext.getContextUrls().getBackEndUrl(),
-                            login(tempContext)));
+                                                                           login(tempContext)));
             }
         }
     }
@@ -307,30 +307,14 @@ public class MBPlatformBaseTest {
      * Give a random AMQP broker URL.
      *
      * @return Broker URL in host:port format (E.g "127.0.0.1:5672")
-     * @throws XPathExpressionException
+     * @throws XPathExpressionException if an error occurs while retrieving values from the configuration
      */
-    protected HostAndPort getRandomAMQPBrokerAddress() throws XPathExpressionException {
+    protected InetSocketAddress getRandomAMQPBrokerAddress() throws XPathExpressionException {
         String randomInstanceKey = getRandomMBInstance();
         AutomationContext tempContext = getAutomationContextWithKey(randomInstanceKey);
 
-        return HostAndPort.fromString(tempContext.getInstance().getHosts().get
-                ("default") + ":" + tempContext.getInstance().getPorts().get("amqp"));
+        String host = tempContext.getInstance().getHosts().get("default");
+        int port = Integer.parseInt(tempContext.getInstance().getPorts().get("amqp"));
+        return new InetSocketAddress(host, port);
     }
-
-    /**
-     * Give a random AMQP broker URL.
-     *
-     * @return Broker URL in host:port format (E.g "127.0.0.1:5672")
-     * @throws XPathExpressionException
-     */
-    protected HostAndPort getRandomMQTTBrokerAddress() throws XPathExpressionException {
-        String randomInstanceKey = getRandomMBInstance();
-        AutomationContext tempContext = getAutomationContextWithKey(randomInstanceKey);
-
-        return HostAndPort.fromString(tempContext.getInstance().getHosts().get
-                ("default") + ":" + tempContext.getInstance().getPorts().get("mqtt"));
-    }
-
-    
-
 }

--- a/integration/broker-tests/tests-platform/pom.xml
+++ b/integration/broker-tests/tests-platform/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.wso2.ei</groupId>
         <artifactId>mb-integration-tests</artifactId>
-        <version>6.5.0-SNAPSHOT</version>
+        <version>6.5.0-m7-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration/broker-tests/tests-platform/tests-clustering/pom.xml
+++ b/integration/broker-tests/tests-platform/tests-clustering/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>org.wso2.ei</groupId>
         <artifactId>org.wso2.ei.mb.platform.tests</artifactId>
-        <version>6.5.0-SNAPSHOT</version>
+        <version>6.5.0-m7-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/integration/broker-tests/tests-platform/tests-clustering/src/test/java/org/wso2/mb/platform/tests/clustering/DifferentAckModeQueueTestCase.java
+++ b/integration/broker-tests/tests-platform/tests-clustering/src/test/java/org/wso2/mb/platform/tests/clustering/DifferentAckModeQueueTestCase.java
@@ -18,7 +18,6 @@
 
 package org.wso2.mb.platform.tests.clustering;
 
-import com.google.common.net.HostAndPort;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -48,6 +47,7 @@ import javax.naming.NamingException;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.xpath.XPathExpressionException;
 import java.io.IOException;
+import java.net.InetSocketAddress;
 import java.net.URISyntaxException;
 import java.rmi.RemoteException;
 
@@ -100,11 +100,11 @@ public class DifferentAckModeQueueTestCase extends MBPlatformBaseTest {
         long printDivider = 10L;
         String queueName = "sessionTransactedAckQueue";
 
-        HostAndPort brokerAddress = getRandomAMQPBrokerAddress();
+        InetSocketAddress brokerAddress = getRandomAMQPBrokerAddress();
 
         // Creating a consumer client configuration
         AndesJMSConsumerClientConfiguration consumerConfig =
-                new AndesJMSConsumerClientConfiguration(brokerAddress.getHostText(),
+                new AndesJMSConsumerClientConfiguration(brokerAddress.getHostName(),
                             brokerAddress.getPort(), ExchangeType.QUEUE, queueName);
         consumerConfig.setMaximumMessagesToReceived(expectedCount * 2);
         consumerConfig.setAcknowledgeMode(JMSAcknowledgeMode.SESSION_TRANSACTED);
@@ -113,7 +113,7 @@ public class DifferentAckModeQueueTestCase extends MBPlatformBaseTest {
 
         // Creating a publisher client configuration
         AndesJMSPublisherClientConfiguration publisherConfig =
-                new AndesJMSPublisherClientConfiguration(brokerAddress.getHostText(),
+                new AndesJMSPublisherClientConfiguration(brokerAddress.getHostName(),
                          brokerAddress.getPort(), ExchangeType.QUEUE, queueName);
         publisherConfig.setNumberOfMessagesToSend(sendCount);
         publisherConfig.setPrintsPerMessageCount(sendCount / printDivider);
@@ -163,17 +163,17 @@ public class DifferentAckModeQueueTestCase extends MBPlatformBaseTest {
         long printDivider = 10L;
         String queueName = "autoAcknowledgeQueue";
 
-        HostAndPort brokerAddress = getRandomAMQPBrokerAddress();
+        InetSocketAddress brokerAddress = getRandomAMQPBrokerAddress();
 
         // Creating a consumer client configuration
         AndesJMSConsumerClientConfiguration consumerConfig =
-                new AndesJMSConsumerClientConfiguration(brokerAddress.getHostText(),
+                new AndesJMSConsumerClientConfiguration(brokerAddress.getHostName(),
                                 brokerAddress.getPort(), ExchangeType.QUEUE, queueName);
         consumerConfig.setMaximumMessagesToReceived(expectedCount * 2);
 
         // Creating a publisher client configuration
         AndesJMSPublisherClientConfiguration publisherConfig =
-                new AndesJMSPublisherClientConfiguration(brokerAddress.getHostText(),
+                new AndesJMSPublisherClientConfiguration(brokerAddress.getHostName(),
                                  brokerAddress.getPort(), ExchangeType.QUEUE, queueName);
         publisherConfig.setNumberOfMessagesToSend(sendCount);
         publisherConfig.setPrintsPerMessageCount(sendCount / printDivider);
@@ -223,11 +223,11 @@ public class DifferentAckModeQueueTestCase extends MBPlatformBaseTest {
         long printDivider = 10L;
         String queueName = "clientAcknowledgeQueue";
 
-        HostAndPort brokerAddress = getRandomAMQPBrokerAddress();
+        InetSocketAddress brokerAddress = getRandomAMQPBrokerAddress();
 
         // Creating a consumer client configuration
         AndesJMSConsumerClientConfiguration consumerConfig =
-                new AndesJMSConsumerClientConfiguration(brokerAddress.getHostText(),
+                new AndesJMSConsumerClientConfiguration(brokerAddress.getHostName(),
                             brokerAddress.getPort(), ExchangeType.QUEUE, queueName);
         consumerConfig.setMaximumMessagesToReceived(expectedCount * 2);
         consumerConfig.setAcknowledgeMode(JMSAcknowledgeMode.CLIENT_ACKNOWLEDGE);
@@ -237,7 +237,7 @@ public class DifferentAckModeQueueTestCase extends MBPlatformBaseTest {
 
         // Creating a publisher client configuration
         AndesJMSPublisherClientConfiguration publisherConfig =
-                new AndesJMSPublisherClientConfiguration(brokerAddress.getHostText(),
+                new AndesJMSPublisherClientConfiguration(brokerAddress.getHostName(),
                             brokerAddress.getPort(), ExchangeType.QUEUE, queueName);
         publisherConfig.setNumberOfMessagesToSend(sendCount);
         publisherConfig.setPrintsPerMessageCount(sendCount / printDivider);
@@ -287,11 +287,11 @@ public class DifferentAckModeQueueTestCase extends MBPlatformBaseTest {
         long printDivider = 10L;
         String queueName = "dupsOkAcknowledgeQueue";
 
-        HostAndPort brokerAddress = getRandomAMQPBrokerAddress();
+        InetSocketAddress brokerAddress = getRandomAMQPBrokerAddress();
 
         // Creating a consumer client configuration
         AndesJMSConsumerClientConfiguration consumerConfig =
-                new AndesJMSConsumerClientConfiguration(brokerAddress.getHostText(),
+                new AndesJMSConsumerClientConfiguration(brokerAddress.getHostName(),
                             brokerAddress.getPort(), ExchangeType.QUEUE, queueName);
         consumerConfig.setMaximumMessagesToReceived(expectedCount * 2);
         consumerConfig.setAcknowledgeMode(JMSAcknowledgeMode.DUPS_OK_ACKNOWLEDGE);
@@ -300,7 +300,7 @@ public class DifferentAckModeQueueTestCase extends MBPlatformBaseTest {
 
         // Creating a publisher client configuration
         AndesJMSPublisherClientConfiguration publisherConfig =
-                new AndesJMSPublisherClientConfiguration(brokerAddress.getHostText(),
+                new AndesJMSPublisherClientConfiguration(brokerAddress.getHostName(),
                              brokerAddress.getPort(), ExchangeType.QUEUE, queueName);
         publisherConfig.setNumberOfMessagesToSend(sendCount);
         publisherConfig.setPrintsPerMessageCount(sendCount / printDivider);

--- a/integration/broker-tests/tests-platform/tests-clustering/src/test/java/org/wso2/mb/platform/tests/clustering/DifferentMessageTypesQueueTestCase.java
+++ b/integration/broker-tests/tests-platform/tests-clustering/src/test/java/org/wso2/mb/platform/tests/clustering/DifferentMessageTypesQueueTestCase.java
@@ -18,7 +18,7 @@
 
 package org.wso2.mb.platform.tests.clustering;
 
-import com.google.common.net.HostAndPort;
+import java.net.InetSocketAddress;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -312,18 +312,18 @@ public class DifferentMessageTypesQueueTestCase extends MBPlatformBaseTest {
         long sendCount = messageCount;
         long printDivider = 10L;
 
-        HostAndPort brokerAddress = getRandomAMQPBrokerAddress();
+        InetSocketAddress brokerAddress = getRandomAMQPBrokerAddress();
 
         // Creating a consumer client configuration
         AndesJMSConsumerClientConfiguration consumerConfig =
-                new AndesJMSConsumerClientConfiguration(brokerAddress.getHostText(),
+                new AndesJMSConsumerClientConfiguration(brokerAddress.getHostName(),
                                     brokerAddress.getPort(), ExchangeType.QUEUE, destinationName);
         consumerConfig.setMaximumMessagesToReceived(sendCount * numberOfPublishers);
         consumerConfig.setPrintsPerMessageCount(sendCount / printDivider);
 
         // Creating publisher client configuration
         AndesJMSPublisherClientConfiguration publisherConfig =
-                new AndesJMSPublisherClientConfiguration(brokerAddress.getHostText(),
+                new AndesJMSPublisherClientConfiguration(brokerAddress.getHostName(),
                                      brokerAddress.getPort(), ExchangeType.QUEUE, destinationName);
         publisherConfig.setNumberOfMessagesToSend(sendCount);
         publisherConfig.setPrintsPerMessageCount(sendCount / printDivider);

--- a/integration/broker-tests/tests-platform/tests-clustering/src/test/java/org/wso2/mb/platform/tests/clustering/DifferentRateSubscriberTestCase.java
+++ b/integration/broker-tests/tests-platform/tests-clustering/src/test/java/org/wso2/mb/platform/tests/clustering/DifferentRateSubscriberTestCase.java
@@ -18,7 +18,7 @@
 
 package org.wso2.mb.platform.tests.clustering;
 
-import com.google.common.net.HostAndPort;
+import java.net.InetSocketAddress;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -90,7 +90,7 @@ public class DifferentRateSubscriberTestCase extends MBPlatformBaseTest {
     public void testSameNodeSlowSubscriber(long messageCount)
             throws IOException, JMSException, AndesClientConfigurationException, NamingException,
                    XPathExpressionException, AndesClientException, DataAccessUtilException, InterruptedException {
-        HostAndPort brokerAddress = getRandomAMQPBrokerAddress();
+        InetSocketAddress brokerAddress = getRandomAMQPBrokerAddress();
         this.runDifferentRateSubscriberTestCase("singleQueue1", 10L, 0L, messageCount, true, brokerAddress, brokerAddress);
     }
 
@@ -109,7 +109,7 @@ public class DifferentRateSubscriberTestCase extends MBPlatformBaseTest {
     public void testSameNodeSlowPublisher(long messageCount)
             throws XPathExpressionException, IOException, JMSException, AndesClientConfigurationException,
                    NamingException, AndesClientException, DataAccessUtilException, InterruptedException {
-        HostAndPort brokerAddress = getRandomAMQPBrokerAddress();
+        InetSocketAddress brokerAddress = getRandomAMQPBrokerAddress();
         this.runDifferentRateSubscriberTestCase("singleQueue2", 0L, 10L, messageCount, true, brokerAddress, brokerAddress);
     }
 
@@ -201,8 +201,8 @@ public class DifferentRateSubscriberTestCase extends MBPlatformBaseTest {
     private void runDifferentRateSubscriberTestCase(String destinationName, long consumerDelay,
             long publisherDelay,
             long messageCount,
-            boolean isSameNode, HostAndPort consumerBrokerAddress,
-            HostAndPort publisherBrokerAddress)
+            boolean isSameNode, InetSocketAddress consumerBrokerAddress,
+            InetSocketAddress publisherBrokerAddress)
             throws AndesClientConfigurationException, NamingException, JMSException, IOException, AndesClientException,
                    DataAccessUtilException, InterruptedException {
         // Number of messages expected
@@ -213,7 +213,7 @@ public class DifferentRateSubscriberTestCase extends MBPlatformBaseTest {
 
         // Creating a consumer client configuration
         AndesJMSConsumerClientConfiguration consumerConfig =
-                new AndesJMSConsumerClientConfiguration(consumerBrokerAddress.getHostText(),
+                new AndesJMSConsumerClientConfiguration(consumerBrokerAddress.getHostName(),
                                 consumerBrokerAddress.getPort(), ExchangeType.QUEUE, destinationName);
         consumerConfig.setMaximumMessagesToReceived(expectedCount * 2);
         consumerConfig.setPrintsPerMessageCount(expectedCount / printDivider);
@@ -221,7 +221,7 @@ public class DifferentRateSubscriberTestCase extends MBPlatformBaseTest {
 
         // Creating a publisher client configuration
         AndesJMSPublisherClientConfiguration publisherConfig =
-                new AndesJMSPublisherClientConfiguration(publisherBrokerAddress.getHostText(),
+                new AndesJMSPublisherClientConfiguration(publisherBrokerAddress.getHostName(),
                              publisherBrokerAddress.getPort(), ExchangeType.QUEUE, destinationName);
         publisherConfig.setNumberOfMessagesToSend(sendCount);
         publisherConfig.setPrintsPerMessageCount(sendCount / printDivider);

--- a/integration/broker-tests/tests-platform/tests-clustering/src/test/java/org/wso2/mb/platform/tests/clustering/MessageExpirationTestCase.java
+++ b/integration/broker-tests/tests-platform/tests-clustering/src/test/java/org/wso2/mb/platform/tests/clustering/MessageExpirationTestCase.java
@@ -18,7 +18,7 @@
 
 package org.wso2.mb.platform.tests.clustering;
 
-import com.google.common.net.HostAndPort;
+import java.net.InetSocketAddress;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -128,8 +128,8 @@ public class MessageExpirationTestCase extends MBPlatformBaseTest{
 
         //Creating a consumer
         AndesJMSConsumerClientConfiguration consumerConfig2 = consumerConfig.clone();
-        HostAndPort randomAMQPBrokerAddress = getRandomAMQPBrokerAddress();
-        consumerConfig2.setHostName(randomAMQPBrokerAddress.getHostText());
+        InetSocketAddress randomAMQPBrokerAddress = getRandomAMQPBrokerAddress();
+        consumerConfig2.setHostName(randomAMQPBrokerAddress.getHostName());
         consumerConfig2.setPort(randomAMQPBrokerAddress.getPort());
         AndesClient consumerClient2 = new AndesClient(consumerConfig2, true);
         consumerClient2.startClient();

--- a/integration/broker-tests/tests-platform/tests-clustering/src/test/java/org/wso2/mb/platform/tests/clustering/MixedQueueTopicTestCase.java
+++ b/integration/broker-tests/tests-platform/tests-clustering/src/test/java/org/wso2/mb/platform/tests/clustering/MixedQueueTopicTestCase.java
@@ -18,7 +18,7 @@
 
 package org.wso2.mb.platform.tests.clustering;
 
-import com.google.common.net.HostAndPort;
+import java.net.InetSocketAddress;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -61,8 +61,8 @@ public class MixedQueueTopicTestCase extends MBPlatformBaseTest {
     String topicName1 = "mixedTopic1";
     String topicName2 = "mixedTopic2";
 
-    HostAndPort broker1;
-    HostAndPort broker2;
+    InetSocketAddress broker1;
+    InetSocketAddress broker2;
 
     Map<String, Set<AndesClient>> publishers = new HashMap<>();
     Map<String, Set<AndesClient>> subscribers = new HashMap<>();
@@ -161,12 +161,12 @@ public class MixedQueueTopicTestCase extends MBPlatformBaseTest {
     private void createQueue1Subscribers() throws AndesClientException, JMSException, IOException, NamingException,
             AndesClientConfigurationException {
         AndesJMSConsumerClientConfiguration queue1ConsumerBroker1Config =
-                new AndesJMSConsumerClientConfiguration(broker1.getHostText(),
+                new AndesJMSConsumerClientConfiguration(broker1.getHostName(),
                         broker1.getPort(), ExchangeType.QUEUE, queueName1);
         queue1ConsumerBroker1Config.setPrintsPerMessageCount(printPerMessageCount);
 
         AndesJMSConsumerClientConfiguration queue1ConsumerBroker2Config =
-                new AndesJMSConsumerClientConfiguration(broker2.getHostText(),
+                new AndesJMSConsumerClientConfiguration(broker2.getHostName(),
                         broker2.getPort(), ExchangeType.QUEUE, queueName1);
         queue1ConsumerBroker2Config.setPrintsPerMessageCount(printPerMessageCount);
 
@@ -193,12 +193,12 @@ public class MixedQueueTopicTestCase extends MBPlatformBaseTest {
     private void createQueue2Subscribers() throws AndesClientException, JMSException, IOException, NamingException,
             AndesClientConfigurationException {
         AndesJMSConsumerClientConfiguration queue2ConsumerBroker1Config =
-                new AndesJMSConsumerClientConfiguration(broker1.getHostText(),
+                new AndesJMSConsumerClientConfiguration(broker1.getHostName(),
                         broker1.getPort(), ExchangeType.QUEUE, queueName2);
         queue2ConsumerBroker1Config.setPrintsPerMessageCount(printPerMessageCount);
 
         AndesJMSConsumerClientConfiguration queue2ConsumerBroker2Config =
-                new AndesJMSConsumerClientConfiguration(broker2.getHostText(),
+                new AndesJMSConsumerClientConfiguration(broker2.getHostName(),
                         broker2.getPort(), ExchangeType.QUEUE, queueName2);
         queue2ConsumerBroker2Config.setPrintsPerMessageCount(printPerMessageCount);
 
@@ -224,12 +224,12 @@ public class MixedQueueTopicTestCase extends MBPlatformBaseTest {
     private void createTopic1Subscribers() throws AndesClientException, JMSException, IOException, NamingException,
             AndesClientConfigurationException {
         AndesJMSConsumerClientConfiguration topic1ConsumerBroker1Config =
-                new AndesJMSConsumerClientConfiguration(broker1.getHostText(),
+                new AndesJMSConsumerClientConfiguration(broker1.getHostName(),
                         broker1.getPort(), ExchangeType.TOPIC, topicName1);
         topic1ConsumerBroker1Config.setPrintsPerMessageCount(printPerMessageCount);
 
         AndesJMSConsumerClientConfiguration topic1ConsumerBroker2Config =
-                new AndesJMSConsumerClientConfiguration(broker2.getHostText(),
+                new AndesJMSConsumerClientConfiguration(broker2.getHostName(),
                         broker2.getPort(), ExchangeType.TOPIC, topicName1);
         topic1ConsumerBroker2Config.setPrintsPerMessageCount(printPerMessageCount);
 
@@ -257,12 +257,12 @@ public class MixedQueueTopicTestCase extends MBPlatformBaseTest {
     private void createTopic2Subscribers() throws IOException, JMSException, AndesClientException, NamingException,
             AndesClientConfigurationException {
         AndesJMSConsumerClientConfiguration topic2ConsumerBroker1Config =
-                new AndesJMSConsumerClientConfiguration(broker1.getHostText(),
+                new AndesJMSConsumerClientConfiguration(broker1.getHostName(),
                         broker1.getPort(), ExchangeType.TOPIC, topicName2);
         topic2ConsumerBroker1Config.setPrintsPerMessageCount(printPerMessageCount);
 
         AndesJMSConsumerClientConfiguration topic2ConsumerBroker2Config =
-                new AndesJMSConsumerClientConfiguration(broker2.getHostText(),
+                new AndesJMSConsumerClientConfiguration(broker2.getHostName(),
                         broker2.getPort(), ExchangeType.TOPIC, topicName2);
         topic2ConsumerBroker2Config.setPrintsPerMessageCount(printPerMessageCount);
 
@@ -292,31 +292,31 @@ public class MixedQueueTopicTestCase extends MBPlatformBaseTest {
     private void createTopic1DurableSubscribers() throws AndesClientConfigurationException, IOException,
             JMSException, AndesClientException, NamingException {
         AndesJMSConsumerClientConfiguration durable1Consumer1Broker1Config =
-                new AndesJMSConsumerClientConfiguration(broker1.getHostText(),
+                new AndesJMSConsumerClientConfiguration(broker1.getHostName(),
                         broker1.getPort(), ExchangeType.TOPIC, topicName1);
         durable1Consumer1Broker1Config.setDurable(true, "ultimateDurable1Sub1Broker1");
         durable1Consumer1Broker1Config.setPrintsPerMessageCount(printPerMessageCount);
 
         AndesJMSConsumerClientConfiguration durable1Consumer2Broker1Config =
-                new AndesJMSConsumerClientConfiguration(broker1.getHostText(),
+                new AndesJMSConsumerClientConfiguration(broker1.getHostName(),
                         broker1.getPort(), ExchangeType.TOPIC, topicName1);
         durable1Consumer2Broker1Config.setDurable(true, "ultimateDurable1Sub2Broker1");
         durable1Consumer2Broker1Config.setPrintsPerMessageCount(printPerMessageCount);
 
         AndesJMSConsumerClientConfiguration durable1Consumer3Broker1Config =
-                new AndesJMSConsumerClientConfiguration(broker1.getHostText(),
+                new AndesJMSConsumerClientConfiguration(broker1.getHostName(),
                         broker1.getPort(), ExchangeType.TOPIC, topicName1);
         durable1Consumer3Broker1Config.setDurable(true, "ultimateDurable1Sub3Broker1");
         durable1Consumer3Broker1Config.setPrintsPerMessageCount(printPerMessageCount);
 
         AndesJMSConsumerClientConfiguration durable1Consumer1Broker2Config =
-                new AndesJMSConsumerClientConfiguration(broker2.getHostText(),
+                new AndesJMSConsumerClientConfiguration(broker2.getHostName(),
                         broker2.getPort(), ExchangeType.TOPIC, topicName1);
         durable1Consumer1Broker2Config.setDurable(true, "ultimateDurable1Sub1Broker2");
         durable1Consumer1Broker2Config.setPrintsPerMessageCount(printPerMessageCount);
 
         AndesJMSConsumerClientConfiguration durable1Consumer2Broker2Config =
-                new AndesJMSConsumerClientConfiguration(broker2.getHostText(),
+                new AndesJMSConsumerClientConfiguration(broker2.getHostName(),
                         broker2.getPort(), ExchangeType.TOPIC, topicName1);
         durable1Consumer2Broker2Config.setDurable(true, "ultimateDurable1Sub2Broker2");
         durable1Consumer2Broker2Config.setPrintsPerMessageCount(printPerMessageCount);
@@ -353,31 +353,31 @@ public class MixedQueueTopicTestCase extends MBPlatformBaseTest {
     private void createTopic2DurableSubscribers() throws AndesClientConfigurationException, AndesClientException,
             JMSException, IOException, NamingException {
         AndesJMSConsumerClientConfiguration durable2Consumer1Broker1Config =
-                new AndesJMSConsumerClientConfiguration(broker1.getHostText(),
+                new AndesJMSConsumerClientConfiguration(broker1.getHostName(),
                         broker1.getPort(), ExchangeType.TOPIC, topicName2);
         durable2Consumer1Broker1Config.setDurable(true, "ultimateDurable2Sub1Broker1");
         durable2Consumer1Broker1Config.setPrintsPerMessageCount(printPerMessageCount);
 
         AndesJMSConsumerClientConfiguration durable2Consumer2Broker1Config =
-                new AndesJMSConsumerClientConfiguration(broker1.getHostText(),
+                new AndesJMSConsumerClientConfiguration(broker1.getHostName(),
                         broker1.getPort(), ExchangeType.TOPIC, topicName2);
         durable2Consumer2Broker1Config.setDurable(true, "ultimateDurable2Sub2Broker1");
         durable2Consumer2Broker1Config.setPrintsPerMessageCount(printPerMessageCount);
 
         AndesJMSConsumerClientConfiguration durable2Consumer1Broker2Config =
-                new AndesJMSConsumerClientConfiguration(broker2.getHostText(),
+                new AndesJMSConsumerClientConfiguration(broker2.getHostName(),
                         broker2.getPort(), ExchangeType.TOPIC, topicName2);
         durable2Consumer1Broker2Config.setDurable(true, "ultimateDurable1Sub3Broker2");
         durable2Consumer1Broker2Config.setPrintsPerMessageCount(printPerMessageCount);
 
         AndesJMSConsumerClientConfiguration durable2Consumer2Broker2Config =
-                new AndesJMSConsumerClientConfiguration(broker2.getHostText(),
+                new AndesJMSConsumerClientConfiguration(broker2.getHostName(),
                         broker2.getPort(), ExchangeType.TOPIC, topicName2);
         durable2Consumer2Broker2Config.setDurable(true, "ultimateDurable2Sub1Broker2");
         durable2Consumer2Broker2Config.setPrintsPerMessageCount(printPerMessageCount);
 
         AndesJMSConsumerClientConfiguration durable2Consumer3Broker2Config =
-                new AndesJMSConsumerClientConfiguration(broker2.getHostText(),
+                new AndesJMSConsumerClientConfiguration(broker2.getHostName(),
                         broker2.getPort(), ExchangeType.TOPIC, topicName2);
         durable2Consumer3Broker2Config.setDurable(true, "ultimateDurable2Sub2Broker2");
         durable2Consumer3Broker2Config.setPrintsPerMessageCount(printPerMessageCount);
@@ -418,13 +418,13 @@ public class MixedQueueTopicTestCase extends MBPlatformBaseTest {
         long queueSendCountPerPublisher = 50000;
 
         AndesJMSPublisherClientConfiguration queue1PublisherBroker1Config =
-                new AndesJMSPublisherClientConfiguration(broker1.getHostText(),
+                new AndesJMSPublisherClientConfiguration(broker1.getHostName(),
                         broker1.getPort(), ExchangeType.QUEUE, queueName1);
         queue1PublisherBroker1Config.setNumberOfMessagesToSend(queueSendCountPerPublisher);
         queue1PublisherBroker1Config.setPrintsPerMessageCount(printPerMessageCount);
 
         AndesJMSPublisherClientConfiguration queue1PublisherBroker2Config =
-                new AndesJMSPublisherClientConfiguration(broker2.getHostText(),
+                new AndesJMSPublisherClientConfiguration(broker2.getHostName(),
                         broker2.getPort(), ExchangeType.QUEUE, queueName1);
         queue1PublisherBroker2Config.setNumberOfMessagesToSend(queueSendCountPerPublisher);
         queue1PublisherBroker2Config.setPrintsPerMessageCount(printPerMessageCount);
@@ -456,13 +456,13 @@ public class MixedQueueTopicTestCase extends MBPlatformBaseTest {
         long queueSendCountPerPublisher = 50000;
 
         AndesJMSPublisherClientConfiguration queue2PublisherBroker1Config =
-                new AndesJMSPublisherClientConfiguration(broker1.getHostText(),
+                new AndesJMSPublisherClientConfiguration(broker1.getHostName(),
                         broker1.getPort(), ExchangeType.QUEUE, queueName2);
         queue2PublisherBroker1Config.setNumberOfMessagesToSend(queueSendCountPerPublisher);
         queue2PublisherBroker1Config.setPrintsPerMessageCount(printPerMessageCount);
 
         AndesJMSPublisherClientConfiguration queue2PublisherBroker2Config =
-                new AndesJMSPublisherClientConfiguration(broker2.getHostText(),
+                new AndesJMSPublisherClientConfiguration(broker2.getHostName(),
                         broker2.getPort(), ExchangeType.QUEUE, queueName2);
         queue2PublisherBroker2Config.setNumberOfMessagesToSend(queueSendCountPerPublisher);
         queue2PublisherBroker2Config.setPrintsPerMessageCount(printPerMessageCount);
@@ -494,14 +494,14 @@ public class MixedQueueTopicTestCase extends MBPlatformBaseTest {
         long topicSendCountPerPublisher = 25000;
 
         AndesJMSPublisherClientConfiguration topic1PublisherBroker1Config =
-                new AndesJMSPublisherClientConfiguration(broker1.getHostText(),
+                new AndesJMSPublisherClientConfiguration(broker1.getHostName(),
                         broker1.getPort(), ExchangeType.TOPIC, topicName1);
         topic1PublisherBroker1Config.setNumberOfMessagesToSend(topicSendCountPerPublisher);
         topic1PublisherBroker1Config.setPrintsPerMessageCount(printPerMessageCount);
         topic1PublisherBroker1Config.setRunningDelay(1L);
 
         AndesJMSPublisherClientConfiguration topic1PublisherBroker2Config =
-                new AndesJMSPublisherClientConfiguration(broker2.getHostText(),
+                new AndesJMSPublisherClientConfiguration(broker2.getHostName(),
                         broker2.getPort(), ExchangeType.TOPIC, topicName1);
         topic1PublisherBroker2Config.setNumberOfMessagesToSend(topicSendCountPerPublisher);
         topic1PublisherBroker2Config.setPrintsPerMessageCount(printPerMessageCount);
@@ -535,14 +535,14 @@ public class MixedQueueTopicTestCase extends MBPlatformBaseTest {
         long topicSendCountPerPublisher = 25000;
 
         AndesJMSPublisherClientConfiguration topic2PublisherBroker1Config =
-                new AndesJMSPublisherClientConfiguration(broker1.getHostText(),
+                new AndesJMSPublisherClientConfiguration(broker1.getHostName(),
                         broker1.getPort(), ExchangeType.TOPIC, topicName2);
         topic2PublisherBroker1Config.setNumberOfMessagesToSend(topicSendCountPerPublisher);
         topic2PublisherBroker1Config.setPrintsPerMessageCount(printPerMessageCount);
         topic2PublisherBroker1Config.setRunningDelay(1L);
 
         AndesJMSPublisherClientConfiguration topic2PublisherBroker2Config =
-                new AndesJMSPublisherClientConfiguration(broker2.getHostText(),
+                new AndesJMSPublisherClientConfiguration(broker2.getHostName(),
                         broker2.getPort(), ExchangeType.TOPIC, topicName2);
         topic2PublisherBroker2Config.setNumberOfMessagesToSend(topicSendCountPerPublisher);
         topic2PublisherBroker2Config.setPrintsPerMessageCount(printPerMessageCount);

--- a/integration/broker-tests/tests-platform/tests-clustering/src/test/java/org/wso2/mb/platform/tests/clustering/MultipleSubscriberMultiplePublisherTestCase.java
+++ b/integration/broker-tests/tests-platform/tests-clustering/src/test/java/org/wso2/mb/platform/tests/clustering/MultipleSubscriberMultiplePublisherTestCase.java
@@ -18,7 +18,7 @@
 
 package org.wso2.mb.platform.tests.clustering;
 
-import com.google.common.net.HostAndPort;
+import java.net.InetSocketAddress;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -98,15 +98,15 @@ public class MultipleSubscriberMultiplePublisherTestCase extends MBPlatformBaseT
         long sendCount = messageCount;
         String queueName = "singleQueue1";
 
-        HostAndPort brokerAddress = getRandomAMQPBrokerAddress();
+        InetSocketAddress brokerAddress = getRandomAMQPBrokerAddress();
 
         AndesJMSConsumerClientConfiguration consumerConfig = new AndesJMSConsumerClientConfiguration(brokerAddress
-                                                .getHostText(), brokerAddress.getPort(), ExchangeType.QUEUE, queueName);
+                                                .getHostName(), brokerAddress.getPort(), ExchangeType.QUEUE, queueName);
         consumerConfig.setMaximumMessagesToReceived(expectedCount);
         consumerConfig.setPrintsPerMessageCount(expectedCount / 10L);
 
         AndesJMSPublisherClientConfiguration publisherConfig = new AndesJMSPublisherClientConfiguration(brokerAddress
-                                                .getHostText(), brokerAddress.getPort(), ExchangeType.QUEUE, queueName);
+                                                .getHostName(), brokerAddress.getPort(), ExchangeType.QUEUE, queueName);
         publisherConfig.setNumberOfMessagesToSend(sendCount);
         publisherConfig.setPrintsPerMessageCount(sendCount / 10L);
 
@@ -180,17 +180,17 @@ public class MultipleSubscriberMultiplePublisherTestCase extends MBPlatformBaseT
         // Number of messages send
         long sendCount = messageCount;
         String queueName = "singleQueue2";
-        HostAndPort consumerBrokerAddress = getRandomAMQPBrokerAddress();
+        InetSocketAddress consumerBrokerAddress = getRandomAMQPBrokerAddress();
 
         AndesJMSConsumerClientConfiguration consumerConfig1 =
-                new AndesJMSConsumerClientConfiguration(consumerBrokerAddress.getHostText(),
+                new AndesJMSConsumerClientConfiguration(consumerBrokerAddress.getHostName(),
                             consumerBrokerAddress.getPort(), ExchangeType.QUEUE, queueName);
         consumerConfig1.setMaximumMessagesToReceived(expectedCount);
         consumerConfig1.setPrintsPerMessageCount(expectedCount / 10L);
 
-        HostAndPort publisherBrokerAddress = getRandomAMQPBrokerAddress();
+        InetSocketAddress publisherBrokerAddress = getRandomAMQPBrokerAddress();
         AndesJMSPublisherClientConfiguration publisherConfig1 =
-                new AndesJMSPublisherClientConfiguration(publisherBrokerAddress.getHostText(),
+                new AndesJMSPublisherClientConfiguration(publisherBrokerAddress.getHostName(),
                              publisherBrokerAddress.getPort(), ExchangeType.QUEUE, queueName);
         publisherConfig1.setNumberOfMessagesToSend(sendCount);
         publisherConfig1.setPrintsPerMessageCount(sendCount / 10L);
@@ -199,22 +199,22 @@ public class MultipleSubscriberMultiplePublisherTestCase extends MBPlatformBaseT
         consumerClient1.startClient();
 
         AndesJMSConsumerClientConfiguration consumerConfig2 = consumerConfig1.clone();
-        HostAndPort randomAMQPBrokerAddress = getRandomAMQPBrokerAddress();
-        consumerConfig2.setHostName(randomAMQPBrokerAddress.getHostText());
+        InetSocketAddress randomAMQPBrokerAddress = getRandomAMQPBrokerAddress();
+        consumerConfig2.setHostName(randomAMQPBrokerAddress.getHostName());
         consumerConfig2.setPort(randomAMQPBrokerAddress.getPort());
         AndesClient consumerClient2 = new AndesClient(consumerConfig2, true);
         consumerClient2.startClient();
 
         AndesJMSConsumerClientConfiguration consumerConfig3 = consumerConfig1.clone();
         randomAMQPBrokerAddress = getRandomAMQPBrokerAddress();
-        consumerConfig3.setHostName(randomAMQPBrokerAddress.getHostText());
+        consumerConfig3.setHostName(randomAMQPBrokerAddress.getHostName());
         consumerConfig3.setPort(randomAMQPBrokerAddress.getPort());
         AndesClient consumerClient3 = new AndesClient(consumerConfig3, true);
         consumerClient3.startClient();
 
         AndesJMSConsumerClientConfiguration consumerConfig4 = consumerConfig1.clone();
         randomAMQPBrokerAddress = getRandomAMQPBrokerAddress();
-        consumerConfig4.setHostName(randomAMQPBrokerAddress.getHostText());
+        consumerConfig4.setHostName(randomAMQPBrokerAddress.getHostName());
         consumerConfig4.setPort(randomAMQPBrokerAddress.getPort());
         AndesClient consumerClient4 = new AndesClient(consumerConfig4, true);
         consumerClient4.startClient();
@@ -226,14 +226,14 @@ public class MultipleSubscriberMultiplePublisherTestCase extends MBPlatformBaseT
 
         AndesJMSPublisherClientConfiguration publisherConfig2 = publisherConfig1.clone();
         randomAMQPBrokerAddress = getRandomAMQPBrokerAddress();
-        publisherConfig2.setHostName(randomAMQPBrokerAddress.getHostText());
+        publisherConfig2.setHostName(randomAMQPBrokerAddress.getHostName());
         publisherConfig2.setPort(randomAMQPBrokerAddress.getPort());
         AndesClient publisherClient2 = new AndesClient(publisherConfig2, true);
         publisherClient2.startClient();
 
         AndesJMSPublisherClientConfiguration publisherConfig3 = publisherConfig1.clone();
         randomAMQPBrokerAddress = getRandomAMQPBrokerAddress();
-        publisherConfig3.setHostName(randomAMQPBrokerAddress.getHostText());
+        publisherConfig3.setHostName(randomAMQPBrokerAddress.getHostName());
         publisherConfig3.setPort(randomAMQPBrokerAddress.getPort());
         AndesClient publisherClient3 = new AndesClient(publisherConfig3, true);
         publisherClient3.startClient();
@@ -241,7 +241,7 @@ public class MultipleSubscriberMultiplePublisherTestCase extends MBPlatformBaseT
 
         AndesJMSPublisherClientConfiguration publisherConfig4 = publisherConfig1.clone();
         randomAMQPBrokerAddress = getRandomAMQPBrokerAddress();
-        publisherConfig4.setHostName(randomAMQPBrokerAddress.getHostText());
+        publisherConfig4.setHostName(randomAMQPBrokerAddress.getHostName());
         publisherConfig4.setPort(randomAMQPBrokerAddress.getPort());
         AndesClient publisherClient4 = new AndesClient(publisherConfig4, true);
         publisherClient4.startClient();
@@ -308,18 +308,18 @@ public class MultipleSubscriberMultiplePublisherTestCase extends MBPlatformBaseT
         String queue5 = "singleQueue5";
         String queue6 = "singleQueue6";
 
-        HostAndPort consumerBrokerAddress = getRandomAMQPBrokerAddress();
+        InetSocketAddress consumerBrokerAddress = getRandomAMQPBrokerAddress();
 
         AndesJMSConsumerClientConfiguration consumerConfig =
-                new AndesJMSConsumerClientConfiguration(consumerBrokerAddress.getHostText(),
+                new AndesJMSConsumerClientConfiguration(consumerBrokerAddress.getHostName(),
                                 consumerBrokerAddress.getPort(), ExchangeType.QUEUE, queue3);
         consumerConfig.setMaximumMessagesToReceived(expectedCount);
         consumerConfig.setPrintsPerMessageCount(expectedCount / 10L);
 
-        HostAndPort publisherBrokerAddress = getRandomAMQPBrokerAddress();
+        InetSocketAddress publisherBrokerAddress = getRandomAMQPBrokerAddress();
 
         AndesJMSPublisherClientConfiguration publisherConfig =
-                new AndesJMSPublisherClientConfiguration(publisherBrokerAddress.getHostText(),
+                new AndesJMSPublisherClientConfiguration(publisherBrokerAddress.getHostName(),
                              publisherBrokerAddress.getPort(), ExchangeType.QUEUE, queue3);
         publisherConfig.setNumberOfMessagesToSend(sendCount);
         publisherConfig.setPrintsPerMessageCount(sendCount / 10L);
@@ -329,8 +329,8 @@ public class MultipleSubscriberMultiplePublisherTestCase extends MBPlatformBaseT
 
         AndesJMSConsumerClientConfiguration consumerConfig2 = consumerConfig.clone();
         consumerConfig2.setDestinationName(queue4);
-        HostAndPort randomAMQPBrokerAddress = getRandomAMQPBrokerAddress();
-        consumerConfig2.setHostName(randomAMQPBrokerAddress.getHostText());
+        InetSocketAddress randomAMQPBrokerAddress = getRandomAMQPBrokerAddress();
+        consumerConfig2.setHostName(randomAMQPBrokerAddress.getHostName());
         consumerConfig2.setPort(randomAMQPBrokerAddress.getPort());
         AndesClient consumerClient2 = new AndesClient(consumerConfig2, true);
         consumerClient2.startClient();
@@ -338,7 +338,7 @@ public class MultipleSubscriberMultiplePublisherTestCase extends MBPlatformBaseT
         AndesJMSConsumerClientConfiguration consumerConfig3 = consumerConfig.clone();
         consumerConfig3.setDestinationName(queue5);
         randomAMQPBrokerAddress = getRandomAMQPBrokerAddress();
-        consumerConfig3.setHostName(randomAMQPBrokerAddress.getHostText());
+        consumerConfig3.setHostName(randomAMQPBrokerAddress.getHostName());
         consumerConfig3.setPort(randomAMQPBrokerAddress.getPort());
         AndesClient consumerClient3 = new AndesClient(consumerConfig3, true);
         consumerClient3.startClient();
@@ -346,7 +346,7 @@ public class MultipleSubscriberMultiplePublisherTestCase extends MBPlatformBaseT
         AndesJMSConsumerClientConfiguration consumerConfig4 = consumerConfig.clone();
         consumerConfig4.setDestinationName(queue6);
         randomAMQPBrokerAddress = getRandomAMQPBrokerAddress();
-        consumerConfig4.setHostName(randomAMQPBrokerAddress.getHostText());
+        consumerConfig4.setHostName(randomAMQPBrokerAddress.getHostName());
         consumerConfig4.setPort(randomAMQPBrokerAddress.getPort());
         AndesClient consumerClient4 = new AndesClient(consumerConfig4, true);
         consumerClient4.startClient();
@@ -359,7 +359,7 @@ public class MultipleSubscriberMultiplePublisherTestCase extends MBPlatformBaseT
         AndesJMSPublisherClientConfiguration publisherConfig2 = publisherConfig.clone();
         publisherConfig2.setDestinationName(queue4);
         randomAMQPBrokerAddress = getRandomAMQPBrokerAddress();
-        publisherConfig2.setHostName(randomAMQPBrokerAddress.getHostText());
+        publisherConfig2.setHostName(randomAMQPBrokerAddress.getHostName());
         publisherConfig2.setPort(randomAMQPBrokerAddress.getPort());
         AndesClient publisherClient2 = new AndesClient(publisherConfig2, true);
         publisherClient2.startClient();
@@ -367,7 +367,7 @@ public class MultipleSubscriberMultiplePublisherTestCase extends MBPlatformBaseT
         AndesJMSPublisherClientConfiguration publisherConfig3 = publisherConfig.clone();
         publisherConfig3.setDestinationName(queue5);
         randomAMQPBrokerAddress = getRandomAMQPBrokerAddress();
-        publisherConfig3.setHostName(randomAMQPBrokerAddress.getHostText());
+        publisherConfig3.setHostName(randomAMQPBrokerAddress.getHostName());
         publisherConfig3.setPort(randomAMQPBrokerAddress.getPort());
         AndesClient publisherClient3 = new AndesClient(publisherConfig3, true);
         publisherClient3.startClient();
@@ -375,7 +375,7 @@ public class MultipleSubscriberMultiplePublisherTestCase extends MBPlatformBaseT
         AndesJMSPublisherClientConfiguration publisherConfig4 = publisherConfig.clone();
         publisherConfig4.setDestinationName(queue6);
         randomAMQPBrokerAddress = getRandomAMQPBrokerAddress();
-        publisherConfig4.setHostName(randomAMQPBrokerAddress.getHostText());
+        publisherConfig4.setHostName(randomAMQPBrokerAddress.getHostName());
         publisherConfig4.setPort(randomAMQPBrokerAddress.getPort());
         AndesClient publisherClient4 = new AndesClient(publisherConfig4, true);
         publisherClient4.startClient();

--- a/integration/broker-tests/tests-platform/tests-clustering/src/test/java/org/wso2/mb/platform/tests/clustering/OrderGuaranteeTestCase.java
+++ b/integration/broker-tests/tests-platform/tests-clustering/src/test/java/org/wso2/mb/platform/tests/clustering/OrderGuaranteeTestCase.java
@@ -18,7 +18,6 @@
 
 package org.wso2.mb.platform.tests.clustering;
 
-import com.google.common.net.HostAndPort;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -48,6 +47,7 @@ import javax.naming.NamingException;
 import javax.xml.stream.XMLStreamException;
 import javax.xml.xpath.XPathExpressionException;
 import java.io.IOException;
+import java.net.InetSocketAddress;
 import java.net.URISyntaxException;
 import java.rmi.RemoteException;
 
@@ -100,11 +100,11 @@ public class OrderGuaranteeTestCase extends MBPlatformBaseTest {
         long printDivider = 10L;
         String queueName = "singleQueueOrder1";
 
-        HostAndPort brokerAddress = getRandomAMQPBrokerAddress();
+        InetSocketAddress brokerAddress = getRandomAMQPBrokerAddress();
 
         // Creating a consumer client configuration
         AndesJMSConsumerClientConfiguration consumerConfig =
-                new AndesJMSConsumerClientConfiguration(brokerAddress.getHostText(),
+                new AndesJMSConsumerClientConfiguration(brokerAddress.getHostName(),
                                     brokerAddress.getPort(), ExchangeType.QUEUE, queueName);
         consumerConfig.setMaximumMessagesToReceived(expectedCount * 2);
         consumerConfig.setPrintsPerMessageCount(expectedCount / printDivider);
@@ -112,7 +112,7 @@ public class OrderGuaranteeTestCase extends MBPlatformBaseTest {
 
         // Creating a publisher client configuration
         AndesJMSPublisherClientConfiguration publisherConfig =
-                new AndesJMSPublisherClientConfiguration(brokerAddress.getHostText(),
+                new AndesJMSPublisherClientConfiguration(brokerAddress.getHostName(),
                                  brokerAddress.getPort(), ExchangeType.QUEUE, queueName);
         publisherConfig.setNumberOfMessagesToSend(sendCount);
         publisherConfig.setPrintsPerMessageCount(sendCount / printDivider);
@@ -166,21 +166,21 @@ public class OrderGuaranteeTestCase extends MBPlatformBaseTest {
         long printDivider = 10L;
         String queueName = "singleQueueOrder2";
 
-        HostAndPort consumerBrokerAddress = getRandomAMQPBrokerAddress();
+        InetSocketAddress consumerBrokerAddress = getRandomAMQPBrokerAddress();
 
         // Creating a consumer client configuration
         AndesJMSConsumerClientConfiguration consumerConfig =
-                new AndesJMSConsumerClientConfiguration(consumerBrokerAddress.getHostText(),
+                new AndesJMSConsumerClientConfiguration(consumerBrokerAddress.getHostName(),
                             consumerBrokerAddress.getPort(), ExchangeType.QUEUE, queueName);
         consumerConfig.setMaximumMessagesToReceived(expectedCount * 2);
         consumerConfig.setPrintsPerMessageCount(expectedCount / printDivider);
         consumerConfig.setFilePathToWriteReceivedMessages(AndesClientConstants.FILE_PATH_TO_WRITE_RECEIVED_MESSAGES);
 
-        HostAndPort publisherBrokerAddress = getRandomAMQPBrokerAddress();
+        InetSocketAddress publisherBrokerAddress = getRandomAMQPBrokerAddress();
 
         // Creating a publisher client configuration
         AndesJMSPublisherClientConfiguration publisherConfig =
-                new AndesJMSPublisherClientConfiguration(publisherBrokerAddress.getHostText(),
+                new AndesJMSPublisherClientConfiguration(publisherBrokerAddress.getHostName(),
                          publisherBrokerAddress.getPort(), ExchangeType.QUEUE, queueName);
         publisherConfig.setNumberOfMessagesToSend(sendCount);
         publisherConfig.setPrintsPerMessageCount(sendCount / printDivider);

--- a/integration/broker-tests/tests-platform/tests-clustering/src/test/java/org/wso2/mb/platform/tests/clustering/SubscriptionDisconnectingTestCase.java
+++ b/integration/broker-tests/tests-platform/tests-clustering/src/test/java/org/wso2/mb/platform/tests/clustering/SubscriptionDisconnectingTestCase.java
@@ -18,7 +18,7 @@
 
 package org.wso2.mb.platform.tests.clustering;
 
-import com.google.common.net.HostAndPort;
+import java.net.InetSocketAddress;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -96,16 +96,16 @@ public class SubscriptionDisconnectingTestCase extends MBPlatformBaseTest {
         long printDivider = 10L;
         String queueName = "singleQueueSubscription1";
 
-        HostAndPort brokerAddress = getRandomAMQPBrokerAddress();
+        InetSocketAddress brokerAddress = getRandomAMQPBrokerAddress();
 
         AndesJMSConsumerClientConfiguration consumerConfig =
-                new AndesJMSConsumerClientConfiguration(brokerAddress.getHostText(),
+                new AndesJMSConsumerClientConfiguration(brokerAddress.getHostName(),
                             brokerAddress.getPort(), ExchangeType.QUEUE, queueName);
         consumerConfig.setMaximumMessagesToReceived(expectedCount);
         consumerConfig.setPrintsPerMessageCount(expectedCount / printDivider);
 
         AndesJMSPublisherClientConfiguration publisherConfig =
-                new AndesJMSPublisherClientConfiguration(brokerAddress.getHostText(),
+                new AndesJMSPublisherClientConfiguration(brokerAddress.getHostName(),
                              brokerAddress.getPort(), ExchangeType.QUEUE, queueName);
         publisherConfig.setNumberOfMessagesToSend(sendCount);
         publisherConfig.setPrintsPerMessageCount(sendCount / printDivider);
@@ -175,16 +175,16 @@ public class SubscriptionDisconnectingTestCase extends MBPlatformBaseTest {
         long printDivider = 10L;
         String queueName = "singleQueueSubscription2";
 
-        HostAndPort brokerAddress = getRandomAMQPBrokerAddress();
+        InetSocketAddress brokerAddress = getRandomAMQPBrokerAddress();
 
         AndesJMSConsumerClientConfiguration consumerConfig =
-                new AndesJMSConsumerClientConfiguration(brokerAddress.getHostText(),
+                new AndesJMSConsumerClientConfiguration(brokerAddress.getHostName(),
                             brokerAddress.getPort(), ExchangeType.QUEUE, queueName);
         consumerConfig.setMaximumMessagesToReceived(expectedCount);
         consumerConfig.setPrintsPerMessageCount(expectedCount / printDivider);
 
         AndesJMSPublisherClientConfiguration publisherConfig =
-                new AndesJMSPublisherClientConfiguration(brokerAddress.getHostText(),
+                new AndesJMSPublisherClientConfiguration(brokerAddress.getHostName(),
                              brokerAddress.getPort(), ExchangeType.QUEUE, queueName);
         publisherConfig.setNumberOfMessagesToSend(sendCount);
         publisherConfig.setPrintsPerMessageCount(sendCount / printDivider);
@@ -203,8 +203,8 @@ public class SubscriptionDisconnectingTestCase extends MBPlatformBaseTest {
                             "Message " + "receiving failed for consumerClient1");
 
         AndesJMSConsumerClientConfiguration consumerConfig2 = consumerConfig.clone();
-        HostAndPort randomAMQPBrokerAddress = getRandomAMQPBrokerAddress();
-        consumerConfig2.setHostName(randomAMQPBrokerAddress.getHostText());
+        InetSocketAddress randomAMQPBrokerAddress = getRandomAMQPBrokerAddress();
+        consumerConfig2.setHostName(randomAMQPBrokerAddress.getHostName());
         consumerConfig2.setPort(randomAMQPBrokerAddress.getPort());
         AndesClient consumerClient2 = new AndesClient(consumerConfig2, true);
         consumerClient2.startClient();
@@ -218,7 +218,7 @@ public class SubscriptionDisconnectingTestCase extends MBPlatformBaseTest {
         
         AndesJMSConsumerClientConfiguration consumerConfig3 = consumerConfig.clone();
         randomAMQPBrokerAddress = getRandomAMQPBrokerAddress();
-        consumerConfig3.setHostName(randomAMQPBrokerAddress.getHostText());
+        consumerConfig3.setHostName(randomAMQPBrokerAddress.getHostName());
         consumerConfig3.setPort(randomAMQPBrokerAddress.getPort());
         AndesClient consumerClient3 = new AndesClient(consumerConfig3, true);
         consumerClient3.startClient();
@@ -230,7 +230,7 @@ public class SubscriptionDisconnectingTestCase extends MBPlatformBaseTest {
 
         AndesJMSConsumerClientConfiguration consumerConfig4 = consumerConfig.clone();
         randomAMQPBrokerAddress = getRandomAMQPBrokerAddress();
-        consumerConfig4.setHostName(randomAMQPBrokerAddress.getHostText());
+        consumerConfig4.setHostName(randomAMQPBrokerAddress.getHostName());
         consumerConfig4.setPort(randomAMQPBrokerAddress.getPort());
         AndesClient consumerClient4 = new AndesClient(consumerConfig4, true);
         consumerClient4.startClient();

--- a/integration/broker-tests/tests-platform/tests-clustering/src/test/resources/automation.xml
+++ b/integration/broker-tests/tests-platform/tests-clustering/src/test/resources/automation.xml
@@ -206,10 +206,10 @@
                     <host type="default">127.0.0.1</host>
                 </hosts>
                 <ports>
-                    <port type="http">9763</port>
-                    <port type="https">9443</port>
-                    <port type="amqp">5672</port>
-                    <port type="mqtt">1883</port>
+                    <port type="http">9766</port>
+                    <port type="https">9446</port>
+                    <port type="amqp">5675</port>
+                    <port type="mqtt">1886</port>
                 </ports>
                 <properties>
 
@@ -220,10 +220,10 @@
                     <host type="default">127.0.0.1</host>
                 </hosts>
                 <ports>
-                    <port type="http">9764</port>
-                    <port type="https">9444</port>
-                    <port type="amqp">5673</port>
-                    <port type="mqtt">1884</port>
+                    <port type="http">9767</port>
+                    <port type="https">9447</port>
+                    <port type="amqp">5676</port>
+                    <port type="mqtt">1887</port>
                 </ports>
                 <properties>
                 


### PR DESCRIPTION
Fixes the following issues of the clustering tests of Broker profile:
1. **Issue:** Non-resolvable parent POM for org.wso2.ei:org.wso2.ei.mb.platform.tests:[unknown-version]: Could not find artifact org.wso2.ei:mb-integration-tests:pom:6.5.0-SNAPSHOT and 'parent.relativePath' points at wrong local POM @ line 23, column 13
**Reason**: tests-platform/pom.xml and tests-clustering/pom.xml having incorrect versions
**Resolution**: Correct versions in the pom file

2. **Issue**: /home/sasikala/Documents/ei/git/product-ei/integration/broker-tests/tests-platform/tests-clustering/src/test/java/org/wso2/mb/platform/tests/clustering/MixedQueueTopicTestCase.java:[164,64] cannot find symbol
  symbol:   method getHostText()
  location: variable broker1 of type com.google.common.net.HostAndPort
**Reason**: method, 'getHostText()' being removed from latest versions of 'HostAndPort'
**Resolution**: Changed class 'HostAndPort' to 'java.net.InetSocketAddress' to remove the dependency for Guava