### PR TITLE
Fix integration test failure ESBJAVA3689AccessMIMEMessageContentTestCase

### DIFF
--- a/integration/mediation-tests/tests-transport/src/test/java/org/wso2/carbon/esb/nhttp/transport/test/ESBJAVA3689AccessMIMEMessageContentTestCase.java
+++ b/integration/mediation-tests/tests-transport/src/test/java/org/wso2/carbon/esb/nhttp/transport/test/ESBJAVA3689AccessMIMEMessageContentTestCase.java
@@ -81,8 +81,8 @@ public class ESBJAVA3689AccessMIMEMessageContentTestCase extends ESBIntegrationT
        
         String expectedMessage = "<soapenv:Body><mediate><file_type>xml</file_type><description>Simple HTTP POST " +
                 "request with an attachment.</description><file_name>attachment.xml</file_name><data " +
-                "filename=\"attachment" + ""
-                + ".xml\">PG1pbWU+CiAgICA8aWQ+MDAwMTwvaWQ+CiAgICA8bmFtZT5NaW1lIGNvbnRlbnQgYWNjZXNzIHRlc3Q8L25hbWU" +
+                "filename=\"attachment.xml\" content-type=\"application/octet-stream\">" +
+                "PG1pbWU+CiAgICA8aWQ+MDAwMTwvaWQ+CiAgICA8bmFtZT5NaW1lIGNvbnRlbnQgYWNjZXNzIHRlc3Q8L25hbWU" +
                 "+CiAgICA8dG9rZW4" + "+d3NvMl9hY2Nlc3NfMDAxPC90b2tlbj4KPC9taW1lPg==</data></mediate></soapenv:Body"
                 + "></soapenv:Envelope>";
 


### PR DESCRIPTION
## Purpose
Fix ESBJAVA3689AccessMIMEMessageContentTestCase integration test failure due to fix wso2-support/wso2-axis2#82 

## Details
This PR should be merged once the PR https://github.com/wso2/wso2-axis2/pull/174 is merged and wso2-axis2 is released. Once the wso2-axis2 is released, the kernel should be updated with the release, and EI should be updated with the new kernel version