### PR TITLE
Exclude jna depenency from elk

### DIFF
--- a/components/org.wso2.ei.analytics.elk/pom.xml
+++ b/components/org.wso2.ei.analytics.elk/pom.xml
@@ -56,6 +56,10 @@
                     <groupId>com.fasterxml.jackson.dataformat</groupId>
                     <artifactId>jackson-dataformat-yaml</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.elasticsearch</groupId>
+                    <artifactId>jna</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -1271,6 +1271,10 @@
                         <groupId>com.fasterxml.jackson.dataformat</groupId>
                         <artifactId>jackson-dataformat-yaml</artifactId>
                     </exclusion>
+                    <exclusion>
+                        <groupId>org.elasticsearch</groupId>
+                        <artifactId>jna</artifactId>
+                    </exclusion>
                 </exclusions>
             </dependency>
             <dependency>


### PR DESCRIPTION
## Purpose
>   Exclude jna library from elastic search Transport.

## Goals
>  Remove LGPL dependencies from product.

Though we are fixing / re writing ELK , removing this for the moment. 