### PR TITLE
Remove vfs smb feature packaging by default

### DIFF
--- a/p2-profile/ei-profile/pom.xml
+++ b/p2-profile/ei-profile/pom.xml
@@ -104,9 +104,6 @@
                                     org.wso2.carbon.mediation:org.apache.synapse.transport.vfs.feature:${carbon.mediation.version}
                                 </featureArtifactDef>
                                 <featureArtifactDef>
-                                    org.wso2.carbon.mediation:org.apache.synapse.transport.vfs.smb.feature:${carbon.mediation.version}
-                                </featureArtifactDef>
-                                <featureArtifactDef>
                                     org.wso2.carbon.mediation:org.wso2.carbon.application.deployer.synapse.feature:${carbon.mediation.version}
                                 </featureArtifactDef>
                                 <featureArtifactDef>
@@ -534,10 +531,6 @@
                                 </feature>
                                 <feature>
                                     <id>org.apache.synapse.transport.vfs.feature.group</id>
-                                    <version>${carbon.mediation.version}</version>
-                                </feature>
-                                <feature>
-                                    <id>org.apache.synapse.transport.vfs.smb.feature.group</id>
                                     <version>${carbon.mediation.version}</version>
                                 </feature>
                                 <feature>


### PR DESCRIPTION
## Purpose
>  Remove packaging the feature by default.

## Goals
> Remove LGPL dependencies in the Pack.


Document Issue Created In https://github.com/wso2/product-ei/issues/4087