### PR TITLE
CXF upgrade to version 3.x.x

### DIFF
--- a/distribution/src/analytics/conf/tomcat/webapp-classloading-environments.xml
+++ b/distribution/src/analytics/conf/tomcat/webapp-classloading-environments.xml
@@ -69,8 +69,8 @@
     -->
     <ExclusiveEnvironments>
         <ExclusiveEnvironment>
-            <Name>CXF</Name>
-            <Classpath>${carbon.home}/../lib/runtimes/cxf/*.jar;${carbon.home}/../lib/runtimes/cxf/</Classpath>
+            <Name>CXF3</Name>
+            <Classpath>${carbon.home}/../lib/runtimes/cxf3/*.jar;${carbon.home}/../lib/runtimes/cxf3/</Classpath>
         </ExclusiveEnvironment>
     </ExclusiveEnvironments>
 

--- a/distribution/src/business-process/conf/tomcat/webapp-classloading-environments.xml
+++ b/distribution/src/business-process/conf/tomcat/webapp-classloading-environments.xml
@@ -69,8 +69,8 @@
     -->	
     <ExclusiveEnvironments>
         <ExclusiveEnvironment>
-            <Name>CXF</Name>
-            <Classpath>${carbon.home}/../lib/runtimes/cxf/*.jar;${carbon.home}/../lib/runtimes/cxf/</Classpath>
+            <Name>CXF3</Name>
+            <Classpath>${carbon.home}/../lib/runtimes/cxf3/*.jar;${carbon.home}/../lib/runtimes/cxf3/</Classpath>
         </ExclusiveEnvironment>
     </ExclusiveEnvironments>
 

--- a/distribution/src/business-process/process-tools/scripts/processcleanuptool.sh
+++ b/distribution/src/business-process/process-tools/scripts/processcleanuptool.sh
@@ -94,7 +94,7 @@ if $cygwin; then
   JAVA_ENDORSED_DIRS=`cygpath --path --windows "$JAVA_ENDORSED_DIRS"`
 fi
 
-CARBON_CLASSPATH=$CARBON_CLASSPATH:$CARBON_HOME/../lib/runtimes/cxf/commons-logging-1.1.1.jar
+CARBON_CLASSPATH=$CARBON_CLASSPATH:$CARBON_HOME/../lib/runtimes/cxf3/commons-logging-1.1.1.jar
 "$JAVA_HOME/bin/java" \
 -classpath "$CARBON_CLASSPATH" \
 -Djava.io.tmpdir="$CARBON_HOME/tmp" \

--- a/distribution/src/business-process/process-tools/scripts/taskmigrationtool.sh
+++ b/distribution/src/business-process/process-tools/scripts/taskmigrationtool.sh
@@ -99,7 +99,7 @@ if $cygwin; then
   JAVA_ENDORSED_DIRS=`cygpath --path --windows "$JAVA_ENDORSED_DIRS"`
 fi
 
-CARBON_CLASSPATH=$CARBON_CLASSPATH:$CARBON_HOME/../lib/runtimes/cxf/commons-logging-1.1.1.jar
+CARBON_CLASSPATH=$CARBON_CLASSPATH:$CARBON_HOME/../lib/runtimes/cxf3/commons-logging-1.1.1.jar
 
 
 "$JAVA_HOME/bin/java" \

--- a/distribution/src/resources/tomcat/webapp-classloading-environments.xml
+++ b/distribution/src/resources/tomcat/webapp-classloading-environments.xml
@@ -69,8 +69,8 @@
     -->	
     <ExclusiveEnvironments>
         <ExclusiveEnvironment>
-            <Name>CXF</Name>
-	    <Classpath>${carbon.home}/wso2/lib/runtimes/cxf/*.jar;${carbon.home}/wso2/lib/runtimes/cxf/</Classpath>
+            <Name>CXF3</Name>
+	    <Classpath>${carbon.home}/wso2/lib/runtimes/cxf3/*.jar;${carbon.home}/wso2/lib/runtimes/cxf3/</Classpath>
         </ExclusiveEnvironment>
     </ExclusiveEnvironments>
 

--- a/p2-profile/broker-profile/pom.xml
+++ b/p2-profile/broker-profile/pom.xml
@@ -132,7 +132,7 @@
                                     org.wso2.carbon.deployment:org.wso2.carbon.webapp.mgt.server.feature:${carbon.deployment.version}
                                 </featureArtifactDef>
 				<featureArtifactDef>
-                                    org.wso2.carbon.deployment:org.wso2.carbon.as.runtimes.cxf.feature:${carbon.deployment.version}
+                                    org.wso2.carbon.deployment:org.wso2.carbon.as.runtimes.cxf3.feature:${carbon.deployment.version}
                                 </featureArtifactDef>
                                 <!--carbon core features -->
                                 <featureArtifactDef>
@@ -304,7 +304,7 @@
                                 </feature>
 				<feature>
                                     <id>org.wso2.carbon.webapp.mgt.server.feature.group</id>
-                                    <id>org.wso2.carbon.as.runtimes.cxf.feature.group</id>
+                                    <id>org.wso2.carbon.as.runtimes.cxf3.feature.group</id>
                                     <version>${carbon.deployment.version}</version>
                                 </feature>
                             </features>

--- a/p2-profile/business-process-profile/pom.xml
+++ b/p2-profile/business-process-profile/pom.xml
@@ -242,7 +242,7 @@
                                     org.wso2.carbon.deployment:org.wso2.carbon.webapp.mgt.server.feature:${carbon.deployment.version}
                                 </featureArtifactDef>
                                 <featureArtifactDef>
-                                    org.wso2.carbon.deployment:org.wso2.carbon.as.runtimes.cxf.feature:${carbon.deployment.version}
+                                    org.wso2.carbon.deployment:org.wso2.carbon.as.runtimes.cxf3.feature:${carbon.deployment.version}
                                 </featureArtifactDef>
 
                                 <!-- 7 Jaggery-->
@@ -578,7 +578,7 @@
                                 </feature>
                                 <!-- as-runtimes-->
                                 <feature>
-                                    <id>org.wso2.carbon.as.runtimes.cxf.feature.group</id>
+                                    <id>org.wso2.carbon.as.runtimes.cxf3.feature.group</id>
                                     <version>${carbon.deployment.version}</version>
                                 </feature>
 

--- a/p2-profile/ei-profile/pom.xml
+++ b/p2-profile/ei-profile/pom.xml
@@ -315,7 +315,7 @@
                                     org.wso2.carbon.deployment:org.wso2.carbon.webapp.mgt.server.feature:${carbon.deployment.version}
                                 </featureArtifactDef>
                                 <featureArtifactDef>
-                                    org.wso2.carbon.deployment:org.wso2.carbon.as.runtimes.cxf.feature:${carbon.deployment.version}
+                                    org.wso2.carbon.deployment:org.wso2.carbon.as.runtimes.cxf3.feature:${carbon.deployment.version}
                                 </featureArtifactDef>
                                 <!--8 Carbon-MultiTenancy-->
                                 <featureArtifactDef>
@@ -729,7 +729,7 @@
                                 </feature>
                                 <feature>
                                     <id>org.wso2.carbon.webapp.mgt.server.feature.group</id>
-                                    <id>org.wso2.carbon.as.runtimes.cxf.feature.group</id>
+                                    <id>org.wso2.carbon.as.runtimes.cxf3.feature.group</id>
                                     <version>${carbon.deployment.version}</version>
                                 </feature>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1523,7 +1523,7 @@
         <product.ei.version>6.6.0-SNAPSHOT</product.ei.version>
 
         <!--Business-Process-->
-        <carbon.business-process.version>4.4.105</carbon.business-process.version>
+        <carbon.business-process.version>4.4.107</carbon.business-process.version>
         <bps.version>3.5.1</bps.version>
         <!--Business-Process-tests-->
         <orbit.version.axis2>1.6.1-wso2v35</orbit.version.axis2>
@@ -1665,7 +1665,7 @@
         <!--<emma.version>2.1.5320</emma.version>-->
         <jacoco.agent.version>0.8.4</jacoco.agent.version>
         <wso2.h2.orbit.version>1.2.140.wso2v3</wso2.h2.orbit.version>
-        <org.apache.cxf.version>2.7.2</org.apache.cxf.version>
+        <org.apache.cxf.version>3.2.8</org.apache.cxf.version>
         <org.springframework.version>4.1.5.RELEASE</org.springframework.version>
         <org.apache.tomcat>7.0.93</org.apache.tomcat>
         <org.codehaus.jackson.version>1.9.12</org.codehaus.jackson.version>

--- a/samples/webapps/jaxrs_basic/build.xml
+++ b/samples/webapps/jaxrs_basic/build.xml
@@ -41,7 +41,7 @@
                 <include name="commons-httpclient_3.1.0.wso2v3.jar"/>
                 <include name="commons-codec_1.4.0.wso2v1.jar"/>
             </fileset>
-	    <fileset dir="${wso2appserver.home}/wso2/lib/runtimes/cxf/">
+	    <fileset dir="${wso2appserver.home}/wso2/lib/runtimes/cxf3/">
                 <include name="*.jar"/>
             </fileset>
         </copy>

--- a/samples/webapps/jaxrs_basic/src/main/webapp/META-INF/webapp-classloading.xml
+++ b/samples/webapps/jaxrs_basic/src/main/webapp/META-INF/webapp-classloading.xml
@@ -29,5 +29,5 @@
 	Tomcat environment is the default and every webapps gets it even if they didn't specify it.
 	e.g. If a webapps requires CXF, they will get both Tomcat and CXF.
      -->
-    <Environments>CXF,Carbon</Environments>
+    <Environments>CXF3,Carbon</Environments>
 </Classloading>

--- a/samples/webapps/pom.xml
+++ b/samples/webapps/pom.xml
@@ -159,7 +159,7 @@
     </dependencyManagement>
 
     <properties>
-        <samples.cxf.version>2.7.2</samples.cxf.version>
+        <samples.cxf.version>3.2.8</samples.cxf.version>
         <samples.version.commons.httpclient>3.1</samples.version.commons.httpclient>
         <samples.version.jsr311.api>1.1.1</samples.version.jsr311.api>
 


### PR DESCRIPTION
## Purpose
> Add CXF 3.x.x runtime for web applications and upgrade the CXF version to 3.2.8
