### PR TITLE
Migrate log4j properties to log4j2

### DIFF
--- a/distribution/src/conf/log4j2.properties
+++ b/distribution/src/conf/log4j2.properties
@@ -160,59 +160,43 @@ loggers = AUDIT_LOG, trace-messages, org-apache-coyote, com-hazelcast, Owasp-Csr
 	  org-apache-directory-server-core-event, com-atomikos, org-quartz, org-apache-jackrabbit-webdav, org-apache-juddi, \
 	  org-apache-commons-digester-Digester, org-apache-jasper-compiler-TldLocationsCache, org-apache-qpid, \
 	  org-apache-qpid-server-Main, qpid-message, qpid-message-broker-listening, org-apache-tiles, \
-	  org-apache-commons-httpclient, org-apache-solr, me-prettyprint-cassandra-hector-TimingLogger, org-apache-axis-enterprise, org-apache-directory-shared-ldap, org-apache-directory-server-ldap-handlers, org-apache-directory-shared-ldap-entry-DefaultServerAttribute, org-apache-directory-server-core-DefaultDirectoryService, org-apache-directory-shared-ldap-ldif-LdifReader, org-apache-directory-server-ldap-LdapProtocolHandler, org-apache-directory-server-core, org-apache-directory-server-ldap-LdapSession, DataNucleus, Datastore, Datastore-Schema, JPOX-Datastore, JPOX-Plugin, JPOX-MetaData, JPOX-Query, JPOX-General, JPOX-Enhancer, org-apache-hadoop-hive, hive, ExecMapper, ExecReducer, net-sf-ehcache-config-ConfigurationFactory, axis2Deployment, equinox, tomcat2, StAXDialectDetector, ModuleDeployer, VFSTransportSender, PassThroughHttpSender, PassThroughHttpSSLSender, PassThroughHttpListener, PassThroughHttpSSLListener, DeploymentEngine, TaskServiceImpl, SynapseControllerFactory, Axis2SynapseController, MultiXMLConfigurationBuilder, XMLConfigurationBuilder, DependencyTracker, VFSTransportListener, NTaskTaskManager, MediationStatisticsComponent, SynapseConfigurationBuilder
+	  org-apache-commons-httpclient, org-apache-solr, me-prettyprint-cassandra-hector-TimingLogger, \
+      org-apache-axis-enterprise, org-apache-directory-shared-ldap, org-apache-directory-server-ldap-handlers, \
+      org-apache-directory-shared-ldap-entry-DefaultServerAttribute, org-apache-directory-server-core-DefaultDirectoryService, \
+      org-apache-directory-shared-ldap-ldif-LdifReader, org-apache-directory-server-ldap-LdapProtocolHandler, \
+      org-apache-directory-server-core, org-apache-directory-server-ldap-LdapSession, DataNucleus, Datastore, Datastore-Schema, \
+      JPOX-Datastore, JPOX-Plugin, JPOX-MetaData, JPOX-Query, JPOX-General, JPOX-Enhancer, org-apache-hadoop-hive, hive, ExecMapper, \
+      ExecReducer, net-sf-ehcache-config-ConfigurationFactory, axis2Deployment, equinox, tomcat2, StAXDialectDetector, \
+      httpclient-wire-header, httpclient-wire-content, synapse-transport-http-headers, synapse-transport-http-wire, \
+      org-apache-synapse, org-apache-synapse-transport, org-apache-axis2, org-apache-axis2-transport, org-wso2-carbon, synapse-transport-http-access
 
-# Info logs for following loggers are disabled to improve performance
-logger.ModuleDeployer.name = org.apache.axis2.deployment.ModuleDeployer
-logger.ModuleDeployer.level = WARN
+logger.org-apache-synapse.name=org.apache.synapse
+logger.org-apache-synapse.level=INFO
+logger.org-apache-synapse.appenderRef.CARBON_LOGFILE.ref = CARBON_LOGFILE
+logger.org-apache-synapse.appenderRef.CARBON_MEMORY.ref = CARBON_MEMORY
 
-logger.VFSTransportSender.name = org.apache.synapse.transport.vfs.VFSTransportSender
-logger.VFSTransportSender.level = WARN
+logger.org-apache-synapse-transport.name=org.apache.synapse.transport
+logger.org-apache-synapse-transport.level=INFO
+logger.org-apache-synapse-transport.appenderRef.CARBON_LOGFILE.ref = CARBON_LOGFILE
+logger.org-apache-synapse-transport.appenderRef.CARBON_MEMORY.ref = CARBON_MEMORY
 
-logger.PassThroughHttpSender.name = org.apache.synapse.transport.passthru.PassThroughHttpSender
-logger.PassThroughHttpSender.level = WARN
+logger.org-apache-axis2.name=org.apache.axis2
+logger.org-apache-axis2.level=INFO
+logger.org-apache-axis2.appenderRef.CARBON_LOGFILE.ref = CARBON_LOGFILE
+logger.org-apache-axis2.appenderRef.CARBON_MEMORY.ref = CARBON_MEMORY
 
-logger.PassThroughHttpSSLSender.name = org.apache.synapse.transport.passthru.PassThroughHttpSSLSender
-logger.PassThroughHttpSSLSender.level = WARN
+logger.org-apache-axis2-transport.name=org.apache.axis2.transport
+logger.org-apache-axis2-transport.level=INFO
+logger.org-apache-axis2-transport.appenderRef.CARBON_LOGFILE.ref = CARBON_LOGFILE
+logger.org-apache-axis2-transport.appenderRef.CARBON_MEMORY.ref = CARBON_MEMORY
 
-logger.PassThroughHttpListener.name = org.apache.synapse.transport.passthru.PassThroughHttpListener
-logger.PassThroughHttpListener.level = WARN
+logger.org-wso2-carbon.name=org.wso2.carbon
+logger.org-wso2-carbon.level=INFO
+logger.org-wso2-carbon.appenderRef.CARBON_LOGFILE.ref = CARBON_LOGFILE
+logger.org-wso2-carbon.appenderRef.CARBON_MEMORY.ref = CARBON_MEMORY
 
-logger.PassThroughHttpSSLListener.name = org.apache.synapse.transport.passthru.PassThroughHttpSSLListener
-logger.PassThroughHttpSSLListener.level = WARN
-
-logger.DeploymentEngine.name = org.apache.axis2.deployment.DeploymentEngine
-logger.DeploymentEngine.level = WARN
-
-logger.TaskServiceImpl.name = org.wso2.carbon.ntask.core.service.impl.TaskServiceImpl
-logger.TaskServiceImpl.level = WARN
-
-logger.SynapseControllerFactory.name = org.apache.synapse.SynapseControllerFactory
-logger.SynapseControllerFactory.level = WARN
-
-logger.Axis2SynapseController.name = org.apache.synapse.Axis2SynapseController
-logger.Axis2SynapseController.level = WARN
-
-logger.MultiXMLConfigurationBuilder.name = org.apache.synapse.config.xml.MultiXMLConfigurationBuilder
-logger.MultiXMLConfigurationBuilder.level = WARN
-
-logger.XMLConfigurationBuilder.name = org.apache.synapse.config.xml.XMLConfigurationBuilder
-logger.XMLConfigurationBuilder.level = WARN
-
-logger.DependencyTracker.name = org.wso2.carbon.mediation.dependency.mgt.DependencyTracker
-logger.DependencyTracker.level = WARN
-
-logger.VFSTransportListener.name = org.apache.synapse.transport.vfs.VFSTransportListener
-logger.VFSTransportListener.level = WARN
-
-logger.NTaskTaskManager.name = org.wso2.carbon.mediation.ntask.NTaskTaskManager
-logger.NTaskTaskManager.level = WARN
-
-logger.MediationStatisticsComponent.name = org.wso2.carbon.das.messageflow.data.publisher.internal.MediationStatisticsComponent
-logger.MediationStatisticsComponent.level = WARN
-
-logger.SynapseConfigurationBuilder.name = org.apache.synapse.config.SynapseConfigurationBuilder
-logger.SynapseConfigurationBuilder.level = WARN
+logger.synapse-transport-http-access.name=org.apache.synapse.transport.http.access
+logger.synapse-transport-http-access.level=WARN
 
 logger.AUDIT_LOG.name = AUDIT_LOG
 logger.AUDIT_LOG.level = INFO
@@ -232,6 +216,28 @@ logger.com-hazelcast.level = ERROR
 logger.Owasp-CsrfGuard.name = Owasp.CsrfGuard
 logger.Owasp-CsrfGuard.level = WARN
 
+# uncomment the following logs to see HTTP headers and messages
+#logger.synapse-transport-http-headers.name=org.apache.synapse.transport.http.headers
+#logger.synapse-transport-http-headers.level=DEBUG
+#logger.synapse-transport-http-headers.appenderRef.CARBON_LOGFILE.ref = CARBON_LOGFILE
+#logger.synapse-transport-http-headers.appenderRef.CARBON_MEMORY.ref = CARBON_MEMORY
+#
+#logger.synapse-transport-http-wire.name=org.apache.synapse.transport.http.wire
+#logger.synapse-transport-http-wire.level=DEBUG
+#logger.synapse-transport-http-wire.appenderRef.CARBON_LOGFILE.ref = CARBON_LOGFILE
+#logger.synapse-transport-http-wire.appenderRef.CARBON_MEMORY.ref = CARBON_MEMORY
+
+# uncomment the flowing entries to see HTTP headers and messages of Callout mediator/MessageProcessor
+#logger.httpclient-wire-header.name=httpclient.wire.header
+#logger.httpclient-wire-header.level=DEBUG
+#logger.httpclient-wire-header.appenderRef.CARBON_LOGFILE.ref = CARBON_LOGFILE
+#logger.httpclient-wire-header.appenderRef.CARBON_MEMORY.ref = CARBON_MEMORY
+#
+#logger.httpclient-wire-content.name=httpclient.wire.content
+#logger.httpclient-wire-content.level=DEBUG
+#logger.httpclient-wire-content.appenderRef.CARBON_LOGFILE.ref = CARBON_LOGFILE
+#logger.httpclient-wire-content.appenderRef.CARBON_MEMORY.ref = CARBON_MEMORY
+
 logger.org-apache-axis2-wsdl-codegen-writer-PrettyPrinter.name = org.apache.axis2.wsdl.codegen.writer.PrettyPrinter
 logger.org-apache-axis2-wsdl-codegen-writer-PrettyPrinter.level = ERROR
 logger.org-apache-axis2-wsdl-codegen-writer-PrettyPrinter.appenderRef.CARBON_LOGFILE.ref = CARBON_LOGFILE
@@ -248,7 +254,7 @@ logger.org-apache.appenderRef.CARBON_LOGFILE.ref = CARBON_LOGFILE
 logger.org-apache.appenderRef.CARBON_MEMORY.ref = CARBON_MEMORY
 
 logger.org-apache-catalina.name = org.apache.catalina
-logger.org-apache-catalina.level = ERROR
+logger.org-apache-catalina.level = WARN
 
 logger.org-apache-tomcat.name = org.apache.tomcat
 logger.org-apache-tomcat.level = INFO
@@ -307,7 +313,7 @@ logger.me-prettyprint-cassandra-hector-TimingLogger.name = me.prettyprint.cassan
 logger.me-prettyprint-cassandra-hector-TimingLogger.level = ERROR
 
 logger.org-wso2.name = org.wso2
-logger.org-wso2.level = ERROR
+logger.org-wso2.level = INFO
 
 logger.org-apache-axis-enterprise.name = org.apache.axis2.enterprise
 logger.org-apache-axis-enterprise.level = FATAL


### PR DESCRIPTION
## Purpose
> This PR has the migration changes of log4j1 properties file to the log4j2 for EI profile.
