### PR TITLE
Remove wire logging for the default distribution

### DIFF
--- a/distribution/src/conf/log4j2.properties
+++ b/distribution/src/conf/log4j2.properties
@@ -167,7 +167,6 @@ loggers = AUDIT_LOG, trace-messages, org-apache-coyote, com-hazelcast, Owasp-Csr
       org-apache-directory-server-core, org-apache-directory-server-ldap-LdapSession, DataNucleus, Datastore, Datastore-Schema, \
       JPOX-Datastore, JPOX-Plugin, JPOX-MetaData, JPOX-Query, JPOX-General, JPOX-Enhancer, org-apache-hadoop-hive, hive, ExecMapper, \
       ExecReducer, net-sf-ehcache-config-ConfigurationFactory, axis2Deployment, equinox, tomcat2, StAXDialectDetector, \
-      httpclient-wire-header, httpclient-wire-content, synapse-transport-http-headers, synapse-transport-http-wire, \
       org-apache-synapse, org-apache-synapse-transport, org-apache-axis2, org-apache-axis2-transport, org-wso2-carbon, synapse-transport-http-access
 
 logger.org-apache-synapse.name=org.apache.synapse


### PR DESCRIPTION
## Purpose
> This PR will remove wire logging loggers for the default EI distribution.