### PR TITLE
Remove spring mediator tests

### DIFF
--- a/integration/mediation-tests/tests-mediator-2/src/test/resources/testng.xml
+++ b/integration/mediation-tests/tests-mediator-2/src/test/resources/testng.xml
@@ -82,11 +82,12 @@
         </packages>
     </test>
 
-    <test name="Spring-mediator-Test" preserve-order="true" verbose="2">
-        <packages>
-            <package name="org.wso2.carbon.esb.mediator.test.spring"/>
-        </packages>
-    </test>
+    <!-- These test cases are removed since the spring mediator is deprecated and the spring server feature is not packed with the EI -->
+<!--    <test name="Spring-mediator-Test" preserve-order="true" verbose="2">-->
+<!--        <packages>-->
+<!--            <package name="org.wso2.carbon.esb.mediator.test.spring"/>-->
+<!--        </packages>-->
+<!--    </test>-->
 
     <test name="Smook-mediator-Test" preserve-order="true" verbose="2">
         <packages>


### PR DESCRIPTION
## Purpose
> This PR will remove the spring mediator tests since it has been deprecated and the feature is not packed in EI.