### PR TITLE
Remove CARBON_MEMORY_APPENDER from the log4j2

### DIFF
--- a/integration/mediation-tests/tests-mediator-1/src/test/resources/artifacts/ESB/server/conf/log4j2.properties
+++ b/integration/mediation-tests/tests-mediator-1/src/test/resources/artifacts/ESB/server/conf/log4j2.properties
@@ -78,7 +78,7 @@
 
 # list of all appenders
 #add entry "syslog" to use the syslog appender
-appenders = CARBON_CONSOLE, CARBON_LOGFILE, AUDIT_LOGFILE, ATOMIKOS_LOGFILE, CARBON_TRACE_LOGFILE, CARBON_MEMORY, osgi, SERVICE_LOGFILE, ERROR_LOGFILE, TestAPI_LOGGER
+appenders = CARBON_CONSOLE, CARBON_LOGFILE, AUDIT_LOGFILE, ATOMIKOS_LOGFILE, CARBON_TRACE_LOGFILE, osgi, SERVICE_LOGFILE, ERROR_LOGFILE, TestAPI_LOGGER
 #, syslog
 
 # CARBON_CONSOLE is set to be a ConsoleAppender using a PatternLayout.
@@ -213,14 +213,6 @@ appender.CARBON_TRACE_LOGFILE.policies.size.size=10MB
 appender.CARBON_TRACE_LOGFILE.strategy.type = DefaultRolloverStrategy
 appender.CARBON_TRACE_LOGFILE.strategy.max = 20
 
-# CARBON_MEMORY is set to be a MemoryAppender using a PatternLayout.
-appender.CARBON_MEMORY.type = MemoryAppender
-appender.CARBON_MEMORY.name = CARBON_MEMORY
-appender.CARBON_MEMORY.layout.type = PatternLayout
-appender.CARBON_MEMORY.layout.pattern = [%d] [%tenantId] %5p {%c} - %m%ex%n
-#appender.CARBON_MEMORY.bufferSize = 200
-appender.CARBON_MEMORY.filter.threshold.type = ThresholdFilter
-appender.CARBON_MEMORY.filter.threshold.level = DEBUG
 
 # Appender config to put correlation Log.
 appender.CORRELATION.type = RollingFile
@@ -268,32 +260,26 @@ loggers = AUDIT_LOG, SERVICE_LOGGER, ERROR_LOGGER, trace-messages, org-apache-co
 logger.org-apache-synapse.name=org.apache.synapse
 logger.org-apache-synapse.level=INFO
 logger.org-apache-synapse.appenderRef.CARBON_LOGFILE.ref = CARBON_LOGFILE
-logger.org-apache-synapse.appenderRef.CARBON_MEMORY.ref = CARBON_MEMORY
 
 logger.org-apache-synapse-transport.name=org.apache.synapse.transport
 logger.org-apache-synapse-transport.level=INFO
 logger.org-apache-synapse-transport.appenderRef.CARBON_LOGFILE.ref = CARBON_LOGFILE
-logger.org-apache-synapse-transport.appenderRef.CARBON_MEMORY.ref = CARBON_MEMORY
 
 logger.org_apache_synapse_mediators_builtin.name=org.apache.synapse.mediators.builtin
 logger.org_apache_synapse_mediators_builtin.level=DEBUG
 logger.org_apache_synapse_mediators_builtin.appenderRef.CARBON_LOGFILE.ref = CARBON_LOGFILE
-logger.org_apache_synapse_mediators_builtin.appenderRef.CARBON_MEMORY.ref = CARBON_MEMORY
 
 logger.org-apache-axis2.name=org.apache.axis2
 logger.org-apache-axis2.level=INFO
 logger.org-apache-axis2.appenderRef.CARBON_LOGFILE.ref = CARBON_LOGFILE
-logger.org-apache-axis2.appenderRef.CARBON_MEMORY.ref = CARBON_MEMORY
 
 logger.org-apache-axis2-transport.name=org.apache.axis2.transport
 logger.org-apache-axis2-transport.level=INFO
 logger.org-apache-axis2-transport.appenderRef.CARBON_LOGFILE.ref = CARBON_LOGFILE
-logger.org-apache-axis2-transport.appenderRef.CARBON_MEMORY.ref = CARBON_MEMORY
 
 logger.org-wso2-carbon.name=org.wso2.carbon
 logger.org-wso2-carbon.level=INFO
 logger.org-wso2-carbon.appenderRef.CARBON_LOGFILE.ref = CARBON_LOGFILE
-logger.org-wso2-carbon.appenderRef.CARBON_MEMORY.ref = CARBON_MEMORY
 
 logger.synapse-transport-http-access.name=org.apache.synapse.transport.http.access
 logger.synapse-transport-http-access.level=WARN
@@ -330,28 +316,23 @@ logger.Owasp-CsrfGuard.level = WARN
 #logger.synapse-transport-http-headers.name=org.apache.synapse.transport.http.headers
 #logger.synapse-transport-http-headers.level=DEBUG
 #logger.synapse-transport-http-headers.appenderRef.CARBON_LOGFILE.ref = CARBON_LOGFILE
-#logger.synapse-transport-http-headers.appenderRef.CARBON_MEMORY.ref = CARBON_MEMORY
 #
 #logger.synapse-transport-http-wire.name=org.apache.synapse.transport.http.wire
 #logger.synapse-transport-http-wire.level=DEBUG
 #logger.synapse-transport-http-wire.appenderRef.CARBON_LOGFILE.ref = CARBON_LOGFILE
-#logger.synapse-transport-http-wire.appenderRef.CARBON_MEMORY.ref = CARBON_MEMORY
 
 # uncomment the flowing entries to see HTTP headers and messages of Callout mediator/MessageProcessor
 #logger.httpclient-wire-header.name=httpclient.wire.header
 #logger.httpclient-wire-header.level=DEBUG
 #logger.httpclient-wire-header.appenderRef.CARBON_LOGFILE.ref = CARBON_LOGFILE
-#logger.httpclient-wire-header.appenderRef.CARBON_MEMORY.ref = CARBON_MEMORY
 #
 #logger.httpclient-wire-content.name=httpclient.wire.content
 #logger.httpclient-wire-content.level=DEBUG
 #logger.httpclient-wire-content.appenderRef.CARBON_LOGFILE.ref = CARBON_LOGFILE
-#logger.httpclient-wire-content.appenderRef.CARBON_MEMORY.ref = CARBON_MEMORY
 
 logger.org-apache-axis2-wsdl-codegen-writer-PrettyPrinter.name = org.apache.axis2.wsdl.codegen.writer.PrettyPrinter
 logger.org-apache-axis2-wsdl-codegen-writer-PrettyPrinter.level = ERROR
 logger.org-apache-axis2-wsdl-codegen-writer-PrettyPrinter.appenderRef.CARBON_LOGFILE.ref = CARBON_LOGFILE
-logger.org-apache-axis2-wsdl-codegen-writer-PrettyPrinter.appenderRef.CARBON_MEMORY.ref = CARBON_MEMORY
 
 logger.org-apache-axis2-clustering.name = org.apache.axis2.clustering
 logger.org-apache-axis2-clustering.level = INFO
@@ -361,7 +342,6 @@ logger.org-apache.name = org.apache
 logger.org-apache.level = INFO
 logger.org-apache.additivity = false
 logger.org-apache.appenderRef.CARBON_LOGFILE.ref = CARBON_LOGFILE
-logger.org-apache.appenderRef.CARBON_MEMORY.ref = CARBON_MEMORY
 
 logger.org-apache-catalina.name = org.apache.catalina
 logger.org-apache-catalina.level = WARN
@@ -428,48 +408,39 @@ logger.org-wso2.level = INFO
 logger.org-apache-axis-enterprise.name = org.apache.axis2.enterprise
 logger.org-apache-axis-enterprise.level = FATAL
 logger.org-apache-axis-enterprise.appenderRef.CARBON_LOGFILE.ref = CARBON_LOGFILE
-logger.org-apache-axis-enterprise.appenderRef.CARBON_MEMORY.ref = CARBON_MEMORY
 
 logger.org-apache-directory-shared-ldap.name = org.apache.directory.shared.ldap
 logger.org-apache-directory-shared-ldap.level = WARN
 logger.org-apache-directory-shared-ldap.appenderRef.CARBON_LOGFILE.ref = CARBON_LOGFILE
-logger.org-apache-directory-shared-ldap.appenderRef.CARBON_MEMORY.ref = CARBON_MEMORY
 
 logger.org-apache-directory-server-ldap-handlers.name = org.apache.directory.server.ldap.handlers
 logger.org-apache-directory-server-ldap-handlers.level = WARN
 logger.org-apache-directory-server-ldap-handlers.appenderRef.CARBON_LOGFILE.ref = CARBON_LOGFILE
-logger.org-apache-directory-server-ldap-handlers.appenderRef.CARBON_MEMORY.ref = CARBON_MEMORY
 
 #Following are to remove false error messages from startup (IS)
 logger.org-apache-directory-shared-ldap-entry-DefaultServerAttribute.name = org.apache.directory.shared.ldap.entry.DefaultServerAttribute
 logger.org-apache-directory-shared-ldap-entry-DefaultServerAttribute.level = FATAL
 logger.org-apache-directory-shared-ldap-entry-DefaultServerAttribute.appenderRef.CARBON_LOGFILE.ref = CARBON_LOGFILE
-logger.org-apache-directory-shared-ldap-entry-DefaultServerAttribute.appenderRef.CARBON_MEMORY.ref = CARBON_MEMORY
 
 logger.org-apache-directory-server-core-DefaultDirectoryService.name = org.apache.directory.server.core.DefaultDirectoryService
 logger.org-apache-directory-server-core-DefaultDirectoryService.level = ERROR
 logger.org-apache-directory-server-core-DefaultDirectoryService.appenderRef.CARBON_LOGFILE.ref = CARBON_LOGFILE
-logger.org-apache-directory-server-core-DefaultDirectoryService.appenderRef.CARBON_MEMORY.ref = CARBON_MEMORY
 
 logger.org-apache-directory-shared-ldap-ldif-LdifReader.name = org.apache.directory.shared.ldap.ldif.LdifReader
 logger.org-apache-directory-shared-ldap-ldif-LdifReader.level = ERROR
 logger.org-apache-directory-shared-ldap-ldif-LdifReader.appenderRef.CARBON_LOGFILE.ref = CARBON_LOGFILE
-logger.org-apache-directory-shared-ldap-ldif-LdifReader.appenderRef.CARBON_MEMORY.ref = CARBON_MEMORY
 
 logger.org-apache-directory-server-ldap-LdapProtocolHandler.name = org.apache.directory.server.ldap.LdapProtocolHandler
 logger.org-apache-directory-server-ldap-LdapProtocolHandler.level = ERROR
 logger.org-apache-directory-server-ldap-LdapProtocolHandler.appenderRef.CARBON_LOGFILE.ref = CARBON_LOGFILE
-logger.org-apache-directory-server-ldap-LdapProtocolHandler.appenderRef.CARBON_MEMORY.ref = CARBON_MEMORY
 
 logger.org-apache-directory-server-core.name = org.apache.directory.server.core
 logger.org-apache-directory-server-core.level = ERROR
 logger.org-apache-directory-server-core.appenderRef.CARBON_LOGFILE.ref = CARBON_LOGFILE
-logger.org-apache-directory-server-core.appenderRef.CARBON_MEMORY.ref = CARBON_MEMORY
 
 logger.org-apache-directory-server-ldap-LdapSession.name = org.apache.directory.server.ldap.LdapSession
 logger.org-apache-directory-server-ldap-LdapSession.level = Error
 logger.org-apache-directory-server-ldap-LdapSession.appenderRef.CARBON_LOGFILE.ref = CARBON_LOGFILE
-logger.org-apache-directory-server-ldap-LdapSession.appenderRef.CARBON_MEMORY.ref = CARBON_MEMORY
 
 logger.correlation.name = correlation
 logger.correlation.level = INFO
@@ -537,7 +508,6 @@ logger.StAXDialectDetector.level = ERROR
 rootLogger.level = INFO
 rootLogger.appenderRef.CARBON_CONSOLE.ref = CARBON_CONSOLE
 rootLogger.appenderRef.CARBON_LOGFILE.ref = CARBON_LOGFILE
-rootLogger.appenderRef.CARBON_MEMORY.ref = CARBON_MEMORY
 #rootLogger.appenderRef.syslog.ref = syslog
 
 logger.API_LOGGER_LogPrint.name = API_LOGGER.LogPrint


### PR DESCRIPTION
## Purpose
> This PR will remove the CARBON_MEMORY_APPENDER from the log4j2.properties file for tests.