### PR TITLE
Update data retention period for each table in EI analytics

### DIFF
--- a/features/org.wso2.ei.analytics.feature/src/main/capp/realtime/DataPurgingDay_1.0.0/artifact.xml
+++ b/features/org.wso2.ei.analytics.feature/src/main/capp/realtime/DataPurgingDay_1.0.0/artifact.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<artifact name="DataPurgingDay" version="1.0.0" type="analytics/dataPurging" serverRole="DataAnalyticsServer">
+    <file>data_purging_for_day.xml</file>
+</artifact>

--- a/features/org.wso2.ei.analytics.feature/src/main/capp/realtime/DataPurgingDay_1.0.0/data_purging_for_day.xml
+++ b/features/org.wso2.ei.analytics.feature/src/main/capp/realtime/DataPurgingDay_1.0.0/data_purging_for_day.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<analytics-data-purging>
+    <cron-expression>0 0 12 * * ?</cron-expression>
+    <purge-include-tables>
+        <table>ORG_WSO2_ESB_ANALYTICS_STREAM_STATPERDAY</table>
+        <table>ORG_WSO2_ESB_ANALYTICS_STREAM_MEDIATORSTATPERDAY</table>
+    </purge-include-tables>
+    <data-retention-days>45</data-retention-days>
+</analytics-data-purging>

--- a/features/org.wso2.ei.analytics.feature/src/main/capp/realtime/DataPurgingSecMinHour_1.0.0/artifact.xml
+++ b/features/org.wso2.ei.analytics.feature/src/main/capp/realtime/DataPurgingSecMinHour_1.0.0/artifact.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<artifact name="DataPurgingSecMinHour" version="1.0.0" type="analytics/dataPurging" serverRole="DataAnalyticsServer">
+    <file>data_purging_for_sec_min_hour.xml</file>
+</artifact>

--- a/features/org.wso2.ei.analytics.feature/src/main/capp/realtime/DataPurgingSecMinHour_1.0.0/data_purging_for_sec_min_hour.xml
+++ b/features/org.wso2.ei.analytics.feature/src/main/capp/realtime/DataPurgingSecMinHour_1.0.0/data_purging_for_sec_min_hour.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<analytics-data-purging>
+    <cron-expression>0 0 12 * * ?</cron-expression>
+    <purge-include-tables>
+        <table>ORG_WSO2_ESB_ANALYTICS_STREAM_STATPERSECOND</table>
+        <table>ORG_WSO2_ESB_ANALYTICS_STREAM_EVENT</table>
+        <table>ORG_WSO2_ESB_ANALYTICS_STREAM_STATPERSECONDALL</table>
+        <table>ORG_WSO2_ESB_ANALYTICS_STREAM_STATPERMINUTE</table>
+        <table>ORG_WSO2_ESB_ANALYTICS_STREAM_STATPERMINUTEALL</table>
+        <table>ORG_WSO2_ESB_ANALYTICS_STREAM_STATPERHOUR</table>
+        <table>ORG_WSO2_ESB_ANALYTICS_STREAM_MEDIATORSTATPERSECOND</table>
+        <table>ORG_WSO2_ESB_ANALYTICS_STREAM_MEDIATORSTATPERMINUTE</table>
+        <table>ORG_WSO2_ESB_ANALYTICS_STREAM_MEDIATORSTATPERHOUR</table>
+    </purge-include-tables>
+    <data-retention-days>2</data-retention-days>
+</analytics-data-purging>

--- a/features/org.wso2.ei.analytics.feature/src/main/capp/realtime/artifacts.xml
+++ b/features/org.wso2.ei.analytics.feature/src/main/capp/realtime/artifacts.xml
@@ -36,5 +36,8 @@
         <dependency artifact="GadgetMediatorProperties" version="1.0.0" include="true" serverRole="DataAnalyticsServer"/>
         <!-- Dashboard Definition -->
         <dependency artifact="Dashboard" version="1.0.0" include="true" serverRole="DataAnalyticsServer"/>
+        <!-- Data Purging -->
+        <dependency artifact="DataPurgingDay" version="1.0.0" include="true" serverRole="DataAnalyticsServer"/>
+        <dependency artifact="DataPurgingSecMinHour" version="1.0.0" include="true" serverRole="DataAnalyticsServer"/>
     </artifact>
 </artifacts>

--- a/features/org.wso2.ei.analytics.feature/src/main/resources/DataPurgingDay_1.0.0/artifact.xml
+++ b/features/org.wso2.ei.analytics.feature/src/main/resources/DataPurgingDay_1.0.0/artifact.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<artifact name="DataPurgingDay" version="1.0.0" type="analytics/dataPurging" serverRole="DataAnalyticsServer">
+    <file>data_purging_for_day.xml</file>
+</artifact>

--- a/features/org.wso2.ei.analytics.feature/src/main/resources/DataPurgingDay_1.0.0/data_purging_for_day.xml
+++ b/features/org.wso2.ei.analytics.feature/src/main/resources/DataPurgingDay_1.0.0/data_purging_for_day.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<analytics-data-purging>
+    <cron-expression>0 0 12 * * ?</cron-expression>
+    <purge-include-tables>
+        <table>ORG_WSO2_ESB_ANALYTICS_STREAM_STATPERDAY</table>
+        <table>ORG_WSO2_ESB_ANALYTICS_STREAM_MEDIATORSTATPERDAY</table>
+    </purge-include-tables>
+    <data-retention-days>45</data-retention-days>
+</analytics-data-purging>

--- a/features/org.wso2.ei.analytics.feature/src/main/resources/DataPurgingSecMinHour_1.0.0/artifact.xml
+++ b/features/org.wso2.ei.analytics.feature/src/main/resources/DataPurgingSecMinHour_1.0.0/artifact.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<artifact name="DataPurgingSecMinHour" version="1.0.0" type="analytics/dataPurging" serverRole="DataAnalyticsServer">
+    <file>data_purging_for_sec_min_hour.xml</file>
+</artifact>

--- a/features/org.wso2.ei.analytics.feature/src/main/resources/DataPurgingSecMinHour_1.0.0/data_purging_for_sec_min_hour.xml
+++ b/features/org.wso2.ei.analytics.feature/src/main/resources/DataPurgingSecMinHour_1.0.0/data_purging_for_sec_min_hour.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<analytics-data-purging>
+    <cron-expression>0 0 12 * * ?</cron-expression>
+    <purge-include-tables>
+        <table>ORG_WSO2_ESB_ANALYTICS_STREAM_STATPERSECOND</table>
+        <table>ORG_WSO2_ESB_ANALYTICS_STREAM_EVENT</table>
+        <table>ORG_WSO2_ESB_ANALYTICS_STREAM_STATPERSECONDALL</table>
+        <table>ORG_WSO2_ESB_ANALYTICS_STREAM_STATPERMINUTE</table>
+        <table>ORG_WSO2_ESB_ANALYTICS_STREAM_STATPERMINUTEALL</table>
+        <table>ORG_WSO2_ESB_ANALYTICS_STREAM_STATPERHOUR</table>
+        <table>ORG_WSO2_ESB_ANALYTICS_STREAM_MEDIATORSTATPERSECOND</table>
+        <table>ORG_WSO2_ESB_ANALYTICS_STREAM_MEDIATORSTATPERMINUTE</table>
+        <table>ORG_WSO2_ESB_ANALYTICS_STREAM_MEDIATORSTATPERHOUR</table>
+    </purge-include-tables>
+    <data-retention-days>2</data-retention-days>
+</analytics-data-purging>

--- a/features/org.wso2.ei.analytics.feature/src/main/resources/artifacts.xml
+++ b/features/org.wso2.ei.analytics.feature/src/main/resources/artifacts.xml
@@ -36,5 +36,8 @@
         <dependency artifact="GadgetMediatorProperties" version="1.0.0" include="true" serverRole="DataAnalyticsServer"/>
         <!-- Dashboard Definition -->
         <dependency artifact="Dashboard" version="1.0.0" include="true" serverRole="DataAnalyticsServer"/>
+        <!-- Data Purging -->
+        <dependency artifact="DataPurgingDay" version="1.0.0" include="true" serverRole="DataAnalyticsServer"/>
+        <dependency artifact="DataPurgingSecMinHour" version="1.0.0" include="true" serverRole="DataAnalyticsServer"/>
     </artifact>
 </artifacts>


### PR DESCRIPTION
Currently, Purging-Analytics-Data documentation guides to add global purging with a retention period of 2 days. But since purging is also done for day tables, it is better to increase the retention period in global configs.

Fix wso2/product-ei#4358
