### PR TITLE
Fix class loading issue with tomcat after upgrade

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -621,6 +621,14 @@
                 <version>${automation.framework.version}</version>
                 <exclusions>
                     <exclusion>
+                        <groupId>org.apache.tomcat.embed</groupId>
+                        <artifactId>tomcat-embed-core</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.apache.tomcat.embed</groupId>
+                        <artifactId>tomcat-embed-logging-juli</artifactId>
+                    </exclusion>
+                    <exclusion>
                         <groupId>org.apache.jmeter</groupId>
                         <artifactId>ApacheJMeter</artifactId>
                     </exclusion>


### PR DESCRIPTION
## Purpose

When running tests on jenkins following exception happens after the tomcat upgrade to 9.x.x.
Purpose is to fix that. 

```
java.lang.NoClassDefFoundError: org/apache/tomcat/util/http/CookieProcessor
	at java.lang.Class.forName0(Native Method)
	at java.lang.Class.forName(Class.java:264)
	at org.apache.catalina.startup.Tomcat.createContext(Tomcat.java:965)
	at org.apache.catalina.startup.Tomcat.addContext(Tomcat.java:662)
	at org.apache.catalina.startup.Tomcat.addContext(Tomcat.java:647)
	at org.apache.catalina.startup.Tomcat.addContext(Tomcat.java:335)
	at org.wso2.carbon.automation.extensions.servers.tomcatserver.TomcatServerManager.startJaxRsServer(TomcatServerManager.java:66)
	at org.wso2.carbon.automation.extensions.servers.tomcatserver.TomcatServerManager$1.run(TomcatServerManager.java:98)
Caused by: java.lang.ClassNotFoundException: org.apache.tomcat.util.http.CookieProcessor
	at java.net.URLClassLoader.findClass(URLClassLoader.java:381)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
	at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:335)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
	... 8 more
Caused by: java.lang.ClassNotFoundException: org.apache.tomcat.util.http.CookieProcessor
	at java.net.URLClassLoader.findClass(URLClassLoader.java:381)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
	at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:335)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
	... 8 more
```

