### PR TITLE
Define source version for product scnearios

### DIFF
--- a/product-scenarios/pom.xml
+++ b/product-scenarios/pom.xml
@@ -34,6 +34,16 @@
                 <artifactId>carbon-p2-plugin</artifactId>
                 <version>${carbon.p2.plugin.version}</version>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.2</version>
+                <configuration>
+                    <encoding>UTF-8</encoding>
+                    <source>1.7</source>
+                    <target>1.7</target>
+                </configuration>
+            </plugin>
         </plugins>
         <pluginManagement>
             <plugins>


### PR DESCRIPTION
## Purpose
>  Since the source version is inferred as 1.5 from transitive dependencies, test-grid builds are failing with following compilation failure.

```
[ERROR] /testgrid/testgrid-home/jobs/wum-sce-test-wso2esb-5.0.0-full/wum-sce-test-wso2esb-5.0.0-full_single-node-deployment_CentOS-7.5_Oracle-SE2-12.1_OPEN_JDK8_run39/workspace/ScenariosRepository/esb-scenarios/product-scenarios/scenarios-commons/src/main/java/org/wso2/carbon/esb/scenario/test/common/ScenarioTestBase.java:[285,13] try-with-resources is not supported in -source 1.5
[2019-10-22 07:54:02,904]  INFO {Shell} - [ERROR] (use -source 7 or higher to enable try-with-resources)
[2019-10-22 07:54:02,904]  INFO {Shell} - [ERROR] /testgrid/testgrid-home/jobs/wum-sce-test-wso2esb-5.0.0-full/wum-sce-test-wso2esb-5.0.0-full_single-node-deployment_CentOS-7.5_Oracle-SE2-12.1_OPEN_JDK8_run39/workspace/ScenariosRepository/esb-scenarios/product-scenarios/scenarios-commons/src/main/java/org/wso2/carbon/esb/scenario/test/common/ScenarioTestBase.java:[355,60] diamond operator is not supported in -source 1.5
[2019-10-22 07:54:02,904]  INFO {Shell} - [ERROR] (use -source 7 or higher to enable diamond operator)
[2019-10-22 07:54:02,904]  INFO {Shell} - [ERROR] /testgrid/testgrid-home/jobs/wum-sce-test-wso2esb-5.0.0-full/wum-sce-test-wso2esb-5.0.0-full_single-node-deployment_CentOS-7.5_Oracle-SE2-12.1_OPEN_JDK8_run39/workspace/ScenariosRepository/esb-scenarios/product-scenarios/scenarios-commons/src/main/java/org/wso2/carbon/esb/scenario/test/common/testng/listeners/TestPrepExecutionListener.java:[95,38] multi-catch statement is not supported in -source 1.5
[2019-10-22 07:54:02,904]  INFO {Shell} - [ERROR] (use -source 7 or higher to enable multi-catch statement)
[2019-10-22 07:54:02,904]  INFO {Shell} - [ERROR] /testgrid/testgrid-home/jobs/wum-sce-test-wso2esb-5.0.0-full/wum-sce-test-wso2esb-5.0.0-full_single-node-deployment_CentOS-7.5_Oracle-SE2-12.1_OPEN_JDK8_run39/workspace/ScenariosRepository/esb-scenarios/product-scenarios/scenarios-commons/src/main/java/org/wso2/carbon/esb/scenario/test/common/ftp/FTPClientWrapper.java:[94,13] try-with-resources is not supported in -source 1.5
[2019-10-22 07:54:02,904]  INFO {Shell} - [ERROR] (use -source 7 or higher to enable try-with-resources)
[2019-10-22 07:54:02,904]  INFO {Shell} - [ERROR] /testgrid/testgrid-home/jobs/wum-sce-test-wso2esb-5.0.0-full/wum-sce-test-wso2esb-5.0.0-full_single-node-deployment_CentOS-7.5_Oracle-SE2-12.1_OPEN_JDK8_run39/workspace/ScenariosRepository/esb-scenarios/product-scenarios/scenarios-commons/src/main/java/org/wso2/carbon/esb/scenario/test/common/ftp/FTPClientWrapper.java:[161,45] diamond operator is not supported in -source 1.5
```

