### PR TITLE
Remove duplicate wire logging for bps

### DIFF
--- a/distribution/src/business-process/conf/log4j2.properties
+++ b/distribution/src/business-process/conf/log4j2.properties
@@ -322,6 +322,9 @@ logger.org-apache-tiles.level = WARN
 logger.org-apache-commons-httpclient.name = org.apache.commons.httpclient
 logger.org-apache-commons-httpclient.level = ERROR
 
+logger.httpclient-wire-content.name=org.apache.http.wire
+logger.httpclient-wire-content.level=DEBUG
+
 logger.org-apache-solr.name = org.apache.solr
 logger.org-apache-solr.level = ERROR
 


### PR DESCRIPTION
## Purpose
> This PR will fix the duplicate wire log entries recorded in the log file of bps. To enable the wirelogs of bps we need to add the following log4j2 configuration and register the respective logger.
```
logger.httpclient-wire-content.name=org.apache.http.wire
logger.httpclient-wire-content.level=DEBUG
```
Fixes : https://github.com/wso2/product-ei/issues/4571