### PR TITLE
Implement migrator for message processor tasks

### DIFF
--- a/migration/migration-service/pom.xml
+++ b/migration/migration-service/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.wso2.ei</groupId>
         <artifactId>wso2ei-parent</artifactId>
-        <version>6.5.0-m7-SNAPSHOT</version>
+        <version>6.6.0-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 
@@ -62,7 +62,7 @@
                     <execution>
                         <id>generate-scr-scrdescriptor</id>
                         <goals>
-                            <goal>scr</goal>
+                            <goal>generate</goal>
                         </goals>
                     </execution>
                 </executions>
@@ -70,6 +70,7 @@
             <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
+                <version>${maven.bundle.plugin.version}</version>
                 <extensions>true</extensions>
                 <configuration>
                     <instructions>

--- a/migration/migration-service/src/main/java/org/wso2/carbon/ei/migration/migrate/MigrationClientConfig.java
+++ b/migration/migration-service/src/main/java/org/wso2/carbon/ei/migration/migrate/MigrationClientConfig.java
@@ -67,10 +67,11 @@ public class MigrationClientConfig {
         }
         try (InputStream in = new FileInputStream(dataSourceFile)) {
             properties.load(in);
-            if (new File(properties.getProperty(MigrationConstants.KEYSTORE_LOCATION)).exists()) {
-                return properties;
-            } else {
+            if (System.getProperty("migrate.from.product.version").startsWith("esb") &&
+                !new File(properties.getProperty(MigrationConstants.KEYSTORE_LOCATION)).exists()) {
                 throw new MigrationClientException("keystore file does not exist");
+            } else {
+                return properties;
             }
         } catch (IOException e) {
             throw new MigrationClientException("Error loading properties from a file at : " + migrationConfPath);

--- a/migration/migration-service/src/main/java/org/wso2/carbon/ei/migration/migrate/MigrationConstants.java
+++ b/migration/migration-service/src/main/java/org/wso2/carbon/ei/migration/migrate/MigrationConstants.java
@@ -30,4 +30,7 @@ public class MigrationConstants {
     public static final String KEYSTORE_PASSWORD = "keystore.identity.key.password";
     public static final String KEYSTORE_LOCATION = "keystore.identity.location";
     public static final String ADMIN_USERNAME = "admin.user.name";
+
+    public static final String ESB_TASK_PATH = "/_system/governance/repository/components/org.wso2.carbon.tasks/definitions/-1234/ESB_TASK/";
+    public static final String SCHEDULED_MP_TASK_PREFIX = "MSMP_";
 }

--- a/migration/migration-service/src/main/java/org/wso2/carbon/ei/migration/migrate/RegistryTaskDeletionClient.java
+++ b/migration/migration-service/src/main/java/org/wso2/carbon/ei/migration/migrate/RegistryTaskDeletionClient.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.wso2.carbon.ei.migration.migrate;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.ei.migration.internal.EIMigrationServiceDataHolder;
+import org.wso2.carbon.registry.core.CollectionImpl;
+import org.wso2.carbon.registry.core.Resource;
+import org.wso2.carbon.registry.core.exceptions.RegistryException;
+import org.wso2.carbon.registry.core.session.UserRegistry;
+
+/**
+ * This class delete tasks related to scheduled message processors from the registry
+ */
+public class RegistryTaskDeletionClient {
+    private static final Log log = LogFactory.getLog(RegistryTaskDeletionClient.class);
+    private UserRegistry userRegistry;
+    private Resource userRegistryResource;
+
+    /**
+     * Default constructor
+     */
+    public RegistryTaskDeletionClient() {
+        String adminUserName = MigrationClientConfig.getInstance()
+                                                    .getMigrationConfiguration()
+                                                    .getProperty(MigrationConstants.ADMIN_USERNAME);
+
+        if (adminUserName.isEmpty()) {
+            throw new MigrationClientException("Invalid admin username");
+        }
+
+        try {
+            this.userRegistry = EIMigrationServiceDataHolder.getRegistryService().getRegistry(adminUserName);
+            this.userRegistryResource = userRegistry.get(MigrationConstants.ESB_TASK_PATH);
+        } catch (RegistryException e) {
+            throw new MigrationClientException("Error occurred while retrieving registry resources", e);
+        }
+    }
+
+    /**
+     * Delete tasks related to scheduled message processors from the registry
+     */
+    public void deleteRegistryTasks(){
+        try {
+            String[] tasks = ((CollectionImpl) userRegistryResource).getChildren();
+            for (String task : tasks) {
+                if (task.startsWith(MigrationConstants.ESB_TASK_PATH + MigrationConstants.SCHEDULED_MP_TASK_PREFIX)) {
+                    log.info("Deleting task : [-1234][ESB_TASK][" +
+                             task.substring(MigrationConstants.ESB_TASK_PATH.length()) + "]");
+                    userRegistry.delete(task);
+                }
+            }
+        } catch (RegistryException e) {
+            throw new MigrationClientException("Error occurred while deleting registry tasks", e);
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,7 @@
         <module>p2-profile</module>
         <module>distribution</module>
         <module>integration</module>
+        <module>migration/migration-service</module>
     </modules>
 
     <dependencyManagement>
@@ -1844,6 +1845,7 @@
 
         <!-- Maven Plugin Version -->
         <maven.build.helper.plugin.version>1.8</maven.build.helper.plugin.version>
+        <maven.bundle.plugin.version>3.2.0</maven.bundle.plugin.version>
         <maven.xmlbeans-maven-plugin.plugin.version>2.3.3</maven.xmlbeans-maven-plugin.plugin.version>
         <maven.docker.plugin.version>0.22.1</maven.docker.plugin.version>
         <maven.failsafe.plugin.version>2.22.0</maven.failsafe.plugin.version>


### PR DESCRIPTION
Fix https://github.com/wso2/product-ei/issues/4781

## Purpose
With the fix done for issue https://github.com/wso2/product-ei/issues/4689, where we change the name of the tasks scheduled for message processor, migrator is needed to delete existing tasks from the registry before migrating to EI 6.6.0.

## Approach
Improve already existing migrator to delete existing message processor tasks from the registry. 

## Related PRs
https://github.com/wso2-support/wso2-synapse/pull/685