### PR TITLE
Fix: https://github.com/wso2/product-ei/issues/5038

### DIFF
--- a/distribution/src/assembly/bin.xml
+++ b/distribution/src/assembly/bin.xml
@@ -947,7 +947,7 @@
 
         <fileSet>
             <directory>./src/resources</directory>
-            <outputDirectory>wso2ei-${pom.version}/lib</outputDirectory>
+            <outputDirectory>wso2ei-${pom.version}/wso2/lib</outputDirectory>
             <includes>
                 <include>**/Saxon-HE-9.5.1-8.jar</include>
             </includes>


### PR DESCRIPTION
## Purpose
Move saxon jar from lib to wso2/lib

Fixes: https://github.com/wso2/product-ei/issues/5038