### PR TITLE
Disable async message scenario

### DIFF
--- a/product-scenarios/11-Asynchronous-message-processing/11.1-Decoupling-interacting-parties-across-time-and-space/11.1.1-Decouple-parties-using-JMS/11.1.1.1-HTTP-ActiveMQ-HTTP/11.1.1.1.1-asynchronous-point-to-point-via-queue/src/test/resources/testng.xml
+++ b/product-scenarios/11-Asynchronous-message-processing/11.1-Decoupling-interacting-parties-across-time-and-space/11.1.1-Decouple-parties-using-JMS/11.1.1.1-HTTP-ActiveMQ-HTTP/11.1.1.1.1-asynchronous-point-to-point-via-queue/src/test/resources/testng.xml
@@ -24,9 +24,11 @@
         <!-- TestLoggingListener : Test listener to log test execution events -->
         <listener class-name="org.wso2.carbon.esb.scenario.test.common.testng.listeners.TestLoggingListener"/>
     </listeners>
-    <test name="ProxyService-Test" preserve-order="true" verbose="2" parallel="false">
+    <!-- This test is failing on testgrid environment. Hence, disable this to avoid creating CloudFormation stacks
+     until getting resolution in mail thread "Scenario Test Results for WUM Updates! #(546) - WSO2 TestGrid"-->
+    <!--<test name="ProxyService-Test" preserve-order="true" verbose="2" parallel="false">
         <classes>
             <class name="org.wso2.carbon.ei.scenario.test.AsyncHttpToHttpViaActiveMqQueueTest"/>
         </classes>
-    </test>
+    </test>-->
 </suite>


### PR DESCRIPTION

## Purpose
This test is failing on testgrid environment. Hence, disable this to avoid creating CloudFormation stacks
