### PR TITLE
Change test structure to run scenario tests on MI

### DIFF
--- a/product-scenarios/1-integrating-systems-that-communicate-in-heterogeneous-message-formats/01-SynapseConfigProject/pom.xml
+++ b/product-scenarios/1-integrating-systems-that-communicate-in-heterogeneous-message-formats/01-SynapseConfigProject/pom.xml
@@ -34,20 +34,6 @@
     <modules>
         <module>01-synapseConfigRegistry</module>
         <module>01-synapseConfig-filter</module>
+        <module>01-synapseConfigCompositeApplication</module>
     </modules>
-    <profiles>
-        <profile>
-            <id>profile_general</id>
-            <modules>
-                <module>01-synapseConfigCompositeApplication</module>
-            </modules>
-        </profile>
-        <profile>
-            <id>profile_490</id>
-            <modules>
-                <module>01-synapseConfigCompositeApplication_490</module>
-            </modules>
-        </profile>
-    </profiles>
-
 </project>

--- a/product-scenarios/1-integrating-systems-that-communicate-in-heterogeneous-message-formats/pom.xml
+++ b/product-scenarios/1-integrating-systems-that-communicate-in-heterogeneous-message-formats/pom.xml
@@ -31,15 +31,6 @@
     <name>Integrating Systems that Communicate in Heterogeneous Message Formats</name>
     <packaging>pom</packaging>
 
-    <modules>
-        <module>01-SynapseConfigProject</module>
-        <module>1.1-converting-soap-to-json</module>
-        <module>1.2-converting-pox-to-json</module>
-        <module>1.3-converting-json-to-soap</module>
-        <module>1.6-xml-message-enrichment</module>
-        <module>1.8-plaintext-message-enrichment</module>
-    </modules>
-
     <dependencies>
         <dependency>
             <groupId>org.wso2.ei</groupId>
@@ -50,6 +41,13 @@
     <profiles>
         <profile>
             <id>profile_general</id>
+            <modules>
+                <module>1.1-converting-soap-to-json</module>
+                <module>1.2-converting-pox-to-json</module>
+                <module>1.3-converting-json-to-soap</module>
+                <module>1.6-xml-message-enrichment</module>
+                <module>1.8-plaintext-message-enrichment</module>
+            </modules>
             <build>
                 <plugins>
                     <plugin>
@@ -102,7 +100,10 @@
             </build>
         </profile>
         <profile>
-            <id>profile_490</id>
+            <id>profile_artifacts</id>
+            <modules>
+                <module>01-SynapseConfigProject</module>
+            </modules>
             <build>
                 <plugins>
                     <plugin>
@@ -133,14 +134,14 @@
                                     <!-- Directory containing carbon applications -->
                                     <name>test.resources.carbonApplications.dir</name>
                                     <value>
-                                        ${basedir}/../../01-SynapseConfigProject/01-synapseConfigCompositeApplication_490/target/
+                                        ${basedir}/../../01-SynapseConfigProject/01-synapseConfigCompositeApplication/target/
                                     </value>
                                 </property>
                                 <property>
                                     <!-- Related carbon applications (comma separated) to deploy -->
                                     <name>test.resources.carbonApplications.list</name>
                                     <value>
-                                        01-synapseConfigCompositeApplication_490_1.0.0
+                                        01-synapseConfigCompositeApplication_1.0.0
                                     </value>
                                 </property>
                                 <property>

--- a/product-scenarios/1-integrating-systems-that-communicate-in-heterogeneous-message-formats/pom.xml
+++ b/product-scenarios/1-integrating-systems-that-communicate-in-heterogeneous-message-formats/pom.xml
@@ -37,7 +37,56 @@
             <artifactId>scenarios-commons</artifactId>
         </dependency>
     </dependencies>
-
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <argLine>-Xms512m -Xmx1024m -XX:MaxPermSize=128m</argLine>
+                    <disableXmlReport>false</disableXmlReport>
+                    <parallel>false</parallel>
+                    <suiteXmlFiles>
+                        <suiteXmlFile>${basedir}/src/test/resources/testng.xml</suiteXmlFile>
+                    </suiteXmlFiles>
+                    <systemProperties>
+                        <property>
+                            <!-- Common resource directory (eg: Key stores, certificates, etc.)-->
+                            <name>common.resources.dir</name>
+                            <value>
+                                ${basedir}/../../resources/
+                            </value>
+                        </property>
+                        <property>
+                            <!-- testcase specific  resources directory-->
+                            <name>test.resources.dir</name>
+                            <value>
+                                ${basedir}/src/test/resources/
+                            </value>
+                        </property>
+                        <property>
+                            <!-- Directory containing carbon applications -->
+                            <name>test.resources.carbonApplications.dir</name>
+                            <value>
+                                ${basedir}/../../01-SynapseConfigProject/01-synapseConfigCompositeApplication/target/
+                            </value>
+                        </property>
+                        <property>
+                            <!-- Related carbon applications (comma separated) to deploy -->
+                            <name>test.resources.carbonApplications.list</name>
+                            <value>
+                                01-synapseConfigCompositeApplication_1.0.0
+                            </value>
+                        </property>
+                        <property>
+                            <name>usedefaultlisteners</name>
+                            <value>false</value>
+                        </property>
+                    </systemProperties>
+                    <workingDirectory>${basedir}/target</workingDirectory>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
     <profiles>
         <profile>
             <id>profile_general</id>
@@ -48,112 +97,12 @@
                 <module>1.6-xml-message-enrichment</module>
                 <module>1.8-plaintext-message-enrichment</module>
             </modules>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <argLine>-Xms512m -Xmx1024m -XX:MaxPermSize=128m</argLine>
-                            <disableXmlReport>false</disableXmlReport>
-                            <parallel>false</parallel>
-                            <suiteXmlFiles>
-                                <suiteXmlFile>${basedir}/src/test/resources/testng.xml</suiteXmlFile>
-                            </suiteXmlFiles>
-                            <systemProperties>
-                                <property>
-                                    <!-- Common resource directory (eg: Key stores, certificates, etc.)-->
-                                    <name>common.resources.dir</name>
-                                    <value>
-                                        ${basedir}/../../resources/
-                                    </value>
-                                </property>
-                                <property>
-                                    <!-- testcase specific  resources directory-->
-                                    <name>test.resources.dir</name>
-                                    <value>
-                                        ${basedir}/src/test/resources/
-                                    </value>
-                                </property>
-                                <property>
-                                    <!-- Directory containing carbon applications -->
-                                    <name>test.resources.carbonApplications.dir</name>
-                                    <value>
-                                        ${basedir}/../../01-SynapseConfigProject/01-synapseConfigCompositeApplication/target/
-                                    </value>
-                                </property>
-                                <property>
-                                    <!-- Related carbon applications (comma separated) to deploy -->
-                                    <name>test.resources.carbonApplications.list</name>
-                                    <value>
-                                        01-synapseConfigCompositeApplication_1.0.0
-                                    </value>
-                                </property>
-                                <property>
-                                    <name>usedefaultlisteners</name>
-                                    <value>false</value>
-                                </property>
-                            </systemProperties>
-                            <workingDirectory>${basedir}/target</workingDirectory>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
         </profile>
         <profile>
             <id>profile_artifacts</id>
             <modules>
                 <module>01-SynapseConfigProject</module>
             </modules>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <argLine>-Xms512m -Xmx1024m -XX:MaxPermSize=128m</argLine>
-                            <disableXmlReport>false</disableXmlReport>
-                            <parallel>false</parallel>
-                            <suiteXmlFiles>
-                                <suiteXmlFile>${basedir}/src/test/resources/testng.xml</suiteXmlFile>
-                            </suiteXmlFiles>
-                            <systemProperties>
-                                <property>
-                                    <!-- Common resource directory (eg: Key stores, certificates, etc.)-->
-                                    <name>common.resources.dir</name>
-                                    <value>
-                                        ${basedir}/../../resources/
-                                    </value>
-                                </property>
-                                <property>
-                                    <!-- testcase specific  resources directory-->
-                                    <name>test.resources.dir</name>
-                                    <value>
-                                        ${basedir}/src/test/resources/
-                                    </value>
-                                </property>
-                                <property>
-                                    <!-- Directory containing carbon applications -->
-                                    <name>test.resources.carbonApplications.dir</name>
-                                    <value>
-                                        ${basedir}/../../01-SynapseConfigProject/01-synapseConfigCompositeApplication/target/
-                                    </value>
-                                </property>
-                                <property>
-                                    <!-- Related carbon applications (comma separated) to deploy -->
-                                    <name>test.resources.carbonApplications.list</name>
-                                    <value>
-                                        01-synapseConfigCompositeApplication_1.0.0
-                                    </value>
-                                </property>
-                                <property>
-                                    <name>usedefaultlisteners</name>
-                                    <value>false</value>
-                                </property>
-                            </systemProperties>
-                            <workingDirectory>${basedir}/target</workingDirectory>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
         </profile>
     </profiles>
 </project>

--- a/product-scenarios/14-periodically-execute-an-integration-process/pom.xml
+++ b/product-scenarios/14-periodically-execute-an-integration-process/pom.xml
@@ -30,67 +30,70 @@
 
     <artifactId>14-periodically-execute-an-integration-process</artifactId>
     <packaging>pom</packaging>
-
-    <modules>
-        <module>14-synapseConfigProject</module>
-        <module>14-test-commons</module>
-        <!--Commented until https://github.com/wso2/product-ei/issues/3841 is fixed-->
-        <!--<module>14.1-scheduling-task-to-invoke-mediation-flow</module>-->
-        <!--<module>14.2-scheduling-a-customized-java-task</module>-->
-    </modules>
-    <build>
-        <plugins>
-            <plugin>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <inherited>true</inherited>
-                <configuration>
-                    <argLine>-Xms512m -Xmx1024m -XX:MaxPermSize=128m</argLine>
-                    <disableXmlReport>false</disableXmlReport>
-                    <parallel>false</parallel>
-                    <suiteXmlFiles>
-                        <suiteXmlFile>${basedir}/src/test/resources/testng.xml</suiteXmlFile>
-                    </suiteXmlFiles>
-                    <systemProperties>
-                        <property>
-                            <!-- Common resource directory (eg: Key stores, certificates, etc.)-->
-                            <name>common.resources.dir</name>
-                            <value>
-                                ${basedir}/../../resources/
-                            </value>
-                        </property>
-                        <property>
-                            <!-- testcase specific  resources directory-->
-                            <name>test.resources.dir</name>
-                            <value>
-                                ${basedir}/src/test/resources/
-                            </value>
-                        </property>
-                        <property>
-                            <!-- Directory containing carbon applications -->
-                            <name>test.resources.carbonApplications.dir</name>
-                            <value>
-                                ${basedir}/../../14-synapseConfigProject/14-synapseConfigCompositeApplication/target/
-                            </value>
-                        </property>
-                        <property>
-                            <!-- Related carbon applications (comma separated) to deploy -->
-                            <name>test.resources.carbonApplications.list</name>
-                            <value>14-synapseConfigCompositeApplication_1.0.0</value>
-                        </property>
-                        <property>
-                            <name>usedefaultlisteners</name>
-                            <value>false</value>
-                        </property>
-                        <sec.verifier.dir>${basedir}/target/security-verifier/</sec.verifier.dir>
-                        <maven.test.haltafterfailure>false</maven.test.haltafterfailure>
-                        <instr.file>${basedir}/coverage-report/instrumentation.txt</instr.file>
-                        <filters.file>${basedir}/coverage-report/filters.txt</filters.file>
-                    </systemProperties>
-                    <workingDirectory>${basedir}/target</workingDirectory>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
+    <profiles>
+        <profile>
+            <id>profile_general</id>
+            <modules>
+                <module>14-test-commons</module>
+                <!--Commented until https://github.com/wso2/product-ei/issues/3841 is fixed-->
+                <!--<module>14.1-scheduling-task-to-invoke-mediation-flow</module>-->
+                <!--<module>14.2-scheduling-a-customized-java-task</module>-->
+            </modules>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <inherited>true</inherited>
+                        <configuration>
+                            <argLine>-Xms512m -Xmx1024m -XX:MaxPermSize=128m</argLine>
+                            <disableXmlReport>false</disableXmlReport>
+                            <parallel>false</parallel>
+                            <suiteXmlFiles>
+                                <suiteXmlFile>${basedir}/src/test/resources/testng.xml</suiteXmlFile>
+                            </suiteXmlFiles>
+                            <systemProperties>
+                                <property>
+                                    <!-- Common resource directory (eg: Key stores, certificates, etc.)-->
+                                    <name>common.resources.dir</name>
+                                    <value>
+                                        ${basedir}/../../resources/
+                                    </value>
+                                </property>
+                                <property>
+                                    <!-- testcase specific  resources directory-->
+                                    <name>test.resources.dir</name>
+                                    <value>
+                                        ${basedir}/src/test/resources/
+                                    </value>
+                                </property>
+                                <property>
+                                    <!-- Directory containing carbon applications -->
+                                    <name>test.resources.carbonApplications.dir</name>
+                                    <value>
+                                        ${basedir}/../../14-synapseConfigProject/14-synapseConfigCompositeApplication/target/
+                                    </value>
+                                </property>
+                                <property>
+                                    <!-- Related carbon applications (comma separated) to deploy -->
+                                    <name>test.resources.carbonApplications.list</name>
+                                    <value>14-synapseConfigCompositeApplication_1.0.0</value>
+                                </property>
+                                <property>
+                                    <name>usedefaultlisteners</name>
+                                    <value>false</value>
+                                </property>
+                                <sec.verifier.dir>${basedir}/target/security-verifier/</sec.verifier.dir>
+                                <maven.test.haltafterfailure>false</maven.test.haltafterfailure>
+                                <instr.file>${basedir}/coverage-report/instrumentation.txt</instr.file>
+                                <filters.file>${basedir}/coverage-report/filters.txt</filters.file>
+                            </systemProperties>
+                            <workingDirectory>${basedir}/target</workingDirectory>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
     <dependencies>
         <dependency>
             <groupId>org.wso2.ei</groupId>

--- a/product-scenarios/2-Bridging-systems-that-communicate-in-different-protocols/pom.xml
+++ b/product-scenarios/2-Bridging-systems-that-communicate-in-different-protocols/pom.xml
@@ -43,112 +43,12 @@
             <modules>
                 <module>2.1-http-to-http-protocol-translation</module>
             </modules>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <argLine>-Xms512m -Xmx1024m -XX:MaxPermSize=128m</argLine>
-                            <disableXmlReport>false</disableXmlReport>
-                            <parallel>false</parallel>
-                            <suiteXmlFiles>
-                                <suiteXmlFile>${basedir}/src/test/resources/testng.xml</suiteXmlFile>
-                            </suiteXmlFiles>
-                            <systemProperties>
-                                <property>
-                                    <!-- Common resource directory (eg: Key stores, certificates, etc.)-->
-                                    <name>common.resources.dir</name>
-                                    <value>
-                                        ${basedir}/../../resources/
-                                    </value>
-                                </property>
-                                <property>
-                                    <!-- testcase specific  resources directory-->
-                                    <name>test.resources.dir</name>
-                                    <value>
-                                        ${basedir}/src/test/resources/
-                                    </value>
-                                </property>
-                                <property>
-                                    <!-- Directory containing carbon applications -->
-                                    <name>test.resources.carbonApplications.dir</name>
-                                    <value>
-                                        ${basedir}/../../02-synapseConfigProject/02-synapseConfigCompositeApplication/target/
-                                    </value>
-                                </property>
-                                <property>
-                                    <!-- Related carbon applications (comma separated) to deploy -->
-                                    <name>test.resources.carbonApplications.list</name>
-                                    <value>
-                                        02-synapseConfigCompositeApplication_1.0.0
-                                    </value>
-                                </property>
-                                <property>
-                                    <name>usedefaultlisteners</name>
-                                    <value>false</value>
-                                </property>
-                            </systemProperties>
-                            <workingDirectory>${basedir}/target</workingDirectory>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
         </profile>
         <profile>
             <id>profile_artifacts</id>
             <modules>
                 <module>02-synapseConfigProject</module>
             </modules>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <argLine>-Xms512m -Xmx1024m -XX:MaxPermSize=128m</argLine>
-                            <disableXmlReport>false</disableXmlReport>
-                            <parallel>false</parallel>
-                            <suiteXmlFiles>
-                                <suiteXmlFile>${basedir}/src/test/resources/testng.xml</suiteXmlFile>
-                            </suiteXmlFiles>
-                            <systemProperties>
-                                <property>
-                                    <!-- Common resource directory (eg: Key stores, certificates, etc.)-->
-                                    <name>common.resources.dir</name>
-                                    <value>
-                                        ${basedir}/../../resources/
-                                    </value>
-                                </property>
-                                <property>
-                                    <!-- testcase specific  resources directory-->
-                                    <name>test.resources.dir</name>
-                                    <value>
-                                        ${basedir}/src/test/resources/
-                                    </value>
-                                </property>
-                                <property>
-                                    <!-- Directory containing carbon applications -->
-                                    <name>test.resources.carbonApplications.dir</name>
-                                    <value>
-                                        ${basedir}/../../02-synapseConfigProject/02-synapseConfigCompositeApplication/target/
-                                    </value>
-                                </property>
-                                <property>
-                                    <!-- Related carbon applications (comma separated) to deploy -->
-                                    <name>test.resources.carbonApplications.list</name>
-                                    <value>
-                                        02-synapseConfigCompositeApplication_1.0.0
-                                    </value>
-                                </property>
-                                <property>
-                                    <name>usedefaultlisteners</name>
-                                    <value>false</value>
-                                </property>
-                            </systemProperties>
-                            <workingDirectory>${basedir}/target</workingDirectory>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
         </profile>
     </profiles>
 
@@ -161,14 +61,14 @@
                     <disableXmlReport>false</disableXmlReport>
                     <parallel>false</parallel>
                     <suiteXmlFiles>
-                        <suiteXmlFile>src/test/resources/testng.xml</suiteXmlFile>
+                        <suiteXmlFile>${basedir}/src/test/resources/testng.xml</suiteXmlFile>
                     </suiteXmlFiles>
                     <systemProperties>
                         <property>
                             <!-- Common resource directory (eg: Key stores, certificates, etc.)-->
                             <name>common.resources.dir</name>
                             <value>
-                                ${basedir}/../../../resources/
+                                ${basedir}/../../resources/
                             </value>
                         </property>
                         <property>
@@ -182,7 +82,7 @@
                             <!-- Directory containing carbon applications -->
                             <name>test.resources.carbonApplications.dir</name>
                             <value>
-                                ${basedir}/../../../../02-SynapseConfigProject/02-synapseConfigCompositeApplication/target/
+                                ${basedir}/../../02-synapseConfigProject/02-synapseConfigCompositeApplication/target/
                             </value>
                         </property>
                         <property>

--- a/product-scenarios/2-Bridging-systems-that-communicate-in-different-protocols/pom.xml
+++ b/product-scenarios/2-Bridging-systems-that-communicate-in-different-protocols/pom.xml
@@ -30,11 +30,6 @@
     <artifactId>2-Bridging-systems-that-communicate-in-different-protocols</artifactId>
     <packaging>pom</packaging>
 
-    <modules>
-        <module>02-synapseConfigProject</module>
-        <module>2.1-http-to-http-protocol-translation</module>
-    </modules>
-
     <dependencies>
         <dependency>
             <groupId>org.wso2.ei</groupId>
@@ -45,6 +40,65 @@
     <profiles>
         <profile>
             <id>profile_general</id>
+            <modules>
+                <module>2.1-http-to-http-protocol-translation</module>
+            </modules>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <argLine>-Xms512m -Xmx1024m -XX:MaxPermSize=128m</argLine>
+                            <disableXmlReport>false</disableXmlReport>
+                            <parallel>false</parallel>
+                            <suiteXmlFiles>
+                                <suiteXmlFile>${basedir}/src/test/resources/testng.xml</suiteXmlFile>
+                            </suiteXmlFiles>
+                            <systemProperties>
+                                <property>
+                                    <!-- Common resource directory (eg: Key stores, certificates, etc.)-->
+                                    <name>common.resources.dir</name>
+                                    <value>
+                                        ${basedir}/../../resources/
+                                    </value>
+                                </property>
+                                <property>
+                                    <!-- testcase specific  resources directory-->
+                                    <name>test.resources.dir</name>
+                                    <value>
+                                        ${basedir}/src/test/resources/
+                                    </value>
+                                </property>
+                                <property>
+                                    <!-- Directory containing carbon applications -->
+                                    <name>test.resources.carbonApplications.dir</name>
+                                    <value>
+                                        ${basedir}/../../02-synapseConfigProject/02-synapseConfigCompositeApplication/target/
+                                    </value>
+                                </property>
+                                <property>
+                                    <!-- Related carbon applications (comma separated) to deploy -->
+                                    <name>test.resources.carbonApplications.list</name>
+                                    <value>
+                                        02-synapseConfigCompositeApplication_1.0.0
+                                    </value>
+                                </property>
+                                <property>
+                                    <name>usedefaultlisteners</name>
+                                    <value>false</value>
+                                </property>
+                            </systemProperties>
+                            <workingDirectory>${basedir}/target</workingDirectory>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>profile_artifacts</id>
+            <modules>
+                <module>02-synapseConfigProject</module>
+            </modules>
             <build>
                 <plugins>
                     <plugin>

--- a/product-scenarios/4-gateway/pom.xml
+++ b/product-scenarios/4-gateway/pom.xml
@@ -31,61 +31,120 @@
     <artifactId>4-gateway</artifactId>
 
     <packaging>pom</packaging>
-
-    <modules>
-        <module>04-SynapseConfigProject/04-synapseConfig</module>
-        <module>04-SynapseConfigProject/04-synapseConfigRegistry</module>
-        <module>04-SynapseConfigProject/04-synapseConfigCompositeApplication</module>
-        <module>4.1-Extend-the-reach-for-existing-or-legacy-applications</module>
-    </modules>
-    <build>
-        <plugins>
-            <plugin>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <argLine>-Xms512m -Xmx1024m -XX:MaxPermSize=128m</argLine>
-                    <disableXmlReport>false</disableXmlReport>
-                    <parallel>false</parallel>
-                    <suiteXmlFiles>
-                        <suiteXmlFile>src/test/resources/testng.xml</suiteXmlFile>
-                    </suiteXmlFiles>
-                    <systemProperties>
-                        <property>
-                            <!-- Common resource directory (eg: Key stores, certificates, etc.)-->
-                            <name>common.resources.dir</name>
-                            <value>
-                                ${basedir}/../../../resources/
-                            </value>
-                        </property>
-                        <property>
-                            <!-- testcase specific  resources directory-->
-                            <name>test.resources.dir</name>
-                            <value>
-                                ${basedir}/src/test/resources/
-                            </value>
-                        </property>
-                        <property>
-                            <!-- Directory containing carbon applications -->
-                            <name>test.resources.carbonApplications.dir</name>
-                            <value>
-                                ${basedir}/../../../04-SynapseConfigProject/04-synapseConfigCompositeApplication/target/
-                            </value>
-                        </property>
-                        <property>
-                            <!-- Related carbon applications (comma separated) to deploy -->
-                            <name>test.resources.carbonApplications.list</name>
-                            <value>
-                                04-synapseConfigCompositeApplication_1.0.0
-                            </value>
-                        </property>
-                        <property>
-                            <name>usedefaultlisteners</name>
-                            <value>false</value>
-                        </property>
-                    </systemProperties>
-                    <workingDirectory>${basedir}/target</workingDirectory>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
+    <profiles>
+        <profile>
+            <id>profile_general</id>
+            <modules>
+                <module>4.1-Extend-the-reach-for-existing-or-legacy-applications</module>
+            </modules>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <argLine>-Xms512m -Xmx1024m -XX:MaxPermSize=128m</argLine>
+                            <disableXmlReport>false</disableXmlReport>
+                            <parallel>false</parallel>
+                            <suiteXmlFiles>
+                                <suiteXmlFile>src/test/resources/testng.xml</suiteXmlFile>
+                            </suiteXmlFiles>
+                            <systemProperties>
+                                <property>
+                                    <!-- Common resource directory (eg: Key stores, certificates, etc.)-->
+                                    <name>common.resources.dir</name>
+                                    <value>
+                                        ${basedir}/../../../resources/
+                                    </value>
+                                </property>
+                                <property>
+                                    <!-- testcase specific  resources directory-->
+                                    <name>test.resources.dir</name>
+                                    <value>
+                                        ${basedir}/src/test/resources/
+                                    </value>
+                                </property>
+                                <property>
+                                    <!-- Directory containing carbon applications -->
+                                    <name>test.resources.carbonApplications.dir</name>
+                                    <value>
+                                        ${basedir}/../../../04-SynapseConfigProject/04-synapseConfigCompositeApplication/target/
+                                    </value>
+                                </property>
+                                <property>
+                                    <!-- Related carbon applications (comma separated) to deploy -->
+                                    <name>test.resources.carbonApplications.list</name>
+                                    <value>
+                                        04-synapseConfigCompositeApplication_1.0.0
+                                    </value>
+                                </property>
+                                <property>
+                                    <name>usedefaultlisteners</name>
+                                    <value>false</value>
+                                </property>
+                            </systemProperties>
+                            <workingDirectory>${basedir}/target</workingDirectory>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>profile_artifacts</id>
+            <modules>
+                <module>04-SynapseConfigProject/04-synapseConfig</module>
+                <module>04-SynapseConfigProject/04-synapseConfigRegistry</module>
+                <module>04-SynapseConfigProject/04-synapseConfigCompositeApplication</module>
+            </modules>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <argLine>-Xms512m -Xmx1024m -XX:MaxPermSize=128m</argLine>
+                            <disableXmlReport>false</disableXmlReport>
+                            <parallel>false</parallel>
+                            <suiteXmlFiles>
+                                <suiteXmlFile>src/test/resources/testng.xml</suiteXmlFile>
+                            </suiteXmlFiles>
+                            <systemProperties>
+                                <property>
+                                    <!-- Common resource directory (eg: Key stores, certificates, etc.)-->
+                                    <name>common.resources.dir</name>
+                                    <value>
+                                        ${basedir}/../../../resources/
+                                    </value>
+                                </property>
+                                <property>
+                                    <!-- testcase specific  resources directory-->
+                                    <name>test.resources.dir</name>
+                                    <value>
+                                        ${basedir}/src/test/resources/
+                                    </value>
+                                </property>
+                                <property>
+                                    <!-- Directory containing carbon applications -->
+                                    <name>test.resources.carbonApplications.dir</name>
+                                    <value>
+                                        ${basedir}/../../../04-SynapseConfigProject/04-synapseConfigCompositeApplication/target/
+                                    </value>
+                                </property>
+                                <property>
+                                    <!-- Related carbon applications (comma separated) to deploy -->
+                                    <name>test.resources.carbonApplications.list</name>
+                                    <value>
+                                        04-synapseConfigCompositeApplication_1.0.0
+                                    </value>
+                                </property>
+                                <property>
+                                    <name>usedefaultlisteners</name>
+                                    <value>false</value>
+                                </property>
+                            </systemProperties>
+                            <workingDirectory>${basedir}/target</workingDirectory>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/product-scenarios/4-gateway/pom.xml
+++ b/product-scenarios/4-gateway/pom.xml
@@ -31,62 +31,62 @@
     <artifactId>4-gateway</artifactId>
 
     <packaging>pom</packaging>
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <argLine>-Xms512m -Xmx1024m -XX:MaxPermSize=128m</argLine>
+                    <disableXmlReport>false</disableXmlReport>
+                    <parallel>false</parallel>
+                    <suiteXmlFiles>
+                        <suiteXmlFile>src/test/resources/testng.xml</suiteXmlFile>
+                    </suiteXmlFiles>
+                    <systemProperties>
+                        <property>
+                            <!-- Common resource directory (eg: Key stores, certificates, etc.)-->
+                            <name>common.resources.dir</name>
+                            <value>
+                                ${basedir}/../../../resources/
+                            </value>
+                        </property>
+                        <property>
+                            <!-- testcase specific  resources directory-->
+                            <name>test.resources.dir</name>
+                            <value>
+                                ${basedir}/src/test/resources/
+                            </value>
+                        </property>
+                        <property>
+                            <!-- Directory containing carbon applications -->
+                            <name>test.resources.carbonApplications.dir</name>
+                            <value>
+                                ${basedir}/../../../04-SynapseConfigProject/04-synapseConfigCompositeApplication/target/
+                            </value>
+                        </property>
+                        <property>
+                            <!-- Related carbon applications (comma separated) to deploy -->
+                            <name>test.resources.carbonApplications.list</name>
+                            <value>
+                                04-synapseConfigCompositeApplication_1.0.0
+                            </value>
+                        </property>
+                        <property>
+                            <name>usedefaultlisteners</name>
+                            <value>false</value>
+                        </property>
+                    </systemProperties>
+                    <workingDirectory>${basedir}/target</workingDirectory>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
     <profiles>
         <profile>
             <id>profile_general</id>
             <modules>
                 <module>4.1-Extend-the-reach-for-existing-or-legacy-applications</module>
             </modules>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <argLine>-Xms512m -Xmx1024m -XX:MaxPermSize=128m</argLine>
-                            <disableXmlReport>false</disableXmlReport>
-                            <parallel>false</parallel>
-                            <suiteXmlFiles>
-                                <suiteXmlFile>src/test/resources/testng.xml</suiteXmlFile>
-                            </suiteXmlFiles>
-                            <systemProperties>
-                                <property>
-                                    <!-- Common resource directory (eg: Key stores, certificates, etc.)-->
-                                    <name>common.resources.dir</name>
-                                    <value>
-                                        ${basedir}/../../../resources/
-                                    </value>
-                                </property>
-                                <property>
-                                    <!-- testcase specific  resources directory-->
-                                    <name>test.resources.dir</name>
-                                    <value>
-                                        ${basedir}/src/test/resources/
-                                    </value>
-                                </property>
-                                <property>
-                                    <!-- Directory containing carbon applications -->
-                                    <name>test.resources.carbonApplications.dir</name>
-                                    <value>
-                                        ${basedir}/../../../04-SynapseConfigProject/04-synapseConfigCompositeApplication/target/
-                                    </value>
-                                </property>
-                                <property>
-                                    <!-- Related carbon applications (comma separated) to deploy -->
-                                    <name>test.resources.carbonApplications.list</name>
-                                    <value>
-                                        04-synapseConfigCompositeApplication_1.0.0
-                                    </value>
-                                </property>
-                                <property>
-                                    <name>usedefaultlisteners</name>
-                                    <value>false</value>
-                                </property>
-                            </systemProperties>
-                            <workingDirectory>${basedir}/target</workingDirectory>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
         </profile>
         <profile>
             <id>profile_artifacts</id>
@@ -95,56 +95,6 @@
                 <module>04-SynapseConfigProject/04-synapseConfigRegistry</module>
                 <module>04-SynapseConfigProject/04-synapseConfigCompositeApplication</module>
             </modules>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <argLine>-Xms512m -Xmx1024m -XX:MaxPermSize=128m</argLine>
-                            <disableXmlReport>false</disableXmlReport>
-                            <parallel>false</parallel>
-                            <suiteXmlFiles>
-                                <suiteXmlFile>src/test/resources/testng.xml</suiteXmlFile>
-                            </suiteXmlFiles>
-                            <systemProperties>
-                                <property>
-                                    <!-- Common resource directory (eg: Key stores, certificates, etc.)-->
-                                    <name>common.resources.dir</name>
-                                    <value>
-                                        ${basedir}/../../../resources/
-                                    </value>
-                                </property>
-                                <property>
-                                    <!-- testcase specific  resources directory-->
-                                    <name>test.resources.dir</name>
-                                    <value>
-                                        ${basedir}/src/test/resources/
-                                    </value>
-                                </property>
-                                <property>
-                                    <!-- Directory containing carbon applications -->
-                                    <name>test.resources.carbonApplications.dir</name>
-                                    <value>
-                                        ${basedir}/../../../04-SynapseConfigProject/04-synapseConfigCompositeApplication/target/
-                                    </value>
-                                </property>
-                                <property>
-                                    <!-- Related carbon applications (comma separated) to deploy -->
-                                    <name>test.resources.carbonApplications.list</name>
-                                    <value>
-                                        04-synapseConfigCompositeApplication_1.0.0
-                                    </value>
-                                </property>
-                                <property>
-                                    <name>usedefaultlisteners</name>
-                                    <value>false</value>
-                                </property>
-                            </systemProperties>
-                            <workingDirectory>${basedir}/target</workingDirectory>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
         </profile>
     </profiles>
 </project>

--- a/product-scenarios/5-route-messages-between-systems/pom.xml
+++ b/product-scenarios/5-route-messages-between-systems/pom.xml
@@ -32,6 +32,60 @@
 
     <packaging>pom</packaging>
 
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <inherited>true</inherited>
+                <configuration>
+                    <argLine>-Xms512m -Xmx1024m -XX:MaxPermSize=128m</argLine>
+                    <disableXmlReport>false</disableXmlReport>
+                    <parallel>false</parallel>
+                    <suiteXmlFiles>
+                        <suiteXmlFile>${basedir}/src/test/resources/testng.xml</suiteXmlFile>
+                    </suiteXmlFiles>
+                    <systemProperties>
+                        <property>
+                            <!-- Common resource directory (eg: Key stores, certificates, etc.)-->
+                            <name>common.resources.dir</name>
+                            <value>
+                                ${basedir}/../../../resources/
+                            </value>
+                        </property>
+                        <property>
+                            <name>test.resources.dir</name>
+                            <value>
+                                ${basedir}/src/test/resources/
+                            </value>
+                        </property>
+                        <property>
+                            <name>usedefaultlisteners</name>
+                            <value>false</value>
+                        </property>
+                        <property>
+                            <!-- Directory containing carbon applications -->
+                            <name>test.resources.carbonApplications.dir</name>
+                            <value>
+                                ${basedir}/../../../05-synapseConfigProject/05-synapseConfigCompositeApplication/target
+                            </value>
+                        </property>
+                        <property>
+                            <!-- Related carbon applications (comma separated) to deploy -->
+                            <name>test.resources.carbonApplications.list</name>
+                            <value>
+                                05-synapseConfigCompositeApplication_1.0.0
+                            </value>
+                        </property>
+                        <sec.verifier.dir>${basedir}/target/security-verifier/</sec.verifier.dir>
+                        <maven.test.haltafterfailure>false</maven.test.haltafterfailure>
+                        <instr.file>${basedir}/coverage-report/instrumentation.txt</instr.file>
+                        <filters.file>${basedir}/coverage-report/filters.txt</filters.file>
+                    </systemProperties>
+                    <workingDirectory>${basedir}/target</workingDirectory>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
     <profiles>
         <profile>
             <id>profile_general</id>
@@ -39,120 +93,12 @@
                 <module>5.1-Route-based-on-the-content-of-the-messages</module>
                 <module>5.3-load-balance-messages-among-systems</module>
             </modules>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <inherited>true</inherited>
-                        <configuration>
-                            <argLine>-Xms512m -Xmx1024m -XX:MaxPermSize=128m</argLine>
-                            <disableXmlReport>false</disableXmlReport>
-                            <parallel>false</parallel>
-                            <suiteXmlFiles>
-                                <suiteXmlFile>${basedir}/src/test/resources/testng.xml</suiteXmlFile>
-                            </suiteXmlFiles>
-                            <systemProperties>
-                                <property>
-                                    <!-- Common resource directory (eg: Key stores, certificates, etc.)-->
-                                    <name>common.resources.dir</name>
-                                    <value>
-                                        ${basedir}/../../../resources/
-                                    </value>
-                                </property>
-                                <property>
-                                    <name>test.resources.dir</name>
-                                    <value>
-                                        ${basedir}/src/test/resources/
-                                    </value>
-                                </property>
-                                <property>
-                                    <name>usedefaultlisteners</name>
-                                    <value>false</value>
-                                </property>
-                                <property>
-                                    <!-- Directory containing carbon applications -->
-                                    <name>test.resources.carbonApplications.dir</name>
-                                    <value>
-                                        ${basedir}/../../../05-synapseConfigProject/05-synapseConfigCompositeApplication/target
-                                    </value>
-                                </property>
-                                <property>
-                                    <!-- Related carbon applications (comma separated) to deploy -->
-                                    <name>test.resources.carbonApplications.list</name>
-                                    <value>
-                                        05-synapseConfigCompositeApplication_1.0.0
-                                    </value>
-                                </property>
-                                <sec.verifier.dir>${basedir}/target/security-verifier/</sec.verifier.dir>
-                                <maven.test.haltafterfailure>false</maven.test.haltafterfailure>
-                                <instr.file>${basedir}/coverage-report/instrumentation.txt</instr.file>
-                                <filters.file>${basedir}/coverage-report/filters.txt</filters.file>
-                            </systemProperties>
-                            <workingDirectory>${basedir}/target</workingDirectory>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
         </profile>
         <profile>
             <id>profile_artifacts</id>
             <modules>
                 <module>05-synapseConfigProject</module>
             </modules>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <inherited>true</inherited>
-                        <configuration>
-                            <argLine>-Xms512m -Xmx1024m -XX:MaxPermSize=128m</argLine>
-                            <disableXmlReport>false</disableXmlReport>
-                            <parallel>false</parallel>
-                            <suiteXmlFiles>
-                                <suiteXmlFile>${basedir}/src/test/resources/testng.xml</suiteXmlFile>
-                            </suiteXmlFiles>
-                            <systemProperties>
-                                <property>
-                                    <!-- Common resource directory (eg: Key stores, certificates, etc.)-->
-                                    <name>common.resources.dir</name>
-                                    <value>
-                                        ${basedir}/../../../resources/
-                                    </value>
-                                </property>
-                                <property>
-                                    <name>test.resources.dir</name>
-                                    <value>
-                                        ${basedir}/src/test/resources/
-                                    </value>
-                                </property>
-                                <property>
-                                    <name>usedefaultlisteners</name>
-                                    <value>false</value>
-                                </property>
-                                <property>
-                                    <!-- Directory containing carbon applications -->
-                                    <name>test.resources.carbonApplications.dir</name>
-                                    <value>
-                                        ${basedir}/../../../05-synapseConfigProject/05-synapseConfigCompositeApplication/target
-                                    </value>
-                                </property>
-                                <property>
-                                    <!-- Related carbon applications (comma separated) to deploy -->
-                                    <name>test.resources.carbonApplications.list</name>
-                                    <value>
-                                        05-synapseConfigCompositeApplication_1.0.0
-                                    </value>
-                                </property>
-                                <sec.verifier.dir>${basedir}/target/security-verifier/</sec.verifier.dir>
-                                <maven.test.haltafterfailure>false</maven.test.haltafterfailure>
-                                <instr.file>${basedir}/coverage-report/instrumentation.txt</instr.file>
-                                <filters.file>${basedir}/coverage-report/filters.txt</filters.file>
-                            </systemProperties>
-                            <workingDirectory>${basedir}/target</workingDirectory>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
         </profile>
     </profiles>
 </project>

--- a/product-scenarios/5-route-messages-between-systems/pom.xml
+++ b/product-scenarios/5-route-messages-between-systems/pom.xml
@@ -32,65 +32,127 @@
 
     <packaging>pom</packaging>
 
-    <modules>
-        <module>05-synapseConfigProject</module>
-        <module>5.1-Route-based-on-the-content-of-the-messages</module>
-        <module>5.3-load-balance-messages-among-systems</module>
-    </modules>
-
-    <build>
-        <plugins>
-            <plugin>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <inherited>true</inherited>
-                <configuration>
-                    <argLine>-Xms512m -Xmx1024m -XX:MaxPermSize=128m</argLine>
-                    <disableXmlReport>false</disableXmlReport>
-                    <parallel>false</parallel>
-                    <suiteXmlFiles>
-                        <suiteXmlFile>${basedir}/src/test/resources/testng.xml</suiteXmlFile>
-                    </suiteXmlFiles>
-                    <systemProperties>
-                        <property>
-                            <!-- Common resource directory (eg: Key stores, certificates, etc.)-->
-                            <name>common.resources.dir</name>
-                            <value>
-                                ${basedir}/../../../resources/
-                            </value>
-                        </property>
-                        <property>
-                            <name>test.resources.dir</name>
-                            <value>
-                                ${basedir}/src/test/resources/
-                            </value>
-                        </property>
-                        <property>
-                            <name>usedefaultlisteners</name>
-                            <value>false</value>
-                        </property>
-                        <property>
-                            <!-- Directory containing carbon applications -->
-                            <name>test.resources.carbonApplications.dir</name>
-                            <value>
-                                ${basedir}/../../../05-synapseConfigProject/05-synapseConfigCompositeApplication/target
-                            </value>
-                        </property>
-                        <property>
-                            <!-- Related carbon applications (comma separated) to deploy -->
-                            <name>test.resources.carbonApplications.list</name>
-                            <value>
-                                05-synapseConfigCompositeApplication_1.0.0
-                            </value>
-                        </property>
-                        <sec.verifier.dir>${basedir}/target/security-verifier/</sec.verifier.dir>
-                        <maven.test.haltafterfailure>false</maven.test.haltafterfailure>
-                        <instr.file>${basedir}/coverage-report/instrumentation.txt</instr.file>
-                        <filters.file>${basedir}/coverage-report/filters.txt</filters.file>
-                    </systemProperties>
-                    <workingDirectory>${basedir}/target</workingDirectory>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
-    
+    <profiles>
+        <profile>
+            <id>profile_general</id>
+            <modules>
+                <module>5.1-Route-based-on-the-content-of-the-messages</module>
+                <module>5.3-load-balance-messages-among-systems</module>
+            </modules>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <inherited>true</inherited>
+                        <configuration>
+                            <argLine>-Xms512m -Xmx1024m -XX:MaxPermSize=128m</argLine>
+                            <disableXmlReport>false</disableXmlReport>
+                            <parallel>false</parallel>
+                            <suiteXmlFiles>
+                                <suiteXmlFile>${basedir}/src/test/resources/testng.xml</suiteXmlFile>
+                            </suiteXmlFiles>
+                            <systemProperties>
+                                <property>
+                                    <!-- Common resource directory (eg: Key stores, certificates, etc.)-->
+                                    <name>common.resources.dir</name>
+                                    <value>
+                                        ${basedir}/../../../resources/
+                                    </value>
+                                </property>
+                                <property>
+                                    <name>test.resources.dir</name>
+                                    <value>
+                                        ${basedir}/src/test/resources/
+                                    </value>
+                                </property>
+                                <property>
+                                    <name>usedefaultlisteners</name>
+                                    <value>false</value>
+                                </property>
+                                <property>
+                                    <!-- Directory containing carbon applications -->
+                                    <name>test.resources.carbonApplications.dir</name>
+                                    <value>
+                                        ${basedir}/../../../05-synapseConfigProject/05-synapseConfigCompositeApplication/target
+                                    </value>
+                                </property>
+                                <property>
+                                    <!-- Related carbon applications (comma separated) to deploy -->
+                                    <name>test.resources.carbonApplications.list</name>
+                                    <value>
+                                        05-synapseConfigCompositeApplication_1.0.0
+                                    </value>
+                                </property>
+                                <sec.verifier.dir>${basedir}/target/security-verifier/</sec.verifier.dir>
+                                <maven.test.haltafterfailure>false</maven.test.haltafterfailure>
+                                <instr.file>${basedir}/coverage-report/instrumentation.txt</instr.file>
+                                <filters.file>${basedir}/coverage-report/filters.txt</filters.file>
+                            </systemProperties>
+                            <workingDirectory>${basedir}/target</workingDirectory>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>profile_artifacts</id>
+            <modules>
+                <module>05-synapseConfigProject</module>
+            </modules>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <inherited>true</inherited>
+                        <configuration>
+                            <argLine>-Xms512m -Xmx1024m -XX:MaxPermSize=128m</argLine>
+                            <disableXmlReport>false</disableXmlReport>
+                            <parallel>false</parallel>
+                            <suiteXmlFiles>
+                                <suiteXmlFile>${basedir}/src/test/resources/testng.xml</suiteXmlFile>
+                            </suiteXmlFiles>
+                            <systemProperties>
+                                <property>
+                                    <!-- Common resource directory (eg: Key stores, certificates, etc.)-->
+                                    <name>common.resources.dir</name>
+                                    <value>
+                                        ${basedir}/../../../resources/
+                                    </value>
+                                </property>
+                                <property>
+                                    <name>test.resources.dir</name>
+                                    <value>
+                                        ${basedir}/src/test/resources/
+                                    </value>
+                                </property>
+                                <property>
+                                    <name>usedefaultlisteners</name>
+                                    <value>false</value>
+                                </property>
+                                <property>
+                                    <!-- Directory containing carbon applications -->
+                                    <name>test.resources.carbonApplications.dir</name>
+                                    <value>
+                                        ${basedir}/../../../05-synapseConfigProject/05-synapseConfigCompositeApplication/target
+                                    </value>
+                                </property>
+                                <property>
+                                    <!-- Related carbon applications (comma separated) to deploy -->
+                                    <name>test.resources.carbonApplications.list</name>
+                                    <value>
+                                        05-synapseConfigCompositeApplication_1.0.0
+                                    </value>
+                                </property>
+                                <sec.verifier.dir>${basedir}/target/security-verifier/</sec.verifier.dir>
+                                <maven.test.haltafterfailure>false</maven.test.haltafterfailure>
+                                <instr.file>${basedir}/coverage-report/instrumentation.txt</instr.file>
+                                <filters.file>${basedir}/coverage-report/filters.txt</filters.file>
+                            </systemProperties>
+                            <workingDirectory>${basedir}/target</workingDirectory>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/product-scenarios/deployment.properties
+++ b/product-scenarios/deployment.properties
@@ -1,8 +1,9 @@
-ESBHttpUrl=http://localhost:8280/
+ESBHttpUrl=http://localhost:8290/
 MgtConsoleUrl=https://localhost:9443/carbon
-ESBHttpsUrl=https://localhost:8243
+ESBHttpsUrl=https://localhost:8253
 CarbonServerUrl=https://localhost:9443/services
 StandaloneDeployment=true
 vfs.uri.hostname=localhost
 localVfsLocation=${user.home}
 ActiveMqHostname=localhost
+ProductVersion=MI-1.2.0

--- a/product-scenarios/pom.xml
+++ b/product-scenarios/pom.xml
@@ -74,22 +74,36 @@
         <activemq.client.version>5.15.8</activemq.client.version>
         <pax.logging.api.version>1.10.1</pax.logging.api.version>
     </properties>
-
-    <modules>
-        <module>scenarios-commons</module>
-        <module>1-integrating-systems-that-communicate-in-heterogeneous-message-formats</module>
-        <module>2-Bridging-systems-that-communicate-in-different-protocols</module>
-        <module>3-connecting-web-apis-cloud-services</module>
-        <module>4-gateway</module>
-        <module>5-route-messages-between-systems</module>
-        <module>7-connecting-with-packaged-applications</module>
-        <module>8-connect-devices-to-enterprise</module>
-        <!--TODO Scenario 10 is commented until VFS is supported-->
-        <!--<module>10-file-processing</module>-->
-        <!--<module>11-Asynchronous-message-processing</module>-->
-        <module>13-micro-services</module>
-        <module>14-periodically-execute-an-integration-process</module>
-    </modules>
+    <profiles>
+        <profile>
+            <id>profile_general</id>
+            <modules>
+                <module>scenarios-commons</module>
+                <module>1-integrating-systems-that-communicate-in-heterogeneous-message-formats</module>
+                <module>2-Bridging-systems-that-communicate-in-different-protocols</module>
+                <module>3-connecting-web-apis-cloud-services</module>
+                <module>4-gateway</module>
+                <module>5-route-messages-between-systems</module>
+                <module>7-connecting-with-packaged-applications</module>
+                <module>8-connect-devices-to-enterprise</module>
+                <!--TODO Scenario 10 is commented until VFS is supported-->
+                <!--<module>10-file-processing</module>-->
+                <!--<module>11-Asynchronous-message-processing</module>-->
+                <module>13-micro-services</module>
+                <module>14-periodically-execute-an-integration-process</module>
+            </modules>
+        </profile>
+        <profile>
+            <id>profile_artifacts</id>
+            <modules>
+                <module>scenarios-commons</module>
+                <module>1-integrating-systems-that-communicate-in-heterogeneous-message-formats</module>
+                <module>2-Bridging-systems-that-communicate-in-different-protocols</module>
+                <module>4-gateway</module>
+                <module>5-route-messages-between-systems</module>
+            </modules>
+        </profile>
+    </profiles>
 
     <repositories>
         <!-- WSO2 released artifact repository -->

--- a/product-scenarios/prepare_artifacts.sh
+++ b/product-scenarios/prepare_artifacts.sh
@@ -34,6 +34,11 @@ function runTestProfile()
     mvn clean install -Dmaven.repo.local="${INPUT_DIR}/m2" -Dinvocation.uuid="$UUID" -Ddata.bucket.location="${INPUT_DIR}" \
     -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=info -fae -B -f ./pom.xml \
      -P $1
+
+     rm -r -f ${HOME}/capps
+     mkdir -p ${HOME}/capps
+     find -iname '*-synapseConfigCompositeApplication_1.0.0.car' -exec cp {} ${HOME}/capps \;
+     rm -f ${HOME}/capps/1_6_10-synapseConfigCompositeApplication_1.0.0.car
 }
 
 optspec=":hiom-:"
@@ -88,7 +93,7 @@ echo "output directory : ${OUTPUT_DIR}"
 
 #export DATA_BUCKET_LOCATION=${INPUT_DIR}
 
-#=============== Execute Scenarios ===============================================
+#=============== Execute Artifact Generation ===============================================
 
 #generate uuid representing the test run
 UUID=$(uuidgen)
@@ -104,7 +109,7 @@ do
     case ${productVersion} in
         ESB-5.0.0|EI-6.0.0|EI-6.1.0|EI-6.1.1|EI-6.2.0|EI-6.3.0|EI-6.4.0|EI-6.5.0|EI-6.6.0|MI-1.2.0)
             echo "Executing tests for the product version: $productVersion"
-            runTestProfile profile_general ;;
+            runTestProfile profile_artifacts ;;
         *)
             echo "ERROR: Unknown product version: " ${productVersion} "read from deployment.properties. Aborting the execution.";;
     esac
@@ -115,7 +120,7 @@ done < "${INPUT_DIR}/deployment.properties"
 
 if ! $PRODUCT_VERSION_FOUND ; then
     echo "deployment.properties file does not contain the product version. Executing the default suite ."
-    runTestProfile profile_general
+    runTestProfile profile_artifacts
 fi
 
 #=============== Copy Surefire Reports ===========================================

--- a/product-scenarios/prepare_artifacts.sh
+++ b/product-scenarios/prepare_artifacts.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Copyright (c) 2018, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+# Copyright (c) 2020, WSO2 Inc. (http://wso2.com) All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -32,7 +32,7 @@ function usage()
 function runTestProfile()
 {
     mvn clean install -Dmaven.repo.local="${INPUT_DIR}/m2" -Dinvocation.uuid="$UUID" -Ddata.bucket.location="${INPUT_DIR}" \
-    -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=info -fae -B -f ./pom.xml \
+    -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -fae -B -f ./pom.xml \
      -P $1
 
      rm -r -f ${HOME}/capps

--- a/product-scenarios/scenarios-commons/src/main/java/org/wso2/carbon/esb/scenario/test/common/ScenarioTestBase.java
+++ b/product-scenarios/scenarios-commons/src/main/java/org/wso2/carbon/esb/scenario/test/common/ScenarioTestBase.java
@@ -104,7 +104,7 @@ public class ScenarioTestBase {
 
         // login
         AuthenticatorClient authenticatorClient = new AuthenticatorClient(backendURL);
-        sessionCookie = authenticatorClient.login("admin", "admin", getServerHost());
+//        sessionCookie = authenticatorClient.login("admin", "admin", getServerHost());
 
         log.info("Service URL: " + serviceURL + " | Secured Service URL: " + securedServiceURL);
         log.info("The Backend service URL : " + backendURL + ". session cookie: " + sessionCookie);

--- a/product-scenarios/scenarios-commons/src/main/java/org/wso2/carbon/esb/scenario/test/common/testng/listeners/TestPrepExecutionListener.java
+++ b/product-scenarios/scenarios-commons/src/main/java/org/wso2/carbon/esb/scenario/test/common/testng/listeners/TestPrepExecutionListener.java
@@ -79,7 +79,7 @@ public class TestPrepExecutionListener implements IExecutionListener {
             setKeyStoreProperties();
 
             // login
-            try {
+            /*try {
                 AuthenticatorClient authenticatorClient = new AuthenticatorClient(backendURL);
                 sessionCookie = authenticatorClient.login("admin", "admin", getServerHost(mgtConsoleUrl));
             } catch (Exception e) {
@@ -94,7 +94,7 @@ public class TestPrepExecutionListener implements IExecutionListener {
                 }
             } catch (RemoteException | ApplicationAdminExceptionException e) {
                 throw new RuntimeException("Error occurred while deploying carbon application : " + carbonAppListStr, e);
-            }
+            }*/
         }
     }
 

--- a/product-scenarios/scenarios-commons/src/main/java/org/wso2/carbon/esb/scenario/test/common/testng/listeners/TestPrepExecutionListener.java
+++ b/product-scenarios/scenarios-commons/src/main/java/org/wso2/carbon/esb/scenario/test/common/testng/listeners/TestPrepExecutionListener.java
@@ -77,24 +77,6 @@ public class TestPrepExecutionListener implements IExecutionListener {
             mgtConsoleUrl = ScenarioTestBase.getMgtConsoleURL();
 
             setKeyStoreProperties();
-
-            // login
-            /*try {
-                AuthenticatorClient authenticatorClient = new AuthenticatorClient(backendURL);
-                sessionCookie = authenticatorClient.login("admin", "admin", getServerHost(mgtConsoleUrl));
-            } catch (Exception e) {
-                throw new RuntimeException("Login failed", e);
-            }
-
-            try {
-                String[] cAppList = carbonAppListStr.split(",");
-                for (String cApp : cAppList) {
-                    // deploy carbon application
-                    deployCarbonApplication(cApp.trim());
-                }
-            } catch (RemoteException | ApplicationAdminExceptionException e) {
-                throw new RuntimeException("Error occurred while deploying carbon application : " + carbonAppListStr, e);
-            }*/
         }
     }
 

--- a/product-scenarios/test.sh
+++ b/product-scenarios/test.sh
@@ -32,7 +32,7 @@ function usage()
 function runTestProfile()
 {
     mvn clean install -Dmaven.repo.local="${INPUT_DIR}/m2" -Dinvocation.uuid="$UUID" -Ddata.bucket.location="${INPUT_DIR}" \
-    -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=info -fae -B -f ./pom.xml \
+    -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn -fae -B -f ./pom.xml \
      -P $1
 }
 


### PR DESCRIPTION
## Purpose
WSO2 Micro Integrator is slightly different from WSO2 Enterprise Integrator since it does not provide the admin services that are shipped with Enterprise Integrator. Since this, the scenario tests to be run against Micro Integrator should be done in a different way. To support that We have created a separate profile (profile_artifacts) to create all the artifacts Then copying them to the working directory. Also, TestPrepExecutionListener and ScenarioTestBase class are modified not to login and not to deploy C-Apps