### PR TITLE
Disable graceful Shutdown in EI integration tests

### DIFF
--- a/integration/mediation-tests/tests-mediator-1/src/test/resources/automation.xml
+++ b/integration/mediation-tests/tests-mediator-1/src/test/resources/automation.xml
@@ -272,6 +272,7 @@
                     <name>org.wso2.esb.integration.common.extensions.carbonserver.CarbonServerExtension</name>
                     <parameter name="-DportOffset" value="200" />
                     <parameter name="startupScript" value="integrator" />
+                    <parameter name="-DgracefulShutdown" value="false"></parameter>
                     <!--<parameter name="cmdArg" value="debug 5005" />-->
                 </class>
                 <class>

--- a/integration/mediation-tests/tests-mediator-2/src/test/resources/automation.xml
+++ b/integration/mediation-tests/tests-mediator-2/src/test/resources/automation.xml
@@ -269,6 +269,7 @@
                     <name>org.wso2.esb.integration.common.extensions.carbonserver.CarbonServerExtension</name>
                     <parameter name="-DportOffset" value="200" />
                     <parameter name="startupScript" value="integrator" />
+                    <parameter name="-DgracefulShutdown" value="false"></parameter>
                     <!--<parameter name="cmdArg" value="debug 5005" />-->
                 </class>
                 <class>

--- a/integration/mediation-tests/tests-other/src/test/resources/automation.xml
+++ b/integration/mediation-tests/tests-other/src/test/resources/automation.xml
@@ -269,6 +269,7 @@
                     <!--  Added for PrometheusStatisticsTest -->
                     <parameter name="-DenablePrometheusApi" value="true"/>
                     <parameter name="startupScript" value="integrator" />
+                    <parameter name="-DgracefulShutdown" value="false"></parameter>
                     <!--<parameter name="cmdArg" value="debug 5005" />-->
                 </class>
                 <class>

--- a/integration/mediation-tests/tests-patches/src/test/resources/automation.xml
+++ b/integration/mediation-tests/tests-patches/src/test/resources/automation.xml
@@ -284,6 +284,7 @@
                     <parameter name="-DportOffset" value="200" />
                     <parameter name="startupScript" value="integrator" />
                     <!--<parameter name="cmdArg" value="debug 5005" />-->
+                    <parameter name="-DgracefulShutdown" value="false"></parameter>
                 </class>
                 <class>
                     <name>org.wso2.carbon.integration.common.extensions.usermgt.UserPopulateExtension</name>

--- a/integration/mediation-tests/tests-sample/src/test/resources/automation.xml
+++ b/integration/mediation-tests/tests-sample/src/test/resources/automation.xml
@@ -267,6 +267,7 @@
                     <name>org.wso2.esb.integration.common.extensions.carbonserver.CarbonServerExtension</name>
                     <parameter name="-DportOffset" value="200" />
                     <parameter name="startupScript" value="integrator" />
+                    <parameter name="-DgracefulShutdown" value="false"></parameter>
                     <!--<parameter name="cmdArg" value="debug 5005" />-->
                 </class>
                 <class>

--- a/integration/mediation-tests/tests-service/src/test/resources/automation.xml
+++ b/integration/mediation-tests/tests-service/src/test/resources/automation.xml
@@ -269,6 +269,7 @@
                     <name>org.wso2.esb.integration.common.extensions.carbonserver.CarbonServerExtension</name>
                     <parameter name="-DportOffset" value="200" />
                     <parameter name="startupScript" value="integrator" />
+                    <parameter name="-DgracefulShutdown" value="false"></parameter>
                     <!--<parameter name="cmdArg" value="debug 5005" />-->
                 </class>
                 <class>

--- a/integration/mediation-tests/tests-transport/src/test/resources/automation.xml
+++ b/integration/mediation-tests/tests-transport/src/test/resources/automation.xml
@@ -282,6 +282,7 @@
                     <name>org.wso2.esb.integration.common.extensions.carbonserver.CarbonServerExtension</name>
                     <parameter name="-DportOffset" value="200" />
                     <parameter name="startupScript" value="integrator" />
+                    <parameter name="-DgracefulShutdown" value="false"></parameter>
                     <!--<parameter name="cmdArg" value="debug 5005" />-->
                 </class>
                 <class>


### PR DESCRIPTION
Related to https://github.com/wso2/wso2-synapse/pull/1478

## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

Graceful Shutdown feature will be added to EI with the following PR in synapse. wso2/wso2-synapse#1478
We need to disable this feature in Integration Tests, since it will take longer time to complete if this is enabled.
