### PR TITLE
Add smb2 feature for EI

### DIFF
--- a/distribution/src/conf/log4j2.properties
+++ b/distribution/src/conf/log4j2.properties
@@ -203,7 +203,7 @@ loggers = AUDIT_LOG, SERVICE_LOGGER, API_LOGGER, trace-messages, org-apache-coyo
       org-apache-directory-server-core, org-apache-directory-server-ldap-LdapSession, DataNucleus, Datastore, Datastore-Schema, \
       JPOX-Datastore, JPOX-Plugin, JPOX-MetaData, JPOX-Query, JPOX-General, JPOX-Enhancer, org-apache-hadoop-hive, hive, ExecMapper, \
       ExecReducer, net-sf-ehcache-config-ConfigurationFactory, axis2Deployment, equinox, tomcat2, StAXDialectDetector, \
-      org-apache-synapse, org-apache-axis2, org-apache-axis2-transport, org-wso2-carbon, synapse-transport-http-access
+      org-apache-synapse, org-apache-axis2, org-apache-axis2-transport, org-wso2-carbon, synapse-transport-http-access, SMBJ
 
 logger.org-apache-synapse.name=org.apache.synapse
 logger.org-apache-synapse.level=INFO
@@ -447,6 +447,9 @@ logger.tomcat2.level = FATAL
 
 logger.StAXDialectDetector.name = org.apache.axiom.util.stax.dialect.StAXDialectDetector
 logger.StAXDialectDetector.level = ERROR
+
+logger.SMBJ.name = com.hierynomus.smbj
+logger.SMBJ.level = ERROR
 
 
 # root loggers

--- a/p2-profile/ei-profile/pom.xml
+++ b/p2-profile/ei-profile/pom.xml
@@ -103,6 +103,9 @@
                                     org.apache.synapse:org.apache.synapse.transport.vfs.feature:${synapse.version}
                                 </featureArtifactDef>
                                 <featureArtifactDef>
+                                    org.apache.synapse:org.apache.synapse.transport.vfs.smb2.feature:${synapse.version}
+                                </featureArtifactDef>
+                                <featureArtifactDef>
                                     org.wso2.carbon.mediation:org.wso2.carbon.application.deployer.synapse.feature:${carbon.mediation.version}
                                 </featureArtifactDef>
                                 <featureArtifactDef>
@@ -574,7 +577,11 @@
                                     <id>org.wso2.carbon.mediator.datamapper.engine.feature.group</id>
                                     <version>${carbon.mediation.version}</version>
                                 </feature>
-
+                                <!-- SMB2 -->
+                                <feature>
+                                    <id>org.apache.synapse.transport.vfs.smb2.feature.group</id>
+                                    <version>${synapse.version}</version>
+                                </feature>
                                 <!-- 2 Carbon-Kernel -->
                                 <feature>
                                     <id>org.wso2.carbon.core.ui.feature.group</id>


### PR DESCRIPTION
## Purpose
This PR adds smb2 feature for EI.
Make sure to update the synapse with a version which includes the following PRs before merging this PR. We may upgrade synapse to 2.1.7-wso2v175.
https://github.com/wso2/wso2-commons-vfs/pull/84, https://github.com/wso2/wso2-synapse/pull/1546, https://github.com/wso2/wso2-synapse/pull/1572
