### PR TITLE
Add testcases for http.response.headers.preserve property

### DIFF
--- a/integration/mediation-tests/tests-patches/src/test/java/org/wso2/carbon/esb/passthru/transport/test/PreseveResponseHeaderTestCase.java
+++ b/integration/mediation-tests/tests-patches/src/test/java/org/wso2/carbon/esb/passthru/transport/test/PreseveResponseHeaderTestCase.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (c) 2020, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wso2.carbon.esb.passthru.transport.test;
+
+import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.impl.client.DefaultHttpClient;
+import org.junit.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import org.wso2.carbon.automation.engine.context.AutomationContext;
+import org.wso2.carbon.automation.engine.context.TestUserMode;
+import org.wso2.esb.integration.common.utils.ESBIntegrationTest;
+import org.wso2.esb.integration.common.utils.common.ServerConfigurationManager;
+
+import java.io.File;
+
+
+public class PreseveResponseHeaderTestCase extends ESBIntegrationTest {
+    private ServerConfigurationManager serverConfigurationManager;
+
+    @BeforeClass
+    public void init() throws Exception {
+        super.init();
+        serverConfigurationManager = new ServerConfigurationManager(new AutomationContext("ESB", TestUserMode.SUPER_TENANT_ADMIN));
+        serverConfigurationManager.applyConfiguration(new File(getESBResourceLocation() + File.separator + "passthru" +
+                                                               File.separator + "transport" + File.separator + "preseveResponseHeaders" + File.separator + "passthru-http.properties"));
+        super.init();
+        verifyAPIExistence("ResponseHeaderPreserveAPI");
+    }
+    @Test(groups = "wso2.esb", description = "Preserve response header test", enabled = true)
+    public void testPreserveContentTypeHeader() throws Exception {
+        DefaultHttpClient httpclient = new DefaultHttpClient();
+        HttpGet httpget = new HttpGet(getApiInvocationURL("ResponseHeaderPreserveAPI"));
+        HttpResponse response;
+        try {
+            response = httpclient.execute(httpget);
+        } finally {
+            httpclient.clearRequestInterceptors();
+        }
+        Assert.assertTrue("Did't receive 200 OK response", "HTTP/1.1 200 OK".equals(response.getStatusLine().toString()));
+        Assert.assertTrue("Response header modified", "application/json".equals(response.getHeaders("Content-Type")[0].getValue()));
+
+    }
+}

--- a/integration/mediation-tests/tests-patches/src/test/java/org/wso2/carbon/esb/passthru/transport/test/PreseveResponseHeaderTestCase.java
+++ b/integration/mediation-tests/tests-patches/src/test/java/org/wso2/carbon/esb/passthru/transport/test/PreseveResponseHeaderTestCase.java
@@ -42,6 +42,7 @@ public class PreseveResponseHeaderTestCase extends ESBIntegrationTest {
         super.init();
         verifyAPIExistence("ResponseHeaderPreserveAPI");
     }
+
     @Test(groups = "wso2.esb", description = "Preserve response header test", enabled = true)
     public void testPreserveContentTypeHeader() throws Exception {
         DefaultHttpClient httpclient = new DefaultHttpClient();

--- a/integration/mediation-tests/tests-patches/src/test/resources/artifacts/ESB/passthru/transport/preseveResponseHeaders/passthru-http.properties
+++ b/integration/mediation-tests/tests-patches/src/test/resources/artifacts/ESB/passthru/transport/preseveResponseHeaders/passthru-http.properties
@@ -1,0 +1,42 @@
+#
+#  Copyright (c) 2020, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+#
+
+## This file contains the configuration parameters used by the Pass-through HTTP transport
+
+## Pass-through HTTP transport specific tuning parameters
+http.socket.timeout=180000
+
+worker_pool_size_core=400
+worker_pool_size_max=500
+#worker_thread_keepalive_sec=60
+#worker_pool_queue_length=-1
+#io_threads_per_reactor=2
+io_buffer_size=16384
+#http.max.connection.per.host.port=32767
+
+# This property is crucial for automated tests
+http.socket.reuseaddr=true
+
+## Other parameters
+#http.user.agent.preserve=false
+#http.server.preserve=true
+http.headers.preserve=Content-Type
+http.response.headers.preserve=Content-Type
+#http.connection.disable.keepalive=false
+rest.dispatcher.service=__MultitenantDispatcherService
+# URI configurations that determine if it requires custom rest dispatcher
+rest_uri_api_regex=\\w+://.+:\\d+/t/.*|\\w+://.+\\w+/t/.*|^(/t/).*
+rest_uri_proxy_regex=\\w+://.+:\\d+/services/t/.*|\\w+://.+\\w+/services/t/.*|^(/services/t/).*

--- a/integration/mediation-tests/tests-patches/src/test/resources/artifacts/ESB/server/repository/deployment/server/synapse-configs/default/api/PreseveResponseHeaderAPI.xml
+++ b/integration/mediation-tests/tests-patches/src/test/resources/artifacts/ESB/server/repository/deployment/server/synapse-configs/default/api/PreseveResponseHeaderAPI.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<api xmlns="http://ws.apache.org/ns/synapse" name="ResponseHeaderPreserveAPI" context="/ResponseHeaderPreserveAPI">
+    <resource methods="POST GET OPTIONS DELETE PUT"
+              url-mapping="/*"
+              faultSequence="fault">
+        <inSequence>
+            <payloadFactory media-type="json">
+                <format>{
+                    "msg":"response"
+                    }</format>
+                <args/>
+            </payloadFactory>
+            <header name="Content-Type" scope="transport" value="application/json"/>
+            <respond/>
+        </inSequence>
+    </resource>
+</api>

--- a/integration/mediation-tests/tests-patches/src/test/resources/testng.xml
+++ b/integration/mediation-tests/tests-patches/src/test/resources/testng.xml
@@ -96,6 +96,7 @@
             <class name="org.wso2.carbon.esb.passthru.transport.test.ESBJAVA3770DropLargePayloadsPreventESBFromOOMTestCase"/>
             <class name="org.wso2.carbon.esb.passthru.transport.test.ESBJAVA3336HostHeaderValuePortCheckTestCase"/>
             <class name="org.wso2.carbon.esb.passthru.transport.test.ForceMessageValidationTestCase" />
+            <class name="org.wso2.carbon.esb.passthru.transport.test.PreseveResponseHeaderTestCase"/>
             <!--<class name="org.wso2.carbon.esb.passthru.transport.test.ESBJAVA4931PreserveContentTypeHeaderCharSetTestCase"/>-->
         </classes>
     </test>


### PR DESCRIPTION
http.response.header.preseve property avoids changing the content type in the response mediation flow. When ESB generate send a response to the client it builds and sets the charset if the above property is not set. Here it checks for the charset and confirms the Content-Type header does not change in mediation flow.