### PR TITLE
Add test case for FMP without the interval parameter

### DIFF
--- a/integration/mediation-tests/tests-patches/src/test/java/org/wso2/carbon/esb/message/processor/test/MessageProcessorWithoutIntervalParamTestCase.java
+++ b/integration/mediation-tests/tests-patches/src/test/java/org/wso2/carbon/esb/message/processor/test/MessageProcessorWithoutIntervalParamTestCase.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.wso2.carbon.esb.message.processor.test;
+
+import org.awaitility.Awaitility;
+import org.junit.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+import org.wso2.carbon.automation.engine.annotations.ExecutionEnvironment;
+import org.wso2.carbon.automation.engine.annotations.SetEnvironment;
+import org.wso2.esb.integration.common.utils.ESBIntegrationTest;
+import org.wso2.esb.integration.common.utils.servers.WireMonitorServer;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * This test case is related to Forwarding Message Processor without the interval parameter
+ */
+public class MessageProcessorWithoutIntervalParamTestCase extends ESBIntegrationTest {
+
+    @BeforeClass(alwaysRun = true)
+    public void setEnvironment() throws Exception {
+
+        super.init();
+        loadESBConfigurationFromClasspath(
+                "/artifacts/ESB/messageProcessorConfig/MessageProcessorWithoutIntervalParam.xml");
+
+    }
+
+    /**
+     * Create a message processor which processes messages that are in a In memory message store without the interval parameter
+     * Test artifact: /artifacts/ESB/messageProcessorConfig/MessageProcessorWithoutIntervalParam.xml
+     *
+     * @throws Exception
+     */
+    @SetEnvironment(executionEnvironments = {ExecutionEnvironment.STANDALONE})
+    @Test(groups = "wso2.esb")
+    public void testForwardingWithCronExpression() throws Exception {
+
+        //Setting up Wire Monitor Server
+        WireMonitorServer wireServer = new WireMonitorServer(9500);
+        wireServer.start();
+
+        try {
+            axis2Client.sendSimpleStockQuoteRequest(getMainSequenceURL(), null, "WSO2");
+            Assert.fail("Unexpected reply received !!!");
+        } catch (Exception e) {
+            // Axis Fault Expected
+        }
+
+        String serverResponse = wireServer.getCapturedMessage();
+
+        Awaitility.await().atMost(5, TimeUnit.SECONDS).until(isMessageReceivedByEndpoint(serverResponse));
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void destroy() throws Exception {
+
+        super.cleanup();
+    }
+
+    public static Callable<Boolean> isMessageReceivedByEndpoint(String serverResponse) {
+
+        return new Callable<Boolean>() {
+            @Override
+            public Boolean call() {
+
+                return serverResponse.contains("WSO2");
+            }
+        };
+    }
+
+}

--- a/integration/mediation-tests/tests-patches/src/test/resources/artifacts/ESB/messageProcessorConfig/MessageProcessorWithoutIntervalParam.xml
+++ b/integration/mediation-tests/tests-patches/src/test/resources/artifacts/ESB/messageProcessorConfig/MessageProcessorWithoutIntervalParam.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<!--
+  ~  Copyright (c) 2021, WSO2 Inc. (http://wso2.com) All Rights Reserved.
+  ~
+  ~  WSO2 Inc. licenses this file to you under the Apache License,
+  ~  Version 2.0 (the "License"); you may not use this file except
+  ~  in compliance with the License.
+  ~  You may obtain a copy of the License at
+  ~
+  ~    http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~  Unless required by applicable law or agreed to in writing,
+  ~  software distributed under the License is distributed on an
+  ~  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~  KIND, either express or implied.  See the License for the
+  ~  specific language governing permissions and limitations
+  ~  under the License.
+  -->
+
+<definitions xmlns="http://ws.apache.org/ns/synapse">
+    <endpoint name="StockQuoteServiceEp">
+        <address uri="http://localhost:9500/">
+            <suspendOnFailure>
+                <errorCodes>-1</errorCodes>
+                <progressionFactor>1.0</progressionFactor>
+            </suspendOnFailure>
+        </address>
+    </endpoint>
+
+    <sequence name="fault">
+        <log level="full">
+            <property name="MESSAGE" value="Executing default 'fault' sequence"/>
+            <property name="ERROR_CODE" expression="get-property('ERROR_CODE')"/>
+            <property name="ERROR_MESSAGE" expression="get-property('ERROR_MESSAGE')"/>
+        </log>
+        <drop/>
+    </sequence>
+
+    <sequence name="main">
+        <in>
+            <log level="full"/>
+            <property name="target.endpoint" value="StockQuoteServiceEp"/>
+            <store messageStore="MyStore"/>
+        </in>
+    </sequence>
+
+    <messageStore name="MyStore"/>
+    <messageProcessor class="org.apache.synapse.message.processor.impl.forwarder.ScheduledMessageForwardingProcessor"
+                      name="ScheduledProcessor" messageStore="MyStore">
+    </messageProcessor>
+</definitions>

--- a/integration/mediation-tests/tests-patches/src/test/resources/testng.xml
+++ b/integration/mediation-tests/tests-patches/src/test/resources/testng.xml
@@ -160,6 +160,7 @@
         <classes>
             <class name="org.wso2.carbon.esb.message.processor.test.ESBJAVA4279_MPRetryUponResponseSC_500_withNonRetryStatusCodes_200_and_202_TestCase" />
             <class name="org.wso2.carbon.esb.message.processor.test.ESBJAVA3650_CustomHeaderPreserved_MessageProcessorOutMessage_TestCase" />
+            <class name="org.wso2.carbon.esb.message.processor.test.MessageProcessorWithoutIntervalParamTestCase" />
         </classes>
     </test>
 


### PR DESCRIPTION
## Purpose
Add test case for Forwarding Message Processor without the interval parameter.

## Related PRs
https://github.com/wso2/wso2-synapse/pull/1838