### PR TITLE
Add javax.activation dependency to wso2-general-project-plugin

### DIFF
--- a/product-scenarios/1-integrating-systems-that-communicate-in-heterogeneous-message-formats/01-SynapseConfigProject/01-synapseConfigRegistry/pom.xml
+++ b/product-scenarios/1-integrating-systems-that-communicate-in-heterogeneous-message-formats/01-SynapseConfigProject/01-synapseConfigRegistry/pom.xml
@@ -130,6 +130,13 @@
         <groupId>org.wso2.maven</groupId>
         <artifactId>wso2-general-project-plugin</artifactId>
         <version>2.1.1</version>
+        <dependencies>
+          <dependency>
+            <groupId>com.sun.activation</groupId>
+            <artifactId>javax.activation</artifactId>
+            <version>1.2.0</version>
+          </dependency>
+        </dependencies>
         <extensions>true</extensions>
         <executions>
           <execution>

--- a/product-scenarios/4-gateway/04-SynapseConfigProject/04-synapseConfigRegistry/pom.xml
+++ b/product-scenarios/4-gateway/04-SynapseConfigProject/04-synapseConfigRegistry/pom.xml
@@ -96,6 +96,13 @@
         <groupId>org.wso2.maven</groupId>
         <artifactId>wso2-general-project-plugin</artifactId>
         <version>2.1.1</version>
+        <dependencies>
+          <dependency>
+            <groupId>com.sun.activation</groupId>
+            <artifactId>javax.activation</artifactId>
+            <version>1.2.0</version>
+          </dependency>
+        </dependencies>
         <extensions>true</extensions>
         <executions>
           <execution>


### PR DESCRIPTION
## Purpose
> $subject
> Fix test failures in wso2ei-6.6.0 scenario tests.
> Java 9 and above doesn't contain javax.activation library by default. Thus need to add the following dependency.

```
<dependency>
     <groupId>com.sun.activation</groupId>
      <artifactId>javax.activation</artifactId>
       <version>1.2.0</version>
</dependency>
```