### PR TITLE
password was not updated using chpasswd.sh script

### DIFF
--- a/distribution/src/scripts/chpasswd.sh
+++ b/distribution/src/scripts/chpasswd.sh
@@ -82,17 +82,17 @@ ant -buildfile "$CARBON_HOME"/bin/build.xml
 
 # update classpath
 CARBON_CLASSPATH=""
-for f in "$CARBON_HOME"/wso2/lib/*.jar
+for f in "$CARBON_HOME"/lib/*.jar
 do
   CARBON_CLASSPATH=$CARBON_CLASSPATH:$f
 done
 
-for g in "$CARBON_HOME"/repository/lib/*.jar
+for g in "$CARBON_HOME"/wso2/components/plugins/*.jar
 do
   CARBON_CLASSPATH=$CARBON_CLASSPATH:$g
 done
 
-for h in "$CARBON_HOME"/wso2/lib/api/*.jar
+for h in "$CARBON_HOME"/wso2/lib/*.jar
 do
   CARBON_CLASSPATH=$CARBON_CLASSPATH:$h
 done
@@ -112,5 +112,4 @@ cd "$CARBON_HOME"
 
 CARBON_CLASSPATH="$CARBON_HOME/lib/patches":"$CARBON_HOME/conf":$CARBON_CLASSPATH
 
-$JAVA_HOME/bin/java -cp "$CARBON_CLASSPATH" org.wso2.carbon.core.util.PasswordUpdater $*
-
+$JAVA_HOME/bin/java -Dcarbon.config.dir.path="$CARBON_HOME/conf" -cp "$CARBON_CLASSPATH" org.wso2.carbon.core.util.PasswordUpdater $*


### PR DESCRIPTION
fix for user-mgt.xml not found by adding the conf directory as a config and paxlogin

error: Error updating credentials for user admin: org.wso2.carbon.user.core.UserStoreException: Error while reading realm configuration from file

added config when executing the script to get the user-mgt.xml file which is needed for the RealmConfigXMLProcessor.java to generate the salt value.

issue: https://github.com/wso2/api-manager/issues/1624